### PR TITLE
do not crash on ampty APICAST_SERVICES env variable

### DIFF
--- a/apicast/src/configuration.lua
+++ b/apicast/src/configuration.lua
@@ -228,7 +228,11 @@ local function to_hash(table)
   local t = {}
 
   for v,id in ipairs(table) do
-    t[tonumber(id)] = true
+    local n = tonumber(id)
+
+    if n then
+      t[n] = true
+    end
   end
 
   return t
@@ -237,7 +241,7 @@ end
 function _M.services_limit()
   local services = {}
   local subset = os.getenv('APICAST_SERVICES')
-  if not subset then return services end
+  if not subset or subset == '' then return services end
 
   local ids = split(subset, ',')
 

--- a/spec/configuration_spec.lua
+++ b/spec/configuration_spec.lua
@@ -115,5 +115,14 @@ describe('Configuration object', function()
 
       assert.same({ [42] = true, [21] = true }, services)
     end)
+
+    it('reads from environment', function()
+      stub(os, 'getenv').on_call_with('APICAST_SERVICES').returns('')
+
+      local services = services_limit()
+
+      assert.same({}, services)
+    end)
   end)
+
 end)


### PR DESCRIPTION
fixes:
init_by_lua error: /opt/app/src/configuration.lua:231: table index is nil