### PR TITLE
Remove double encoding for config and set content-type

### DIFF
--- a/apicast/src/configuration.lua
+++ b/apicast/src/configuration.lua
@@ -210,6 +210,14 @@ function _M.decode(contents, encoder)
   return config
 end
 
+function _M.encode(contents, encoder)
+  if type(contents) == 'string' then return contents end
+  
+  encoder = encoder or cjson
+
+  return encoder.encode(contents)
+end
+
 function _M.parse(contents, encoder)
   local config = _M.decode(contents, encoder)
 

--- a/apicast/src/management.lua
+++ b/apicast/src/management.lua
@@ -36,10 +36,9 @@ function _M.status()
 end
 
 function _M.config()
-  local config = cjson.encode(provider.contents)
-
+  ngx.header.content_type = 'application/json; charset=utf-8'
   ngx.status = 200
-  ngx.say(config)
+  ngx.say(provider.contents)
 end
 
 function _M.update_config()

--- a/apicast/src/management.lua
+++ b/apicast/src/management.lua
@@ -52,11 +52,11 @@ function _M.update_config()
     data = assert(io.open(file)):read('*a')
   end
 
-  local configuration = configuration.decode(data)
-
-  provider.configure(configuration)
+  local config = configuration.decode(data)
+  provider.configure(config)
   -- TODO: respond with proper 304 Not Modified when config is the same
-  local response = cjson.encode({ status = 'ok', config = configuration or cjson.null })
+  local response = cjson.encode({ status = 'ok', config = config or cjson.null })
+  ngx.header.content_type = 'application/json; charset=utf-8'
   ngx.say(response)
 end
 
@@ -66,19 +66,20 @@ function _M.delete_config()
   provider.configure(nil)
   -- TODO: respond with proper 304 Not Modified when config is the same
   local response = cjson.encode({ status = 'ok', config = cjson.null })
+  ngx.header.content_type = 'application/json; charset=utf-8'
   ngx.say(response)
 end
 
 local util = require 'util'
 
 function _M.boot()
-  local config = util.timer('configuration.boot', configuration.boot)
-  local configuration = configuration.decode(config)
-  local response = cjson.encode({ status = 'ok', config = configuration or cjson.null })
+  local data = util.timer('configuration.boot', configuration.boot)
+  local config = configuration.decode(data)
+  local response = cjson.encode({ status = 'ok', config = config or cjson.null })
 
-  ngx.log(ngx.DEBUG, 'management boot config:' .. inspect(config))
+  ngx.log(ngx.DEBUG, 'management boot config:' .. inspect(data))
 
-  provider.init(configuration)
+  provider.init(config)
 
   ngx.say(response)
 end

--- a/apicast/src/provider.lua
+++ b/apicast/src/provider.lua
@@ -36,7 +36,7 @@ local _M = {
 function _M.configure(contents)
   local config = configuration.parse(contents)
 
-  _M.contents = contents
+  _M.contents = configuration.encode(contents)
   _M.configured = true
   _M.configuration = config
   _M.services = config.services or {} -- for compatibility reasons

--- a/spec/configuration_spec.lua
+++ b/spec/configuration_spec.lua
@@ -71,6 +71,22 @@ describe('Configuration object', function()
     end)
   end)
 
+  describe('.encode', function()
+    it('encodes to json by default', function()
+      local t = { a = 1, b = 2 }
+      assert.same('{"a":1,"b":2}', configuration.encode(t))
+    end)
+
+    it('does not do double encoding', function()
+      local str = '{"a":1,"b":2}'
+      assert.same(str, configuration.encode(str))
+    end)
+
+    it('encodes nil to null', function()
+      assert.same('null', configuration.encode(nil))
+    end)
+  end)
+
   describe('.url', function()
     it('works with port', function()
       assert.same({'https', false, false, 'example.com', '8443'}, configuration.url('https://example.com:8443'))

--- a/t/001-management.t
+++ b/t/001-management.t
@@ -254,18 +254,18 @@ JSON response body and content type application/json should be returned.
 --- config
   include $TEST_NGINX_MANAGEMENT_CONFIG;
 --- request eval
-[ "DELETE /config", "PUT /config 
-{\"services\":[{\"id\":42}]}", "POST /config
-{\"services\":[{\"id\":42}]}", "GET /config" ]
+[ 'DELETE /config', 'PUT /config 
+{"services":[{"id":42}]}', 'POST /config
+{"services":[{"id":42}]}', 'GET /config' ]
 --- response_headers eval
-[ "Content-Type: application/json; charset=utf-8",
-  "Content-Type: application/json; charset=utf-8",
-  "Content-Type: application/json; charset=utf-8", 
-  "Content-Type: application/json; charset=utf-8" ]
+[ 'Content-Type: application/json; charset=utf-8',
+  'Content-Type: application/json; charset=utf-8',
+  'Content-Type: application/json; charset=utf-8', 
+  'Content-Type: application/json; charset=utf-8' ]
 --- response_body eval
 [ '{"status":"ok","config":null}'."\n",
   '{"status":"ok","config":{"services":[{"id":42}]}}'."\n",
   '{"status":"ok","config":{"services":[{"id":42}]}}'."\n",
- '{"services":[{"id":42}]}'."\n"]  
+  '{"services":[{"id":42}]}'."\n" ]  
 --- no_error_log
 [error]

--- a/t/001-management.t
+++ b/t/001-management.t
@@ -125,6 +125,8 @@ Endpoint that dumps the original configuration.
 include $TEST_NGINX_MANAGEMENT_CONFIG;
 --- request
 GET /config
+--- response_headers
+Content-Type: application/json; charset=utf-8
 --- response_body
 {"services":[{"id":42}]}
 --- error_code: 200
@@ -242,5 +244,28 @@ GET /test
 {"status":"ok","config":null}
 null
 --- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 9: all endpoints use correct Content-Type
+JSON response body and content type application/json should be returned.
+--- http_config
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+--- config
+  include $TEST_NGINX_MANAGEMENT_CONFIG;
+--- request eval
+[ "DELETE /config", "PUT /config 
+{\"services\":[{\"id\":42}]}", "POST /config
+{\"services\":[{\"id\":42}]}", "GET /config" ]
+--- response_headers eval
+[ "Content-Type: application/json; charset=utf-8",
+  "Content-Type: application/json; charset=utf-8",
+  "Content-Type: application/json; charset=utf-8", 
+  "Content-Type: application/json; charset=utf-8" ]
+--- response_body eval
+[ '{"status":"ok","config":null}'."\n",
+  '{"status":"ok","config":{"services":[{"id":42}]}}'."\n",
+  '{"status":"ok","config":{"services":[{"id":42}]}}'."\n",
+ '{"services":[{"id":42}]}'."\n"]  
 --- no_error_log
 [error]


### PR DESCRIPTION
Closes #94 

- `provider.contents` is already JSON-encoded, so no need to encode it again.
- adding `application/json` content type instead of the default `text/plain`