### PR TITLE
[bin] drop luarocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ IMAGE_NAME ?= apicast-test
 BUILDER_IMAGE ?= quay.io/3scale/s2i-openresty-centos7
 
 test: ## Run all tests
-	$(MAKE) --keep-going busted prove test-docker prove-docker
+	$(MAKE) --keep-going busted prove test-docker prove-docker test-docker-release
 
 busted: dependencies ## Test Lua.
 	@bin/busted

--- a/apicast/bin/apicast
+++ b/apicast/bin/apicast
@@ -15,10 +15,6 @@ fi
 bin_dir=$(dirname "${path}")
 apicast_dir="$( cd "${bin_dir}/.." && pwd )"
 
-if (luarocks help > /dev/null 2>&1 ); then
-  eval `luarocks path`
-fi
-
 pick_openresty() {
   for cmd in "$@"
   do


### PR DESCRIPTION
apicast should not depend on luarocks
luarocks should be configured properly
to install into correct paths

depends on https://github.com/3scale/s2i-openresty/pull/12