### PR TITLE
balancer_by_lua

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,5 +1,6 @@
 return {
   _all = {
+    helper = 'spec/spec_helper.lua'
   },
   default = {
     verbose = true,

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,10 @@ push: ## Push image to the registry
 	docker tag $(IMAGE_NAME) $(REGISTRY)/$(IMAGE_NAME)
 	docker push $(REGISTRY)/$(IMAGE_NAME)
 
+bash: export IMAGE_NAME = apicast-test
+bash: export SERVICE = gateway
 bash: ## Run bash inside the build image
-	$(DOCKER_COMPOSE) run --user=root --rm --entrypoint=bash gateway -i
+	$(DOCKER_COMPOSE) run --user=root --rm --entrypoint=bash $(SERVICE) -i
 
 test-docker: export IMAGE_NAME = apicast-test
 test-docker: build clean ## Test build docker

--- a/apicast/conf.d/apicast.conf
+++ b/apicast/conf.d/apicast.conf
@@ -60,9 +60,10 @@ location / {
     local configuration = require('configuration')
     local provider = require('provider')
 
-    local config = configuration.boot()
-
-    provider.init(config)
+    if not provider.configured then
+      local config = configuration.boot()
+      provider.init(config)
+    end
   }
   access_by_lua_block {
     local provider = require('provider')

--- a/apicast/conf.d/apicast.conf
+++ b/apicast/conf.d/apicast.conf
@@ -4,10 +4,12 @@ location = /threescale_authrep {
   internal;
 
   proxy_pass_request_headers off;
+  proxy_http_version 1.1;
   proxy_pass $backend_endpoint/transactions/authrep.xml?$backend_authentication_type=$backend_authentication_value&service_id=$service_id&$usage&$credentials; # &log%5Bcode%5D=$arg_code&log%5Brequest%5D=$arg_req&log%5Bresponse%5D=$arg_resp;
   proxy_set_header  Host  "$backend_host";
   proxy_set_header  X-3scale-User-Agent "nginx$deployment";
   proxy_set_header  X-3scale-Version "$version";
+  proxy_set_header  Connection "";
 
   log_by_lua_block {
     ngx.log(ngx.INFO, '[authrep] ' .. ngx.var.request_uri .. ' ' .. ngx.var.status)
@@ -19,6 +21,13 @@ location @out_of_band_authrep_action {
   internal;
 
   proxy_pass_request_headers off;
+
+  set_by_lua $original_request_time 'return ngx.var.request_time';
+
+log_by_lua_block {
+ngx.var.post_action_impact = ngx.var.request_time - ngx.var.original_request_time
+ngx.log(ngx.INFO, '[authrep] ' .. ngx.var.request_uri .. ' ' .. ngx.var.status)
+}
 
   content_by_lua_block { require('provider').post_action_content() }
 }
@@ -43,6 +52,8 @@ location / {
   set $backend_authentication_value null;
   set $version null;
 
+  set $post_action_impact null;
+
   proxy_ignore_client_abort on;
 
   rewrite_by_lua_block {
@@ -55,7 +66,7 @@ location / {
   }
   access_by_lua_block {
     local provider = require('provider')
-    provider.call()
+    provider.call()()
 }
 
   body_filter_by_lua_block {
@@ -71,10 +82,12 @@ location / {
   }
 
   proxy_pass $proxy_pass;
+  proxy_http_version 1.1;
   proxy_set_header X-Real-IP  $remote_addr;
   proxy_set_header Host $http_host;
   proxy_set_header X-3scale-proxy-secret-token $secret_token;
   proxy_set_header X-3scale-debug "";
+  proxy_set_header Connection "";
 
   post_action @out_of_band_authrep_action;
 }
@@ -125,28 +138,4 @@ location = /_threescale/client_secret_matches {
   proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
 
   proxy_pass $backend_endpoint/transactions/oauth_authorize.xml?$backend_authentication_type=$backend_authentication_value&service_id=$service_id&app_id=$client_id;
-}
-
-location = /out_of_band_oauth_authrep_action {
-  internal;
-  proxy_pass_request_headers off;
-
-  content_by_lua_block {
-    local method, path, headers = ngx.req.get_method(), ngx.var.request_uri, ngx.req.get_headers()
-
-    local req = cjson.encode{method=method, path=path, headers=headers}
-    local resp = cjson.encode{ body = ngx.var.resp_body, headers = cjson.decode(ngx.var.resp_headers)}
-
-    local cached_key = ngx.var.cached_key
-    if cached_key ~= nil and cached_key ~= "null" then
-      local status_code = ngx.var.status
-      local res1 = ngx.location.capture("/threescale_oauth_authrep?code=".. status_code .. "&req=" .. ngx.escape_uri(req) .. "&resp=" .. ngx.escape_uri(resp), { share_all_vars = true, ctx = ngx.ctx })
-      if res1.status ~= 200 then
-        local api_keys = ngx.shared.api_keys
-        api_keys:delete(cached_key)
-      end
-    end
-
-    ngx.exit(ngx.HTTP_OK)
-  }
 }

--- a/apicast/conf.d/apicast.conf
+++ b/apicast/conf.d/apicast.conf
@@ -140,7 +140,7 @@ location = /out_of_band_oauth_authrep_action {
     local cached_key = ngx.var.cached_key
     if cached_key ~= nil and cached_key ~= "null" then
       local status_code = ngx.var.status
-      local res1 = ngx.location.capture("/threescale_oauth_authrep?code=".. status_code .. "&req=" .. ngx.escape_uri(req) .. "&resp=" .. ngx.escape_uri(resp), { share_all_vars = true })
+      local res1 = ngx.location.capture("/threescale_oauth_authrep?code=".. status_code .. "&req=" .. ngx.escape_uri(req) .. "&resp=" .. ngx.escape_uri(resp), { share_all_vars = true, ctx = ngx.ctx })
       if res1.status ~= 200 then
         local api_keys = ngx.shared.api_keys
         api_keys:delete(cached_key)

--- a/apicast/conf.d/backend.conf
+++ b/apicast/conf.d/backend.conf
@@ -1,3 +1,6 @@
+set_by_lua_block $delay { return ngx.var.arg_delay or 0 }
+
 location /transactions/authrep.xml {
+  echo_sleep $delay;
   echo "transactions authrep!";
 }

--- a/apicast/conf.d/echo.conf
+++ b/apicast/conf.d/echo.conf
@@ -1,0 +1,8 @@
+set_by_lua_block $delay { return ngx.var.arg_delay or 0 }
+location / {
+      echo_duplicate 1 $echo_client_request_headers;
+      echo "\r";
+      echo_sleep $delay;
+      echo_read_request_body;
+      echo $request_body;
+}

--- a/apicast/conf/nginx.conf
+++ b/apicast/conf/nginx.conf
@@ -40,6 +40,7 @@ http {
   init_by_lua_block {
     pcall(require, 'luarocks.loader')
 
+    require("resty.core")
     require('resty.resolver').init()
 
     local config = require('configuration').init()
@@ -49,6 +50,8 @@ http {
     else
       ngx.log(ngx.ERR, 'boot configuration load failed')
     end
+
+    collectgarbage("collect")
   }
 
   include ../http.d/*.conf;

--- a/apicast/conf/nginx.conf
+++ b/apicast/conf/nginx.conf
@@ -15,7 +15,7 @@ env REDIS_PORT;
 # error_log stderr notice;
 # error_log logs/error.log warn;
 
-error_log stderr info;
+error_log stderr debug;
 
 events {
     worker_connections 256;

--- a/apicast/conf/nginx.conf
+++ b/apicast/conf/nginx.conf
@@ -11,6 +11,7 @@ env APICAST_PATH_ROUTING_ENABLED;
 env APICAST_SERVICES;
 env REDIS_HOST;
 env REDIS_PORT;
+env RESOLVER;
 
 # error_log stderr notice;
 # error_log logs/error.log warn;
@@ -38,6 +39,8 @@ http {
 
   init_by_lua_block {
     pcall(require, 'luarocks.loader')
+
+    require('resty.resolver').init()
 
     local config = require('configuration').init()
 

--- a/apicast/conf/nginx.conf
+++ b/apicast/conf/nginx.conf
@@ -2,7 +2,7 @@
 # user user group;
 
 ## THIS PARAMETERS BE SAFELY OVER RIDDEN BY YOUR DEFAULT NGINX CONF
-worker_processes 1;
+worker_processes auto;
 env THREESCALE_DEPLOYMENT_ENV;
 env THREESCALE_PORTAL_ENDPOINT;
 env THREESCALE_CONFIG_FILE;
@@ -15,7 +15,7 @@ env REDIS_PORT;
 # error_log stderr notice;
 # error_log logs/error.log warn;
 
-error_log stderr debug;
+error_log stderr notice;
 
 events {
     worker_connections 256;
@@ -28,7 +28,8 @@ http {
 
   server_names_hash_bucket_size 128;
 
-  access_log /dev/stdout combined;
+  log_format time '[$time_local] $host:$server_port $remote_addr:$remote_port "$request" $status $body_bytes_sent ($request_time) $post_action_impact';
+  access_log off;
 
   lua_package_path ";;${prefix}?.lua;${prefix}src/?.lua";
 
@@ -66,6 +67,16 @@ http {
   }
 
   server {
+    listen 8081;
+
+    server_name echo;
+
+    include ../conf.d/echo.conf;
+  }
+
+  server {
+    access_log /dev/stdout time;
+
     listen 8080;
 
     server_name _;

--- a/apicast/conf/nginx.conf
+++ b/apicast/conf/nginx.conf
@@ -19,10 +19,17 @@ env RESOLVER;
 error_log stderr notice;
 
 events {
-    worker_connections 256;
+  worker_connections  8096;
+  multi_accept        on;
 }
 
+worker_rlimit_nofile 40000;
+
 http {
+  sendfile           on;
+  tcp_nopush         on;
+  tcp_nodelay        on;
+
   lua_shared_dict api_keys 10m;
   lua_shared_dict configuration 10m;
   lua_shared_dict locks 1m;

--- a/apicast/http.d/upstream.conf
+++ b/apicast/http.d/upstream.conf
@@ -1,0 +1,41 @@
+
+upstream upstream {
+  server 0.0.0.1:1;
+
+  balancer_by_lua_block {
+    local resty_balancer = require 'resty.balancer'
+
+    local balancer = resty_balancer.new('round-robin')
+    local peers = balancer:peers(ngx.ctx.upstream)
+
+    local peer, err = balancer:set_peer(peers)
+
+    if not peer then
+      ngx.status = ngx.HTTP_SERVICE_UNAVAILABLE
+      ngx.log(ngx.ERR, "failed to set current peer: "..err)
+      ngx.exit(ngx.status)
+    end
+  }
+
+  keepalive 32;
+}
+
+upstream backend_upstream {
+  server 0.0.0.1:1;
+
+  balancer_by_lua_block {
+    local resty_balancer = require 'resty.balancer'
+      local balancer = resty_balancer.new('round-robin')
+      local peers = balancer:peers(ngx.ctx.backend_upstream)
+
+      local peer, err = balancer:set_peer(peers)
+
+      if not peer then
+        ngx.status = ngx.HTTP_SERVICE_UNAVAILABLE
+        ngx.log(ngx.ERR, "failed to set current peer: "..err)
+        ngx.exit(ngx.status)
+      end
+  }
+
+  keepalive 32;
+}

--- a/apicast/http.d/upstream.conf
+++ b/apicast/http.d/upstream.conf
@@ -12,7 +12,7 @@ upstream upstream {
 
     if not peer then
       ngx.status = ngx.HTTP_SERVICE_UNAVAILABLE
-      ngx.log(ngx.ERR, "failed to set current peer: "..err)
+      ngx.log(ngx.ERR, "failed to set current upstream peer: ", err)
       ngx.exit(ngx.status)
     end
   }
@@ -32,7 +32,7 @@ upstream backend_upstream {
 
       if not peer then
         ngx.status = ngx.HTTP_SERVICE_UNAVAILABLE
-        ngx.log(ngx.ERR, "failed to set current peer: "..err)
+        ngx.log(ngx.ERR, "failed to set current backend peer: ", err)
         ngx.exit(ngx.status)
       end
   }

--- a/apicast/http.d/upstream.conf
+++ b/apicast/http.d/upstream.conf
@@ -3,9 +3,9 @@ upstream upstream {
   server 0.0.0.1:1;
 
   balancer_by_lua_block {
-    local resty_balancer = require 'resty.balancer'
+    local round_robin = require 'resty.balancer.round_robin'
 
-    local balancer = resty_balancer.new('round-robin')
+    local balancer = round_robin.new()
     local peers = balancer:peers(ngx.ctx.upstream)
 
     local peer, err = balancer:set_peer(peers)
@@ -24,8 +24,9 @@ upstream backend_upstream {
   server 0.0.0.1:1;
 
   balancer_by_lua_block {
-    local resty_balancer = require 'resty.balancer'
-      local balancer = resty_balancer.new('round-robin')
+      local round_robin = require 'resty.balancer.round_robin'
+
+      local balancer = round_robin.new()
       local peers = balancer:peers(ngx.ctx.backend_upstream)
 
       local peer, err = balancer:set_peer(peers)

--- a/apicast/src/authorize.lua
+++ b/apicast/src/authorize.lua
@@ -89,6 +89,7 @@ local function check_client_credentials(params)
         redirect_uri = params.redirect_uri
       },
       copy_all_vars = true,
+      ctx = ngx.ctx
     })
 
   if res.status == 200 then

--- a/apicast/src/configuration.lua
+++ b/apicast/src/configuration.lua
@@ -46,7 +46,7 @@ end
 local function check_rule(req, rule, usage_t, matched_rules)
   local param = {}
   local p = regexpify(rule.pattern)
-  local m = ngx.re.match(req.path, format("^%s",p))
+  local m = ngx.re.match(req.path, format("^%s",p), 'oj')
 
   if m and req.method == rule.method then
     local args = req.args
@@ -92,7 +92,7 @@ local regex_variable = '\\{[-\\w_]+\\}'
 
 local function check_querystring_params(params, args)
   for param, expected in pairs(params) do
-    local m, err = ngx.re.match(expected, regex_variable)
+    local m, err = ngx.re.match(expected, regex_variable, 'oj')
     local value = args[param]
 
     if m then
@@ -410,7 +410,7 @@ function _M.url(endpoint)
     return nil, 'missing endpoint'
   end
 
-  local match = ngx.re.match(endpoint, "^(https?):\\/\\/(?:(.+)@)?([^\\/\\s]+?)(?::(\\d+))?(\\/.+)?$")
+  local match = ngx.re.match(endpoint, "^(https?):\\/\\/(?:(.+)@)?([^\\/\\s]+?)(?::(\\d+))?(\\/.+)?$", 'oj')
 
   if not match then
     return nil, 'invalid endpoint' -- TODO: maybe improve the error message?
@@ -420,7 +420,7 @@ function _M.url(endpoint)
 
   if path == '/' then path = nil end
 
-  local match = userinfo and ngx.re.match(tostring(userinfo), "^([^:\\s]+)?(?::(.*))?$")
+  local match = userinfo and ngx.re.match(tostring(userinfo), "^([^:\\s]+)?(?::(.*))?$", 'oj')
   local user, pass = unpack(match or {})
 
   return { scheme, user or false, pass or false, host, port or false, path or nil }

--- a/apicast/src/get_token.lua
+++ b/apicast/src/get_token.lua
@@ -52,7 +52,7 @@ end
 local function check_client_credentials(params)
   local res = ngx.location.capture("/_threescale/check_credentials",
     { args = { app_id = params.client_id, app_key = params.client_secret, redirect_uri = params.redirect_uri },
-      copy_all_vars = true })
+      copy_all_vars = true, ctx = ngx.ctx })
 
   if res.status == 200 then
     return { ["status"] = res.status, ["body"] = res.body }
@@ -82,7 +82,7 @@ end
 local function store_token(params, token)
   local body = ts.build_query({ app_id = params.client_id, token = token.access_token, user_id = params.user_id, ttl = token.expires_in })
   local stored = ngx.location.capture( "/_threescale/oauth_store_token", {
-    method = ngx.HTTP_POST, body = body, copy_all_vars = true } )
+    method = ngx.HTTP_POST, body = body, copy_all_vars = true, ctx = ngx.ctx } )
   stored.body = stored.body or stored.status
   return { ["status"] = stored.status , ["body"] = stored.body }
 end

--- a/apicast/src/provider.lua
+++ b/apicast/src/provider.lua
@@ -286,7 +286,7 @@ function _M.call(host)
     end
   end
 
-  ngx.ctx.dns = dns_resolver:new{ nameservers = { { "127.0.0.1", 53 } } }
+  ngx.ctx.dns = dns_resolver:new{ nameservers = resty_resolver.nameservers() }
   ngx.ctx.resolver = resty_resolver.new(ngx.ctx.dns)
 
   local backend_upstream = ngx.ctx.resolver:get_servers(host, { port = port or nil })

--- a/apicast/src/resty/balancer.lua
+++ b/apicast/src/resty/balancer.lua
@@ -1,0 +1,112 @@
+local setmetatable = setmetatable
+local tostring = tostring
+local pairs = pairs
+local ipairs = ipairs
+local unpack = unpack
+
+local balancer = require "ngx.balancer"
+
+local _M = {
+  _VERSION = '0.1'
+}
+
+local mt = { __index = _M }
+
+local function round_robin(peers)
+  return peers[1]
+end
+
+local modes = {
+  ['round-robin'] = round_robin
+}
+
+function _M.new(mode)
+  local m = modes[mode]
+
+  if not m then
+    return nil, 'invalid mode: ' .. tostring(mode)
+  end
+
+  return setmetatable({
+    mode = m,
+    balancer = balancer
+  }, mt)
+end
+
+function _M.modes()
+  local m = {}
+
+  for name, _ in pairs(modes) do
+    m[#m+1] = name
+  end
+
+  return m
+end
+
+local function new_peer(server, port)
+  return {
+    server.address,
+    server.port or port or 80
+  }
+end
+
+local function convert_servers(servers, port)
+  local peers = {}
+
+  for _, server in ipairs(servers) do
+    peers[#peers+1] = new_peer(server, port)
+  end
+
+  peers.servers = servers
+
+  return peers
+end
+
+function _M.peers(self, servers, port)
+  if not servers then
+    return nil, 'missing servers'
+  end
+
+  local peers, err = convert_servers(servers, port)
+
+  return peers, err
+end
+
+function _M.set_peer(self, peers)
+  local mode = self.mode
+  local balancer = self.balancer
+
+  if not mode then
+    return nil, 'not initialized'
+  end
+
+  if not balancer then
+    return nil, 'balancer not available'
+  end
+
+  if not peers then
+    return nil, 'missing peers'
+  end
+
+  local peer, err = mode(peers)
+
+  if not peer then
+    return nil, err or 'no peer found'
+  end
+
+  local address, port = unpack(peer)
+
+  if not address or not port then
+    return nil, 'peer missing address or port'
+  end
+
+  ngx.log(ngx.DEBUG, 'balancer set peer ' .. tostring(address) .. ':' .. tostring(port))
+
+  local ok, err = balancer.set_current_peer(address, port)
+
+  if ok then return peer end
+
+  return nil, err
+end
+
+return _M

--- a/apicast/src/resty/balancer/random.lua
+++ b/apicast/src/resty/balancer/random.lua
@@ -1,0 +1,26 @@
+local balancer = require 'resty.balancer'
+
+local _M = {
+  _VERSION = '0.1'
+}
+
+local maxn = table.maxn
+local random = math.random
+
+
+function _M.new()
+  return balancer.new(_M.call)
+end
+
+local function random_peer(peers)
+  local n = maxn(peers)
+  local i = random(1, n)
+
+  return peers[i], i
+end
+
+function _M.call(peers)
+  return random_peer(peers)
+end
+
+return _M

--- a/apicast/src/resty/balancer/round_robin.lua
+++ b/apicast/src/resty/balancer/round_robin.lua
@@ -1,0 +1,48 @@
+local balancer = require 'resty.balancer'
+local random = require 'resty.balancer.random'
+
+local _M = {
+  _VERSION = '0.1'
+}
+
+local semaphore = require 'ngx.semaphore'
+local call = semaphore.new(1)
+
+local cursor = {}
+
+function _M.new()
+  return balancer.new(_M.call)
+end
+
+
+function _M.call(peers)
+  local hash = peers.hash
+
+  if not hash then
+    return random.call(peers)
+  end
+
+  local ok, _ = call:wait(0)
+
+  local peer
+  local i = cursor[hash] or peers.cur
+
+  if i then
+    peer = peers[i]
+  else
+    peer, i = random.call(peers)
+    cursor[hash] = i
+  end
+
+  if i == #peers then
+    cursor[hash] = 1
+  else
+    cursor[hash] = i + 1
+  end
+
+  if ok then call:post(1) end
+
+  return peer, i
+end
+
+return _M

--- a/apicast/src/resty/resolver.lua
+++ b/apicast/src/resty/resolver.lua
@@ -1,14 +1,87 @@
 local setmetatable = setmetatable
 local ipairs = ipairs
 local next = next
+local open = io.open
+local gmatch = string.gmatch
+local insert = table.insert
+local getenv = os.getenv
+local concat = table.concat
+local io_type = io.type
 
+local semaphore = require "ngx.semaphore"
 local resolver_cache = require 'resty.resolver.cache'
 
+local init = semaphore.new(1)
+
 local _M = {
-  _VERSION = '0.1'
+  _VERSION = '0.1',
+  _nameservers = {}
 }
 
+
 local mt = { __index = _M }
+
+function _M.parse_nameservers(path)
+  local nameservers = {}
+  local path = path or '/etc/resolv.conf'
+
+  local resolver = getenv('RESOLVER')
+  if resolver then
+    insert(nameservers, { resolver })
+    return nameservers
+  end
+
+  local handle, err
+
+  if io_type(path) then
+    handle = path
+  else
+    handle, err = open(path)
+  end
+
+  local output
+
+  if handle then
+    handle:seek("set")
+    output = handle:read("*a")
+    handle:close()
+  else
+    return nil, err
+  end
+
+  for nameserver in gmatch(output, 'nameserver%s+([^%s]+)') do
+    -- TODO: implement port matching based on https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=549190
+    local port
+    insert(nameservers, { nameserver, port } )
+  end
+
+  return nameservers
+end
+
+function _M.init_nameservers()
+  for _,nameserver in ipairs(_M.parse_nameservers()) do
+    ngx.log(ngx.INFO, 'adding ', concat(nameserver,':'), ' as default nameserver')
+    insert(_M._nameservers, nameserver)
+  end
+end
+
+function _M.nameservers()
+  local ok, _ = init:wait(0)
+
+  if ok and not next(_M._nameservers) then
+    _M.init()
+  end
+
+  if ok then
+    init:post()
+  end
+
+  return _M._nameservers
+end
+
+function _M.init()
+  _M.init_nameservers()
+end
 
 function _M.new(dns, opts)
   local opts = opts or {}

--- a/apicast/src/resty/resolver.lua
+++ b/apicast/src/resty/resolver.lua
@@ -173,6 +173,8 @@ function _M.get_servers(self, qname, opts)
 
   local servers = convert_answers(answers, port)
 
+  servers.query = qname
+
   return servers
 end
 

--- a/apicast/src/resty/resolver.lua
+++ b/apicast/src/resty/resolver.lua
@@ -110,7 +110,7 @@ local function new_answer(address, port)
 end
 
 local function is_ip(address)
-  local m, err = ngx.re.match(address, '^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$', 'o')
+  local m, err = ngx.re.match(address, '^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$', 'oj')
 
   if m then
     return next(m)

--- a/apicast/src/resty/resolver.lua
+++ b/apicast/src/resty/resolver.lua
@@ -1,0 +1,66 @@
+local setmetatable = setmetatable
+local ipairs = ipairs
+
+local _M = {
+  _VERSION = '0.1'
+}
+
+local mt = { __index = _M }
+
+function _M.new(dns)
+  return setmetatable({
+    dns = dns
+  }, mt)
+end
+
+
+local function new_server(answer, port)
+  return {
+    address = answer.address,
+    ttl = answer.ttl,
+    port = answer.port or port
+  }
+end
+
+local function convert_answers(answers, port)
+  local servers = {}
+
+  for _, answer in ipairs(answers) do
+    servers[#servers+1] = new_server(answer, port)
+  end
+
+  servers.answers = answers
+
+  return servers
+end
+
+function _M.get_servers(self, qname, opts)
+  local opts = opts or {}
+  local dns = self.dns
+  local port = opts.port
+
+  if not dns then
+    return nil, 'resolver not initialized'
+  end
+
+  -- TODO: implement cache
+  -- TODO: pass proper options to dns resolver (like SRV query type)
+
+  local answers, err = dns:query(qname)
+
+  if err then
+    return nil, err
+  end
+
+  if not answers then
+    return nil, 'no answers'
+  end
+
+  local servers = convert_answers(answers, port)
+
+  return servers
+end
+
+
+
+return _M

--- a/apicast/src/resty/resolver/cache.lua
+++ b/apicast/src/resty/resolver/cache.lua
@@ -1,0 +1,150 @@
+local lrucache = require "resty.lrucache"
+
+local setmetatable = setmetatable
+local ipairs = ipairs
+local pairs = pairs
+local min = math.min
+local insert = table.insert
+
+local co_yield = coroutine.yield
+local co_create = coroutine.create
+local co_resume = coroutine.resume
+
+
+local _M = {
+  _VERSION = '0.1'
+}
+
+local mt = { __index = _M }
+
+function _M.new(cache)
+  local cache = cache or lrucache.new(1000)
+
+  return setmetatable({
+    cache = cache
+  }, mt)
+end
+
+local function compact_answers(servers)
+  local hash = {}
+  local compact = {}
+
+  for _, server in ipairs(servers) do
+    local name = server.name
+
+    local packed = hash[name]
+
+    if packed then
+      insert(packed, server)
+      packed.ttl = min(packed.ttl, server.ttl)
+    else
+      packed = {
+        server,
+        name = name,
+        ttl = server.ttl
+      }
+
+      insert(compact, packed)
+      hash[name] = packed
+    end
+  end
+
+  return compact
+end
+
+function _M.store(self, answer)
+  local cache = self.cache
+
+  if not cache then
+    return nil, 'not initialized'
+  end
+
+  return cache:set(answer.name, answer, answer.ttl)
+end
+
+function _M.save(self, answers)
+  local answers = compact_answers(answers or {})
+
+  for _, answer in pairs(answers) do
+    local _, err = self:store(answer)
+
+    if err then
+      return nil, err
+    end
+  end
+
+  return answers
+end
+
+
+local function fetch(cache, name, stale)
+  local circular_reference = {}
+
+  local function fetch_answers(name, stale)
+    if not name then
+      return {}, 'missing name'
+    end
+
+    if circular_reference[name] then
+      error('circular reference detected when querying '.. name)
+      return
+    else
+      circular_reference[name] = true
+    end
+
+    local answers, stale_answers = cache:get(name)
+
+    if not answers then
+      if stale and stale_answers then
+        return stale_answers
+      else
+        return {}
+      end
+    end
+
+    return answers
+  end
+
+  local function yieldfetch(name, stale)
+    local answers = fetch_answers(name, stale)
+
+    for _,answer in ipairs(answers) do
+      yieldfetch(answer.cname)
+      co_yield(answer)
+    end
+  end
+
+  local co = co_create(function () yieldfetch(name, stale) end)
+
+  return function ()
+    local code, res = co_resume(co)
+
+    if code then
+      return res
+    else
+      return nil, 'error when trying to fetch from cache'
+    end
+  end
+end
+
+function _M.get(self, name)
+  local cache = self.cache
+
+  if not cache then
+    return nil, 'not initialized'
+  end
+
+  local answers = { addresses = {} }
+
+  for data in fetch(cache, name) do
+    insert(answers, data)
+
+    if data.address then
+      insert(answers.addresses, data.address)
+    end
+  end
+
+  return answers
+end
+
+return _M

--- a/apicast/src/resty/resolver/cache.lua
+++ b/apicast/src/resty/resolver/cache.lua
@@ -69,7 +69,13 @@ function _M.store(self, answer)
 
   ngx.log(ngx.DEBUG, 'resolver cache write ', name, ' with TLL ', answer.ttl)
 
-  return cache:set(name, answer, answer.ttl)
+  local ttl = answer.ttl
+
+  if ttl == -1 then
+    ttl = nil
+  end
+
+  return cache:set(name, answer, ttl)
 end
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       TEST_NGINX_APICAST_PATH: /opt/app
       TEST_NGINX_REDIS_HOST: redis
     command: prove
+    depends_on:
+      - redis
     volumes:
             - ./t:/opt/app/t
   redis:

--- a/examples/configuration/local.json
+++ b/examples/configuration/local.json
@@ -1,0 +1,32 @@
+{
+  "id": 1234567890987,
+  "provider_key": "provider-key",
+  "services": [
+    {
+      "id": 654321,
+      "backend_version": "1",
+      "proxy": {
+        "api_backend": "http://127.0.0.1:8081",
+        "hostname_rewrite": "echo",
+        "hosts": [
+          "localhost",
+          "127.0.0.1"
+        ],
+        "backend": {
+          "endpoint": "http://127.0.0.1:8081",
+          "host": "backend"
+        },
+        "proxy_rules": [
+          {
+            "http_method": "GET",
+            "pattern": "/",
+            "metric_system_name": "hits",
+            "delta": 1,
+            "parameters": [],
+            "querystring_parameters": {}
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/script/reorder-tests
+++ b/script/reorder-tests
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+if ARGF.filename == '-'
+  ARGV.replace(Dir['t/*.t'])
+end
+
+ARGF.inplace_mode = ''
+
+tests = Hash.new(0)
+
+ARGF.each_line do |line|
+  print line.sub(/^=== TEST (\d+):/) { "=== TEST #{tests[ARGF.filename] += 1}:" }
+end

--- a/script/resolver.lua
+++ b/script/resolver.lua
@@ -1,0 +1,33 @@
+#!/usr/bin/env resty -I apicast/src
+
+local inspect = require 'inspect'
+
+local resty_resolver = require 'resty.resolver'
+local dns_resolver = require 'resty.dns.resolver'
+
+local dns, err = dns_resolver:new{ nameservers = { "8.8.8.8", "8.8.4.4" } }
+
+if err then
+  print('error: ', err)
+  os.exit(1)
+end
+
+local r = resty_resolver.new(dns)
+
+local host = arg[1]
+
+if not host then
+  print('missing host')
+  print('usage: ' .. arg[0] .. ' example.com')
+  os.exit(1)
+end
+
+local servers, err = r:get_servers(host)
+
+if err then
+  print('error: ', err)
+  print(inspect(r))
+  os.exit(1)
+end
+
+print(inspect(servers))

--- a/spec/resty/balancer_spec.lua
+++ b/spec/resty/balancer_spec.lua
@@ -1,0 +1,67 @@
+local resty_balancer = require 'resty.balancer'
+
+describe('resty.balancer', function()
+
+  describe('.new', function()
+    local new = resty_balancer.new
+
+    it('accepts mode', function()
+      local b, err = new('round-robin')
+
+      assert.equal('function', type(b.mode))
+      assert.falsy(err)
+    end)
+
+    it('returns error on invalid mode', function()
+      local b, err = new('invalid-mode')
+
+      assert.equal('invalid mode: invalid-mode', err)
+      assert.falsy(b)
+    end)
+  end)
+
+  describe('.modes', function()
+    local modes = resty_balancer.modes
+
+    it('returns available modes', function()
+      local available_modes = {
+        'round-robin'
+      }
+
+      assert.same(available_modes, modes())
+    end)
+  end)
+
+  describe(':peers', function()
+    local balancer = resty_balancer.new('round-robin')
+
+    it('returns peers from servers', function()
+      local servers = {
+        { }
+      }
+
+      local peers, err = balancer:peers(servers)
+
+      assert.falsy(err)
+      assert.equal(1, #peers)
+    end)
+  end)
+
+  describe(':set_peer', function()
+    local b = resty_balancer.new('round-robin')
+    b.balancer = { }
+
+    it('returns peers from servers', function()
+      local peers = {
+        { '127.0.0.2', 8091 }
+      }
+      b.balancer.set_current_peer = spy.new(function() return true end)
+
+      local ok, err = b:set_peer(peers)
+
+      assert.falsy(err)
+      assert.truthy(ok)
+      assert.spy(b.balancer.set_current_peer).was.called_with('127.0.0.2', 8091)
+    end)
+  end)
+end)

--- a/spec/resty/balancer_spec.lua
+++ b/spec/resty/balancer_spec.lua
@@ -37,10 +37,10 @@ describe('resty.balancer', function()
 
     it('returns peers from servers', function()
       local servers = {
-        { }
+        { address = '127.0.0.2' }
       }
 
-      local peers, err = balancer:peers(servers)
+      local peers, err = balancer:peers(servers, 80)
 
       assert.falsy(err)
       assert.equal(1, #peers)
@@ -62,6 +62,22 @@ describe('resty.balancer', function()
       assert.falsy(err)
       assert.truthy(ok)
       assert.spy(b.balancer.set_current_peer).was.called_with('127.0.0.2', 8091)
+    end)
+  end)
+
+  describe('round-robin balancer', function()
+    local balancer = resty_balancer.new('round-robin')
+
+    local servers = {
+      { address = '127.0.0.1', port = 80 },
+      { address = '127.0.0.2', port = 80 },
+      { address = '127.0.0.3', port = 80 },
+    }
+
+    local peers = balancer:peers()
+
+    it('loops through peers', function()
+
     end)
   end)
 end)

--- a/spec/resty/resolver/cache_spec.lua
+++ b/spec/resty/resolver/cache_spec.lua
@@ -1,0 +1,94 @@
+local resolver_cache = require 'resty.resolver.cache'
+
+inspect = require 'inspect'
+
+describe('resty.resolver.cache', function()
+
+  local answers = { {
+    class = 1,
+    cname = "elb.example.com",
+    name = "www.example.com",
+    section = 1,
+    ttl = 599,
+    type = 5
+  }, {
+    class = 1,
+    cname = "example.us-east-1.elb.amazonaws.com",
+    name = "elb.example.com",
+    section = 1,
+    ttl = 299,
+    type = 5
+  }, {
+    address = "54.221.208.116",
+    class = 1,
+    name = "example.us-east-1.elb.amazonaws.com",
+    section = 1,
+    ttl = 59,
+    type = 1
+  }, {
+    address = "54.221.221.16",
+    class = 1,
+    name = "example.us-east-1.elb.amazonaws.com",
+    section = 1,
+    ttl = 59,
+    type = 1
+  } }
+
+  describe('.save', function()
+
+    local c = resolver_cache.new()
+
+    it('returns compacted answers', function()
+      local keys = {}
+
+      for _,v in ipairs(c:save(answers)) do
+        table.insert(keys, v.name)
+      end
+
+      assert.same(
+        {'www.example.com',  'elb.example.com', 'example.us-east-1.elb.amazonaws.com' },
+        keys)
+    end)
+
+    it('stores the result', function()
+      c.store = spy.new(c.store)
+
+      c:save(answers)
+
+      assert.spy(c.store).was.called(3) -- TODO: proper called_with(args)
+    end)
+  end)
+
+  describe('.store', function()
+    local cache = {}
+    local c = resolver_cache.new(cache)
+
+    it('writes to the cache', function()
+      local record = { 'someting' }
+      local answer = { record, ttl = 60, name = 'foo.example.com' }
+      c.cache.set = spy.new(function(self, key, value, ttl)
+        assert.same('foo.example.com', key)
+        assert.same(answer, value)
+        assert.same(60, ttl)
+      end)
+
+      c:store(answer)
+
+      assert.spy(c.cache.set).was.called(1)
+    end)
+  end)
+
+  describe('.get', function()
+    local c = resolver_cache.new()
+
+    it('returns answers', function()
+      c:save(answers)
+
+      local answers = c:get('www.example.com')
+
+      assert.same({ "54.221.208.116", "54.221.221.16" }, answers.addresses)
+    end)
+
+  end)
+
+end)

--- a/spec/resty/resolver/cache_spec.lua
+++ b/spec/resty/resolver/cache_spec.lua
@@ -76,6 +76,20 @@ describe('resty.resolver.cache', function()
 
       assert.spy(c.cache.set).was.called(1)
     end)
+
+    it('works with -1 ttl', function()
+      local answer = { { 'something' }, ttl = -1, name = 'foo.example.com' }
+
+      c.cache.set = spy.new(function(self, key, value, ttl)
+        assert.same('foo.example.com', key)
+        assert.same(answer, value)
+        assert.same(nil, ttl)
+      end)
+
+      c:store(answer)
+
+      assert.spy(c.cache.set).was.called(1)
+    end)
   end)
 
   describe('.get', function()
@@ -88,7 +102,6 @@ describe('resty.resolver.cache', function()
 
       assert.same({ "54.221.208.116", "54.221.221.16" }, answers.addresses)
     end)
-
   end)
 
 end)

--- a/spec/resty/resolver_spec.lua
+++ b/spec/resty/resolver_spec.lua
@@ -1,0 +1,48 @@
+local resty_resolver = require 'resty.resolver'
+
+describe('resty.resolver', function()
+
+  -- TODO: consider :new(self) self api like resty.dns.resolver
+  describe('.new', function()
+    local new = resty_resolver.new
+
+    it('accepts dns', function()
+      local dns = { 'dns resolver' }
+      local r = new(dns)
+
+      assert.equal(dns, r.dns)
+    end)
+  end)
+
+  describe(':get_servers', function()
+    local dns = { }
+    local resolver = resty_resolver.new(dns)
+
+    it('returns servers', function()
+      dns.query = spy.new(function()
+        return {
+          { name = '3scale.net' , address = '127.0.0.1' }
+        }
+      end)
+
+      local servers, err = resolver:get_servers('3scale.net')
+
+      assert.falsy(err)
+      assert.equal(1, #servers)
+      assert.spy(dns.query).was.called_with(dns, '3scale.net')
+    end)
+
+    it('accepts port', function()
+      dns.query = function() return { {address = '127.0.0.2'} } end
+
+      local servers, err = resolver:get_servers('localhost', { port = 1337 })
+      local server, _ = unpack(servers or {})
+
+      assert.falsy(err)
+      assert.truthy(server)
+      assert.equal(1337, server.port)
+      assert.equal('127.0.0.2', server.address)
+    end)
+  end)
+
+end)

--- a/spec/resty/resolver_spec.lua
+++ b/spec/resty/resolver_spec.lua
@@ -38,7 +38,7 @@ describe('resty.resolver', function()
       local servers, err = resolver:get_servers('127.0.0.2')
 
       assert.falsy(err)
-      assert.same({ answer, answers = { answer } }, servers)
+      assert.same({ answer, answers = { answer }, query = '127.0.0.2' }, servers)
     end)
 
     it('accepts port', function()
@@ -51,6 +51,13 @@ describe('resty.resolver', function()
       assert.truthy(server)
       assert.equal(1337, server.port)
       assert.equal('127.0.0.2', server.address)
+    end)
+
+    it('returns back the query', function()
+      local answer, err = resolver:get_servers('example.com')
+
+      assert.falsy(err)
+      assert.equal('example.com', answer.query)
     end)
   end)
 

--- a/spec/resty/resolver_spec.lua
+++ b/spec/resty/resolver_spec.lua
@@ -32,6 +32,15 @@ describe('resty.resolver', function()
       assert.spy(dns.query).was.called_with(dns, '3scale.net')
     end)
 
+    it('returns servers for ip', function()
+      local answer = { address = '127.0.0.2', ttl = -1 }
+
+      local servers, err = resolver:get_servers('127.0.0.2')
+
+      assert.falsy(err)
+      assert.same({ answer, answers = { answer } }, servers)
+    end)
+
     it('accepts port', function()
       dns.query = function() return { {address = '127.0.0.2'} } end
 

--- a/spec/resty/resolver_spec.lua
+++ b/spec/resty/resolver_spec.lua
@@ -54,4 +54,19 @@ describe('resty.resolver', function()
     end)
   end)
 
+  describe('.parse_nameservers', function()
+    local tmpname = io.tmpfile()
+
+    tmpname:write('nameserver 127.0.0.2\n')
+    tmpname:write('nameserver 127.0.0.1\n')
+
+    it('returns nameserver touples', function()
+      local nameservers = resty_resolver.parse_nameservers(tmpname)
+
+      assert.equal(2, #nameservers)
+      assert.same({ {'127.0.0.2' }, { '127.0.0.1' } }, nameservers)
+    end)
+
+  end)
+
 end)

--- a/spec/spec_helper.lua
+++ b/spec/spec_helper.lua
@@ -1,0 +1,2 @@
+require 'ffi'
+require 'resty.lrucache'

--- a/t/001-management.t
+++ b/t/001-management.t
@@ -81,7 +81,7 @@ GET /status/ready
 --- no_error_log
 [error]
 
-=== TEST 2: readiness probe with 0 services
+=== TEST 3: readiness probe with 0 services
 Should respond with error status and a reason.
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";
@@ -173,7 +173,7 @@ Could not resolve GET /foobar - nil
 --- no_error_log
 [error]
 
-=== TEST 7: boot
+=== TEST 8: boot
 exposes boot function
 --- main_config
 env THREESCALE_PORTAL_ENDPOINT=http://localhost:$TEST_NGINX_SERVER_PORT/config/;
@@ -196,7 +196,7 @@ $::dns->("localhost", "127.0.0.1")
 --- no_error_log
 [error]
 
-=== TEST 7: boot called twice
+=== TEST 9: boot called twice
 keeps the same configuration
 --- main_config
 env THREESCALE_PORTAL_ENDPOINT=http://localhost:$TEST_NGINX_SERVER_PORT/config/;
@@ -225,7 +225,7 @@ $::dns->("localhost", "127.0.0.1")
 [error]
 
 
-=== TEST 8: config endpoint can delete configuration
+=== TEST 10: config endpoint can delete configuration
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";
 --- config
@@ -247,7 +247,7 @@ null
 --- no_error_log
 [error]
 
-=== TEST 9: all endpoints use correct Content-Type
+=== TEST 11: all endpoints use correct Content-Type
 JSON response body and content type application/json should be returned.
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";

--- a/t/003-apicast.t
+++ b/t/003-apicast.t
@@ -5,6 +5,7 @@ my $pwd = cwd();
 my $apicast = $ENV{TEST_NGINX_APICAST_PATH} || "$pwd/apicast";
 
 $ENV{TEST_NGINX_LUA_PATH} = "$apicast/src/?.lua;;";
+$ENV{TEST_NGINX_UPSTREAM_CONFIG} = "$apicast/http.d/upstream.conf";
 $ENV{TEST_NGINX_BACKEND_CONFIG} = "$apicast/conf.d/backend.conf";
 $ENV{TEST_NGINX_APICAST_CONFIG} = "$apicast/conf.d/apicast.conf";
 
@@ -111,6 +112,8 @@ credentials invalid!
 === TEST 4: api backend gets the request
 It asks backend and then forwards the request to the api.
 --- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
+
   lua_package_path "$TEST_NGINX_LUA_PATH";
   init_by_lua_block {
     require('configuration').save({
@@ -160,6 +163,7 @@ apicast cache miss key: 42:value:usage[hits]=2
 === TEST 5: call to backend is cached
 First call is done synchronously and the second out of band.
 --- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
   lua_package_path "$TEST_NGINX_LUA_PATH";
   init_by_lua_block {
     require('configuration').save({
@@ -217,6 +221,7 @@ apicast cache hit key: 42:value:usage[hits]=2
 === TEST 6: multi service configuration
 Two services can exist together and are split by their hostname.
 --- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
   lua_package_path "$TEST_NGINX_LUA_PATH";
   init_by_lua_block {
     require('configuration').save({
@@ -289,6 +294,7 @@ apicast cache write key: 21:two-id:two-key:usage[hits]=2
 === TEST 7: mapping rule with fixed value is mandatory
 When mapping rule has a parameter with fixed value it has to be matched.
 --- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
   lua_package_path "$TEST_NGINX_LUA_PATH";
   init_by_lua_block {
     require('configuration').save({
@@ -326,6 +332,7 @@ no mapping rules matched!
 === TEST 8: mapping rule with fixed value is mandatory
 When mapping rule has a parameter with fixed value it has to be matched.
 --- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
   lua_package_path "$TEST_NGINX_LUA_PATH";
   init_by_lua_block {
     require('configuration').save({
@@ -370,6 +377,7 @@ X-3scale-matched-rules: /foo?bar=baz
 === TEST 9: mapping rule with variable value is required to be sent
 When mapping rule has a parameter with variable value it has to exist.
 --- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
   lua_package_path "$TEST_NGINX_LUA_PATH";
   init_by_lua_block {
     require('configuration').save({

--- a/t/003-apicast.t
+++ b/t/003-apicast.t
@@ -367,7 +367,7 @@ X-3scale-matched-rules: /foo?bar=baz
 --- no_error_log
 [error]
 
-=== TEST 8: mapping rule with variable value is required to be sent
+=== TEST 9: mapping rule with variable value is required to be sent
 When mapping rule has a parameter with variable value it has to exist.
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";

--- a/t/004-apicast-path-routing.t
+++ b/t/004-apicast-path-routing.t
@@ -5,6 +5,7 @@ my $pwd = cwd();
 my $apicast = $ENV{TEST_NGINX_APICAST_PATH} || "$pwd/apicast";
 
 $ENV{TEST_NGINX_LUA_PATH} = "$apicast/src/?.lua;;";
+$ENV{TEST_NGINX_UPSTREAM_CONFIG} = "$apicast/http.d/upstream.conf";
 $ENV{TEST_NGINX_BACKEND_CONFIG} = "$apicast/conf.d/backend.conf";
 $ENV{TEST_NGINX_APICAST_CONFIG} = "$apicast/conf.d/apicast.conf";
 
@@ -20,6 +21,7 @@ Two services can exist together and are split by their hostname and mapping rule
 --- main_config
 env APICAST_PATH_ROUTING_ENABLED=1;
 --- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
   lua_package_path "$TEST_NGINX_LUA_PATH";
   init_by_lua_block {
     require('configuration').save({

--- a/t/005-apicast-oauth.t
+++ b/t/005-apicast-oauth.t
@@ -122,7 +122,7 @@ Location: http://example.com/redirect\?scope=whatever&response_type=token&error=
 --- no_error_log
 [error]
 
-=== TEST 1: calling /oauth/token returns correct error message on missing parameters
+=== TEST 4: calling /oauth/token returns correct error message on missing parameters
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";
   init_by_lua_block {
@@ -140,7 +140,7 @@ POST /oauth/token
 {"error":"invalid_client"}
 --- error_code: 401
 
-=== TEST 2: calling /oauth/token returns correct error message on invalid parameters
+=== TEST 5: calling /oauth/token returns correct error message on invalid parameters
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";
   init_by_lua_block {
@@ -158,7 +158,7 @@ POST /oauth/token?grant_type=authorization_code&client_id=client_id&redirect_uri
 {"error":"invalid_client"}
 --- error_code: 401
 
-=== TEST 3: calling /callback without params returns correct erro message
+=== TEST 6: calling /callback without params returns correct erro message
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";
   init_by_lua_block {
@@ -176,7 +176,7 @@ GET /callback
 {"error":"missing redirect_uri"}
 --- error_code: 400
 
-=== TEST 4: calling /callback redirects to correct error when state is missing
+=== TEST 7: calling /callback redirects to correct error when state is missing
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";
   init_by_lua_block {
@@ -196,7 +196,7 @@ include $TEST_NGINX_APICAST_CONFIG;
 --- response_body_like chomp
 ^<html>
 
-=== TEST 4: calling /callback redirects to correct error when state is missing
+=== TEST 8: calling /callback redirects to correct error when state is missing
 --- main_config
   env REDIS_HOST=$TEST_NGINX_REDIS_HOST;
 --- http_config
@@ -217,7 +217,7 @@ include $TEST_NGINX_APICAST_CONFIG;
 --- response_headers eval
 "Location: http://127.0.0.1:$ENV{TEST_NGINX_SERVER_PORT}/redirect_uri#error=invalid_request&error_description=invalid_or_expired_state&state=foo"
 
-=== TEST 7: calling /callback works
+=== TEST 9: calling /callback works
 Not part of the RFC. This is the Gateway API to create access tokens and redirect back to the Client.
 --- main_config
   env REDIS_HOST=$TEST_NGINX_REDIS_HOST;
@@ -255,7 +255,7 @@ GET /fake-authorize
 --- response_headers_like
 Location: http://example.com/redirect\?code=\w+&state=\w+
 
-=== TEST 8: calling /oauth/token returns correct error message on invalid parameters
+=== TEST 10: calling /oauth/token returns correct error message on invalid parameters
 --- main_config
   env REDIS_HOST=$TEST_NGINX_REDIS_HOST;
 --- http_config

--- a/t/006-apicast-subset-of-services.t
+++ b/t/006-apicast-subset-of-services.t
@@ -5,6 +5,7 @@ my $pwd = cwd();
 my $apicast = $ENV{TEST_NGINX_APICAST_PATH} || "$pwd/apicast";
 
 $ENV{TEST_NGINX_LUA_PATH} = "$apicast/src/?.lua;;";
+$ENV{TEST_NGINX_UPSTREAM_CONFIG} = "$apicast/http.d/upstream.conf";
 $ENV{TEST_NGINX_BACKEND_CONFIG} = "$apicast/conf.d/backend.conf";
 $ENV{TEST_NGINX_APICAST_CONFIG} = "$apicast/conf.d/apicast.conf";
 
@@ -19,6 +20,7 @@ __DATA__
 --- main_config
 env APICAST_SERVICES=42,21;
 --- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
   lua_package_path "$TEST_NGINX_LUA_PATH";
   init_by_lua_block {
     require('configuration').save({

--- a/t/007-apicast-upstream-balancer.t
+++ b/t/007-apicast-upstream-balancer.t
@@ -1,0 +1,136 @@
+use Test::Nginx::Socket::Lua 'no_plan';
+use Cwd qw(cwd);
+
+my $pwd = cwd();
+my $apicast = $ENV{TEST_NGINX_APICAST_PATH} || "$pwd/apicast";
+$ENV{TEST_NGINX_LUA_PATH} = "$apicast/src/?.lua;;";
+
+require("t/dns.pl");
+
+log_level('debug');
+repeat_each(2);
+no_root_location();
+run_tests();
+
+
+__DATA__
+
+=== TEST 1: resolver
+
+--- http_config
+lua_package_path "$TEST_NGINX_LUA_PATH";
+--- config
+location /t {
+  rewrite_by_lua_block {
+    local resty_resolver = require 'resty.resolver'
+    local dns_resolver = require 'resty.dns.resolver'
+
+    local dns = dns_resolver:new{ nameservers = { { "127.0.0.1", 1953 } } }
+    local resolver = resty_resolver.new(dns)
+
+    local servers = resolver:get_servers('3scale.net')
+    servers.answers = nil
+    ngx.ctx.upstream = servers
+  }
+
+  content_by_lua_block {
+    ngx.say(require('cjson').encode(ngx.ctx.upstream))
+  }
+}
+--- udp_listen: 1953
+--- udp_reply eval
+$::dns->("localhost", "127.0.0.1")
+--- request
+GET /t
+--- response_body
+[{"address":"127.0.0.1","ttl":0}]
+--- error_code: 200
+
+
+=== TEST 2: balancer
+
+--- http_config
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+
+  upstream upstream {
+    server 0.0.0.1:1;
+
+    balancer_by_lua_block {
+      local resty_balancer = require 'resty.balancer'
+
+      local balancer = resty_balancer.new('round-robin')
+      local servers = { { address = '127.0.0.1', port = $TEST_NGINX_SERVER_PORT } }
+      local peers = balancer:peers(servers)
+
+      local ok, err = balancer:set_peer(peers)
+
+      if not ok then
+        ngx.status = ngx.HTTP_SERVICE_UNAVAILABLE
+        ngx.log(ngx.ERR, "failed to set current peer: "..err)
+        ngx.exit(ngx.status)
+      end
+    }
+  }
+--- config
+location /api {
+  echo 'yay';
+}
+
+location /t {
+  proxy_pass http://upstream/api;
+}
+--- request
+GET /t
+--- response_body
+yay
+--- error_code: 200
+
+=== TEST 3: resolver + balancer
+
+--- http_config
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+
+  upstream upstream {
+    server 0.0.0.1:1;
+
+    balancer_by_lua_block {
+      local resty_balancer = require 'resty.balancer'
+
+      local balancer = resty_balancer.new('round-robin')
+      local peers = balancer:peers(ngx.ctx.upstream)
+
+      local peer, err = balancer:set_peer(peers)
+
+      if not peer then
+        ngx.status = ngx.HTTP_SERVICE_UNAVAILABLE
+        ngx.log(ngx.ERR, "failed to set current peer: "..err)
+        ngx.exit(ngx.status)
+      end
+    }
+  }
+--- config
+location /api {
+  echo 'yay';
+}
+
+location /t {
+  rewrite_by_lua_block {
+    local resty_resolver = require 'resty.resolver'
+    local dns_resolver = require 'resty.dns.resolver'
+
+    local dns = dns_resolver:new{ nameservers = { { "127.0.0.1", 1953 } } }
+    local resolver = resty_resolver.new(dns)
+
+    ngx.ctx.upstream = resolver:get_servers('localhost', { port = $TEST_NGINX_SERVER_PORT })
+  }
+
+  proxy_pass http://upstream/api;
+}
+--- udp_listen: 1953
+--- udp_reply eval
+$::dns->("localhost", "127.0.0.1")
+--- request
+GET /t
+--- response_body
+yay
+--- error_code: 200

--- a/t/007-apicast-upstream-balancer.t
+++ b/t/007-apicast-upstream-balancer.t
@@ -70,6 +70,8 @@ GET /t
         ngx.exit(ngx.status)
       end
     }
+
+    keepalive 32;
   }
 --- config
 location /api {
@@ -107,6 +109,8 @@ yay
         ngx.exit(ngx.status)
       end
     }
+
+    keepalive 32;
   }
 --- config
 location /api {

--- a/t/dns.pl
+++ b/t/dns.pl
@@ -1,0 +1,33 @@
+our $dns = sub ($$$) {
+  my ($host, $ip) = @_;
+
+  return sub {
+    # Get DNS request ID from passed UDP datagram
+    my $dns_id = unpack("n", shift);
+    # Set name and encode it
+    my $name = $host;
+    $name =~ s/([^.]+)\.?/chr(length($1)) . $1/ge;
+    $name .= "\0";
+    my $s = '';
+    $s .= pack("n", $dns_id);
+    # DNS response flags, hardcoded
+    # response, opcode, authoritative, truncated, recursion desired, recursion available, reserved
+    my $flags = (1 << 15) + (0 << 11) + (1 << 10) + (0 << 9) + (1 << 8) + (1 << 7) + 0;
+    $flags = pack("n", $flags);
+    $s .= $flags;
+    $s .= pack("nnnn", 1, 1, 0, 0);
+    $s .= $name;
+    $s .= pack("nn", 1, 1); # query class A
+
+    # Set response address and pack it
+    my @addr = split /\./, $ip;
+    my $data = pack("CCCC", @addr);
+
+    # pointer reference to the first name
+    # $name = pack("n", 0b1100000000001100);
+
+    # name + type A + class IN + TTL + length + data(ip)
+    $s .= $name. pack("nnNn", 1, 1, 0, 4) . $data;
+    return $s;
+  }
+};


### PR DESCRIPTION
closes #90

introduces `lua-resty-balancer` that will later be extracted into own package.

it is a library for implementing load balancers

# TODO

- [x] benchmark ([gist](https://gist.github.com/mikz/bafc0e25e3809cef2761b70a1df3d67a) with flamegraphs) 
- [x] implement 2 balancing algorithms (round-robin, random)