### PR TITLE
ability to crash on missing configuration

### DIFF
--- a/.env
+++ b/.env
@@ -12,3 +12,7 @@ REDIS_HOST=redis
 
 # Limit to subset of services. Comma separated list of service ids.
 # APICAST_SERVICES=265,31,42
+
+
+# What to do when Apicast does not have configuration. Allowed values are: log, exit
+# APICAST_MISSING_CONFIGURATION=log

--- a/apicast/bin/apicast
+++ b/apicast/bin/apicast
@@ -32,27 +32,44 @@ default_openresty_binary=$(pick_openresty openresty-debug openresty nginx)
 openresty_binary=${APICAST_OPENRESTY_BINARY:-$default_openresty_binary}
 log_level=${APICAST_LOG_LEVEL:-warn}
 log_file=${APICAST_LOG_FILE:-stderr}
+log_levels=(emerg alert crit error warn notice info debug)
+((max_log_level=${#log_levels[@]}-1))
+
+for ((i=0; i < ${#log_levels[@]}; i++)); do
+	ll=${log_levels[i]}
+	declare -r "log_level_${ll}=$i"
+done
+
+log="log_level_${log_level}"
+log_level="${!log}"
 
 mkdir -p "${apicast_dir}/logs"
 
 daemon=off
 
 usage () {
-	cat <<USAGE
-Usage $0
-	-h Show this help
-	-c <file> Path to custom config file (JSON).
-	-d Daemonize
+	cat <<-USAGE
+	Usage $0
+	  -h Show this help
+	  -c <file> Path to custom config file (JSON).
+	  -d Daemonize
+	  -v Increase verbosity (can be repeated)
 USAGE
 }
 
-while getopts ":dc:h" opt; do
+while getopts ":dc:hvq" opt; do
   case "${opt}" in
     d)
       daemon=on
       ;;
     c)
       export THREESCALE_CONFIG_FILE="$OPTARG"
+      ;;
+    v)
+	    log_level=$((log_level == max_log_level ? max_log_level : log_level+1))
+      ;;
+    q)
+	    log_level=$((log_level == 0 ? 0 : log_level-1))
       ;;
     h)
       usage
@@ -67,4 +84,4 @@ while getopts ":dc:h" opt; do
   esac
 done
 
-exec "${openresty_binary}" -p "${apicast_dir}" -c conf/nginx.conf -g "daemon ${daemon}; error_log ${log_file} ${log_level};"
+exec "${openresty_binary}" -p "${apicast_dir}" -c conf/nginx.conf -g "daemon ${daemon}; error_log ${log_file} ${log_levels[log_level]};"

--- a/apicast/bin/apicast
+++ b/apicast/bin/apicast
@@ -37,15 +37,34 @@ mkdir -p "${apicast_dir}/logs"
 
 daemon=off
 
-while getopts ":d" opt; do
+usage () {
+	cat <<USAGE
+Usage $0
+	-h Show this help
+	-c <file> Path to custom config file (JSON).
+	-d Daemonize
+USAGE
+}
+
+while getopts ":dc:h" opt; do
   case "${opt}" in
     d)
       daemon=on
       ;;
+    c)
+      export THREESCALE_CONFIG_FILE="$OPTARG"
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
     \?)
       echo "Invalid option: -${OPTARG}" >&2
+      echo
+      usage
+      exit 1
       ;;
   esac
 done
 
-exec ${openresty_binary} -p ${apicast_dir} -c conf/nginx.conf -g "daemon ${daemon}; error_log ${log_file} ${log_level};"
+exec "${openresty_binary}" -p "${apicast_dir}" -c conf/nginx.conf -g "daemon ${daemon}; error_log ${log_file} ${log_level};"

--- a/apicast/conf/nginx.conf
+++ b/apicast/conf/nginx.conf
@@ -13,6 +13,7 @@ env REDIS_HOST;
 env REDIS_PORT;
 env RESOLVER;
 env APICAST_MODULE;
+env APICAST_MISSING_CONFIGURATION;
 
 # error_log stderr notice;
 # error_log logs/error.log warn;

--- a/apicast/src/apicast.lua
+++ b/apicast/src/apicast.lua
@@ -5,13 +5,27 @@ local _M = {
   _VERSION = '0.1'
 }
 
+local missing_configuration = os.getenv('APICAST_MISSING_CONFIGURATION') or 'log'
+
+local function handle_missing_configuration(err)
+  if missing_configuration == 'log' then
+    ngx.log(ngx.ERR, 'failed to load configuration, continuing: ', err)
+  elseif missing_configuration == 'exit' then
+    ngx.log(ngx.EMERG, 'failed to load configuration, exiting: ', err)
+    os.exit(1)
+  else
+    ngx.log(ngx.ERR, 'unknown value of APICAST_MISSING_CONFIGURATION: ', missing_configuration)
+    os.exit(1)
+  end
+end
+
 function _M.init()
-  local config = configuration.init()
+  local config, err = configuration.init()
 
   if config then
     provider.init(config)
   else
-    ngx.log(ngx.ERR, 'boot configuration load failed')
+    handle_missing_configuration(err)
   end
 end
 

--- a/apicast/src/configuration.lua
+++ b/apicast/src/configuration.lua
@@ -309,8 +309,10 @@ function _M.init()
   elseif exit then
     if code then
       ngx.log(ngx.ERR, 'boot could not get configuration, ' .. tostring(exit) .. ': '.. tostring(code))
+      return nil, exit
     else
       ngx.log(ngx.ERR, 'boot failed read: '.. tostring(exit))
+      return nil, exit
     end
   end
 end

--- a/openshift/apicast-template.yml
+++ b/openshift/apicast-template.yml
@@ -43,6 +43,8 @@ objects:
             value: ${RESOLVER}
           - name: APICAST_SERVICES
             value: ${APICAST_SERVICES}
+          - name: APICAST_MISSING_CONFIGURATION
+            value: ${MISSING_CONFIGURATION}
           image: ${THREESCALE_GATEWAY_IMAGE}
           imagePullPolicy: Always
           name: ${THREESCALE_GATEWAY_NAME}
@@ -112,3 +114,7 @@ parameters:
   value:
   name: APICAST_SERVICES
   required: false
+- description: What to do on missing or invalid configuration. Allowed values are: log, exit.
+  value: exit
+  required: false
+  name: MISSING_CONFIGURATION


### PR DESCRIPTION
exit when gateway can't find its configuration
propagate any error message

OpenShift template defaults to exiting on missing configuration.