### PR TITLE
Fix OpenShift template PATH_ROUTING value

### DIFF
--- a/openshift/apicast-template.yml
+++ b/openshift/apicast-template.yml
@@ -128,4 +128,4 @@ parameters:
 - description: "Enable path routing. Experimental feature."
   name: PATH_ROUTING
   required: false
-  value: false
+  value: "false"


### PR DESCRIPTION
Resolves the error:

    error: unable to load template file "openshift-template.yml": unable to decode "openshift-template.yml": [pos 3503]: json: expect char '"' but got char 'f'