### PR TITLE
Put balancer() logic of the apicast module in a separate & reusable module

### DIFF
--- a/apicast/src/apicast.lua
+++ b/apicast/src/apicast.lua
@@ -1,5 +1,6 @@
 local configuration = require('configuration')
 local provider = require('provider')
+local balancer = require('balancer')
 
 local _M = {
   _VERSION = '0.1'
@@ -60,20 +61,6 @@ function _M.header_filter()
   ngx.var.resp_headers = require('cjson').encode(ngx.resp.get_headers())
 end
 
-function _M.balancer()
-  local round_robin = require 'resty.balancer.round_robin'
-  local name = ngx.var.proxy_host
-
-  local balancer = round_robin.new()
-  local peers = balancer:peers(ngx.ctx[name])
-
-  local peer, err = balancer:set_peer(peers)
-
-  if not peer then
-    ngx.status = ngx.HTTP_SERVICE_UNAVAILABLE
-    ngx.log(ngx.ERR, "failed to set current backend peer: ", err)
-    ngx.exit(ngx.status)
-  end
-end
+_M.balancer = balancer.call
 
 return _M

--- a/apicast/src/balancer.lua
+++ b/apicast/src/balancer.lua
@@ -1,0 +1,18 @@
+local round_robin = require 'resty.balancer.round_robin'
+
+local _M = { }
+
+function _M.call()
+  local balancer = round_robin.new()
+  local peers = balancer:peers(ngx.ctx[ngx.var.proxy_host])
+
+  local peer, err = balancer:set_peer(peers)
+
+  if not peer then
+    ngx.status = ngx.HTTP_SERVICE_UNAVAILABLE
+    ngx.log(ngx.ERR, "failed to set current backend peer: ", err)
+    ngx.exit(ngx.status)
+  end
+end
+
+return _M


### PR DESCRIPTION
The logic inside the balancer() method is probably not going to be used only from the Apicast module. Let's extract it and make it reusable.