### PR TITLE
Sort directives by execution order in apicast.conf

### DIFF
--- a/apicast/conf.d/apicast.conf
+++ b/apicast/conf.d/apicast.conf
@@ -29,7 +29,7 @@ location @out_of_band_authrep_action {
 
   set_by_lua $original_request_time 'return ngx.var.request_time';
 
-  content_by_lua_block { require('module').call() }
+  content_by_lua_block { require('module').new():call('post_action') }
 
   log_by_lua_block {
     ngx.var.post_action_impact = ngx.var.request_time - ngx.var.original_request_time

--- a/apicast/conf.d/apicast.conf
+++ b/apicast/conf.d/apicast.conf
@@ -29,12 +29,12 @@ location @out_of_band_authrep_action {
 
   set_by_lua $original_request_time 'return ngx.var.request_time';
 
+  content_by_lua_block { require('module').call() }
+
   log_by_lua_block {
     ngx.var.post_action_impact = ngx.var.request_time - ngx.var.original_request_time
     ngx.log(ngx.INFO, '[authrep] ' .. ngx.var.request_uri .. ' ' .. ngx.var.status)
   }
-
-  content_by_lua_block { require('module').call() }
 }
 
 location / {

--- a/apicast/src/apicast.lua
+++ b/apicast/src/apicast.lua
@@ -40,7 +40,7 @@ function _M.rewrite()
   end
 end
 
-function _M.content()
+function _M.post_action()
   provider.post_action_content()
 end
 

--- a/apicast/src/apicast.lua
+++ b/apicast/src/apicast.lua
@@ -41,7 +41,7 @@ function _M.rewrite()
 end
 
 function _M.post_action()
-  provider.post_action_content()
+  provider.post_action()
 end
 
 function _M.access()

--- a/apicast/src/provider.lua
+++ b/apicast/src/provider.lua
@@ -373,7 +373,7 @@ function _M.access(service)
 end
 
 
-function _M.post_action_content()
+function _M.post_action()
   local service_id = tonumber(ngx.var.service_id, 10)
 
   _M.call(service_id) -- initialize resolver and get backend upstream peers

--- a/spec/provider_spec.lua
+++ b/spec/provider_spec.lua
@@ -19,9 +19,9 @@ describe('Provider', function()
     assert.same('function', type(provider.authorize))
   end)
 
-  it('has post_action_content function', function()
-    assert.truthy(provider.post_action_content)
-    assert.same('function', type(provider.post_action_content))
+  it('has post_action function', function()
+    assert.truthy(provider.post_action)
+    assert.same('function', type(provider.post_action))
   end)
 
   it('has services', function()


### PR DESCRIPTION
The content phase is executed before the log one, but in the config `log_by_lua` appeared before `content_by_lua`. There are some operations performed to calculate run times and to understand them it's necessary to know the order of execution of the phases. I think that sorting them in the config helps.