### PR TITLE
Execute functionality that can be used in other modules in the rewrite phase

### DIFF
--- a/apicast/src/apicast.lua
+++ b/apicast/src/apicast.lua
@@ -40,6 +40,9 @@ function _M.rewrite()
     local config = configuration.boot()
     provider.init(config)
   end
+
+  provider.set_service()
+  provider.set_upstream()
 end
 
 function _M.post_action()

--- a/apicast/src/provider.lua
+++ b/apicast/src/provider.lua
@@ -259,7 +259,7 @@ function _M.authorize(backend_version, service)
   end
 end
 
-function _M.call(host)
+function _M.set_service(host)
   host = host or ngx.var.host
   local service = _M.find_service(host)
 
@@ -267,12 +267,22 @@ function _M.call(host)
     error_service_not_found(host)
   end
 
+  ngx.ctx.service = service
+end
+
+function _M.call(host)
+  host = host or ngx.var.host
+  if not ngx.ctx.service then
+    _M.set_service(host)
+  end
+
+  local service = ngx.ctx.service
+
   ngx.var.backend_authentication_type = service.backend_authentication.type
   ngx.var.backend_authentication_value = service.backend_authentication.value
   ngx.var.backend_host = service.backend.host or ngx.var.backend_host
 
   ngx.var.service_id = tostring(service.id)
-  ngx.ctx.service = service
 
   ngx.var.version = _M.configuration.version
 

--- a/apicast/src/provider.lua
+++ b/apicast/src/provider.lua
@@ -272,7 +272,11 @@ end
 
 function _M.set_upstream()
   local service = ngx.ctx.service
-  local scheme, _, _, host, port, path = unpack(configuration.url(service.api_backend) or {})
+
+  -- The default values are only for tests. We need to set at least the scheme.
+  local scheme, _, _, host, port, path =
+    unpack(configuration.url(service.api_backend) or { 'http' })
+
   ngx.ctx.dns = dns_resolver:new{ nameservers = resty_resolver.nameservers() }
   ngx.ctx.resolver = resty_resolver.new(ngx.ctx.dns)
   ngx.var.proxy_pass = scheme .. '://upstream' .. (path or '')

--- a/apicast/src/provider.lua
+++ b/apicast/src/provider.lua
@@ -82,6 +82,13 @@ local function error_no_match(service)
   ngx.print(service.error_no_match)
   ngx.exit(ngx.HTTP_OK)
 end
+
+local function error_service_not_found(host)
+  ngx.status = 404
+  ngx.print('')
+  ngx.log(ngx.WARN, 'could not find service for host: ', host)
+  ngx.exit(ngx.status)
+end
 -- End Error Codes
 
 -- Aux function to split a string
@@ -257,10 +264,7 @@ function _M.call(host)
   local service = _M.find_service(host)
 
   if not service then
-    ngx.status = 404
-    ngx.print('')
-    ngx.log(ngx.WARN, 'could not find service for host: ', host)
-    return ngx.exit(ngx.status)
+    error_service_not_found(host)
   end
 
   ngx.var.backend_authentication_type = service.backend_authentication.type


### PR DESCRIPTION
This moves some of the logic that runs in the access phase to the rewrite one. Only 2 things have been moved, saving the service and the data needed to resolve upstream to ngx.ctx. This greatly simplifies writing a new module that shares a lot of functionality with the Apicast one and inherits from it.