### PR TITLE
DNS domain search

### DIFF
--- a/apicast/conf.d/apicast.conf
+++ b/apicast/conf.d/apicast.conf
@@ -12,16 +12,17 @@ location = /threescale_authrep {
     local log = ngx.var.arg_log;
     if log then return '&' .. ngx.unescape_uri(log) end
   }
+  set $path /transactions/authrep.xml?$backend_authentication_type=$backend_authentication_value&service_id=$service_id&$usage&$credentials$log;
   proxy_pass_request_headers off;
   proxy_http_version 1.1;
-  proxy_pass $backend_endpoint/transactions/authrep.xml?$backend_authentication_type=$backend_authentication_value&service_id=$service_id&$usage&$credentials$log;
+  proxy_pass $backend_endpoint$path;
   proxy_set_header  Host  "$backend_host";
   proxy_set_header  X-3scale-User-Agent "nginx$deployment";
   proxy_set_header  X-3scale-Version "$version";
   proxy_set_header  Connection "";
 
-  log_by_lua_block {
-    ngx.log(ngx.INFO, '[authrep] ' .. ngx.var.request_uri .. ' ' .. ngx.var.status)
+  rewrite_by_lua_block {
+    ngx.var.real_url = ngx.var.backend_endpoint .. ngx.var.path
   }
 }
 
@@ -60,6 +61,7 @@ location / {
   set $backend_authentication_type null;
   set $backend_authentication_value null;
   set $version null;
+  set $real_url null;
 
   set $post_action_impact null;
 

--- a/apicast/src/provider.lua
+++ b/apicast/src/provider.lua
@@ -202,10 +202,20 @@ local http = {
   get = function(url)
     ngx.log(ngx.INFO, '[http] requesting ' .. url)
     local backend_upstream = ngx.ctx.backend_upstream
+    local previous_real_url = ngx.var.real_url
     ngx.log(ngx.DEBUG, '[ctx] copying backend_upstream of size: ', #backend_upstream)
     local res = ngx.location.capture(assert(url), { share_all_vars = true, ctx = { backend_upstream = backend_upstream } })
 
-    ngx.log(ngx.INFO, '[http] status: ' .. tostring(res.status))
+    local real_url = ngx.var.real_url
+
+    if real_url ~= previous_real_url then
+      ngx.log(ngx.INFO, '[http] ', real_url, ' (',tostring(res.status), ')')
+    else
+      ngx.log(ngx.INFO, '[http] status: ', tostring(res.status))
+    end
+
+    ngx.var.real_url = ''
+
     return res
   end
 }

--- a/apicast/src/resty/resolver/dns.lua
+++ b/apicast/src/resty/resolver/dns.lua
@@ -1,0 +1,43 @@
+local resty_resolver = require 'resty.dns.resolver'
+
+local setmetatable = setmetatable
+local ipairs = ipairs
+local concat = table.concat
+
+local _M = {
+  _VERSION = '0.1'
+}
+local mt = { __index = _M }
+
+function _M.new(_, options)
+  local resolvers = {}
+  local opts = options or {}
+  local nameservers = opts.nameservers or {}
+
+  for _,nameserver in ipairs(nameservers) do
+    resolvers[nameserver] = resty_resolver:new({ nameservers = { nameserver }})
+  end
+
+  return setmetatable({
+    resolvers = resolvers
+  }, mt)
+end
+
+function _M.query(self, qname, opts)
+  local resolvers = self.resolvers
+  local answers, err
+
+  for nameserver, resolver in pairs(resolvers) do
+    answers, err = resolver:query(qname, opts)
+
+    ngx.log(ngx.DEBUG, 'resolver query: ', qname, ' nameserver: ', concat(nameserver,':'))
+
+    if answers and not answers.errcode and not err then
+      break
+    end
+  end
+
+  return answers, err
+end
+
+return _M

--- a/spec/resty/resolver_spec.lua
+++ b/spec/resty/resolver_spec.lua
@@ -43,6 +43,28 @@ describe('resty.resolver', function()
       assert.spy(dns.query).was.called_with(dns, '3scale.net', { qtype = 1 })
     end)
 
+    it('searches domains', function()
+      dns.TYPE_A = 1
+      dns.query = spy.new(function(_, qname)
+        if qname == '3scale.net' then
+          return {
+            { name = '3scale.net' , address = '127.0.0.1' }
+          }
+        else
+          return { errcode = 3, errstr = 'name error' }
+        end
+      end)
+      resolver.search = { 'example.com', 'net' }
+
+      local servers, err = resolver:get_servers('3scale')
+
+      assert.falsy(err)
+      assert.equal(1, #servers)
+      assert.spy(dns.query).was.called_with(dns, '3scale', { qtype = 1 })
+      assert.spy(dns.query).was.called_with(dns, '3scale.example.com', { qtype = 1 })
+      assert.spy(dns.query).was.called_with(dns, '3scale.net', { qtype = 1 })
+    end)
+
     it('returns servers for ip', function()
       local answer = { address = '127.0.0.2', ttl = -1 }
 

--- a/spec/resty/resolver_spec.lua
+++ b/spec/resty/resolver_spec.lua
@@ -15,8 +15,18 @@ describe('resty.resolver', function()
   end)
 
   describe(':get_servers', function()
-    local dns = { }
-    local resolver = resty_resolver.new(dns)
+    local dns, resolver
+
+    before_each(function()
+      dns = {
+        query = spy.new(function(_, name)
+          return {
+            { name = name , address = '127.0.0.1' }
+          }
+        end)
+      }
+      resolver = resty_resolver.new(dns)
+    end)
 
     it('returns servers', function()
       dns.TYPE_A = 1
@@ -63,16 +73,29 @@ describe('resty.resolver', function()
   end)
 
   describe('.parse_nameservers', function()
-    local tmpname = io.tmpfile()
+    local tmpname
 
-    tmpname:write('nameserver 127.0.0.2\n')
-    tmpname:write('nameserver 127.0.0.1\n')
+    before_each(function()
+      tmpname = io.tmpfile()
+
+      tmpname:write('search localdomain.example.com local\n')
+      tmpname:write('nameserver 127.0.0.2\n')
+      tmpname:write('nameserver 127.0.0.1\n')
+    end)
 
     it('returns nameserver touples', function()
       local nameservers = resty_resolver.parse_nameservers(tmpname)
 
       assert.equal(2, #nameservers)
-      assert.same({ {'127.0.0.2' }, { '127.0.0.1' } }, nameservers)
+      assert.same({ '127.0.0.2' },  nameservers[1])
+      assert.same({ '127.0.0.1' }, nameservers[2])
+    end)
+
+    it('returns search domains', function()
+      local search = resty_resolver.parse_nameservers(tmpname).search
+
+      assert.equal(2, #search)
+      assert.same({ 'localdomain.example.com', 'local' },  search)
     end)
 
   end)


### PR DESCRIPTION
`/etc/resolv.conf` can specify `search` section that is used for domains without TLD.

For example on openshift, there is service `foobar`. If you try `dig foobar` you won't get an answer.
The proper host is `foobar.something.svc.cluster.local`. That domain is defined in the `search` section of `/etc/resolv.conf`.