### PR TITLE
.mailmap: map authors to their names/addresses

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Michal Cichra <michal@cichra.cz> Michal Cichra <mikz@users.noreply.github.com>
+Joaquim Moreno <jmprusi@keepalive.io> builder <build@localhost>


### PR DESCRIPTION
Add entries for people with multiple or wrong addresses.

This avoids running something like 'filter-branch' which would have
the side effect of rewriting the repository's history.

Edit: unable to push to this repository, so forking.