### PR TITLE
Remove unused OAuth location

### DIFF
--- a/apicast/conf.d/apicast.conf
+++ b/apicast/conf.d/apicast.conf
@@ -46,7 +46,6 @@ location @out_of_band_authrep_action {
 location / {
   set $cached_key null;
   set $credentials null;
-  set $access_token null;
   set $usage null;
   set $service_id null;
   set $proxy_pass null;
@@ -91,19 +90,6 @@ location = /_threescale/oauth_store_token {
   proxy_set_header  Host  "$backend_host";
 
   proxy_pass $backend_endpoint/services/$service_id/oauth_access_tokens.xml?$backend_authentication_type=$backend_authentication_value;
-}
-
-location /_threescale/oauth_authorize {
-  internal; # changed, wasnt before
-
-  proxy_set_header  X-Real-IP  $remote_addr;
-  proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-  proxy_set_header  Host  "$backend_host";
-  proxy_set_header  X-3scale-User-Agent "nginx$deployment";
-  proxy_set_header  X-3scale-Version "$version";
-
-  proxy_ignore_client_abort on;
-  proxy_pass $backend_endpoint/transactions/oauth_authorize.xml?$backend_authentication_type=$backend_authentication_value&service_id=$service_id&access_token=$arg_access_token&$usage;
 }
 
 location = /_threescale/check_credentials {

--- a/apicast/src/provider.lua
+++ b/apicast/src/provider.lua
@@ -385,7 +385,6 @@ function _M.access(service)
     ngx.var.cached_key = concat({service.id, params.app_id, params.app_key}, ':')
 
   elseif backend_version == 'oauth' then
-    ngx.var.access_token = parameters.access_token
     params.access_token = parameters.access_token
     ngx.var.cached_key = concat({service.id, params.access_token}, ':')
   else


### PR DESCRIPTION
The `ngx.var.access_token` is not used anywhere else, so it can be safely removed too.