### PR TITLE
Refactor auth params extraction

### DIFF
--- a/apicast/src/configuration.lua
+++ b/apicast/src/configuration.lua
@@ -46,26 +46,19 @@ local function regexpify(path)
 end
 
 local function check_rule(req, rule, usage_t, matched_rules)
-  local param = {}
   local pattern = rule.regexpified_pattern
   local match = ngx.re.match(req.path, format("^%s", pattern), 'oj')
 
   if match and req.method == rule.method then
     local args = req.args
 
-    if rule.querystring_params(args) then -- may return an empty table
-      -- when no querystringparams
-      -- in the rule. it's fine
-      for i,p in ipairs(rule.parameters or {}) do
-        param[p] = match[i]
-      end
-
+    -- querystring_params returns 'true' if the querystring matches the rule, and 'false' otherwise
+    if rule.querystring_params(args) then
       insert(matched_rules, rule.pattern)
       usage_t[rule.system_name] = set_or_inc(usage_t, rule.system_name, rule.delta)
     end
   end
 end
-
 
 local function first_values(a)
   local r = {}

--- a/apicast/src/provider.lua
+++ b/apicast/src/provider.lua
@@ -139,19 +139,6 @@ local build_query = build_querystring_formatter("%s=%s")
   Authorization logic
 ]]--
 
-local function get_auth_params(where, method)
-  local params
-  if where == "headers" then
-    params = ngx.req.get_headers()
-  elseif method == "GET" then
-    params = ngx.req.get_uri_args()
-  else
-    ngx.req.read_body()
-    params = ngx.req.get_post_args()
-  end
-  return first_values(params)
-end
-
 local function get_debug_value()
   return ngx.var.http_x_3scale_debug == _M.configuration.debug_header
 end
@@ -368,38 +355,24 @@ function _M.access(service)
     ngx.exit(403)
   end
 
-  local request = ngx.var.request
-  local credentials = service.credentials
-  local parameters = get_auth_params(credentials.location, split(request, " ")[1] )
-
   ngx.var.secret_token = service.secret_token
 
-  if backend_version == '1' then
-    params.user_key = parameters[credentials.user_key]
-    ngx.var.cached_key = concat({service.id, params.user_key}, ':')
+  local request = ngx.var.request
+  local method =  split(request, " ")[1]
 
-  elseif backend_version == '2' then
-    params.app_id = parameters[credentials.app_id]
-    params.app_key = parameters[credentials.app_key] -- or ""  -- Uncoment the first part if you want to allow not passing app_key
+  local auth_params, cached_key = service:extract_credentials(method)
 
-    ngx.var.cached_key = concat({service.id, params.app_id, params.app_key}, ':')
-
-  elseif backend_version == 'oauth' then
-    ngx.var.access_token = parameters.access_token
-    params.access_token = parameters.access_token
-    ngx.var.cached_key = concat({service.id, params.access_token}, ':')
-  else
-    error('unknown backend version: ' .. tostring(backend_version))
-  end
-
-  if not service:get_credentials(params) then
+  if not cached_key then 
     return error_no_credentials(service)
   end
 
   usage, matched_patterns = service:extract_usage(request)
 
   ngx.log(ngx.INFO, inspect{usage, matched_patterns})
-  ngx.var.credentials = build_query(params)
+  
+  ngx.var.access_token = auth_params.access_token
+  ngx.var.cached_key = cached_key
+  ngx.var.credentials = build_query(auth_params)
   ngx.var.usage = build_querystring(usage)
 
   -- WHAT TO DO IF NO USAGE CAN BE DERIVED FROM THE REQUEST.

--- a/apicast/src/provider.lua
+++ b/apicast/src/provider.lua
@@ -15,7 +15,6 @@ local type = type
 local pairs = pairs
 local ipairs = ipairs
 local insert = table.insert
-local lower = string.lower
 
 local concat = table.concat
 local tostring = tostring
@@ -102,20 +101,6 @@ local function error_service_not_found(host)
   ngx.exit(ngx.status)
 end
 -- End Error Codes
-
--- Aux function to split a string
-
-local function first_values(a)
-  local r = {}
-  for k,v in pairs(a) do
-    if type(v) == "table" then
-      r[lower(k)] = v[1] -- TODO: use metatable to convert all access to lowercase
-    else
-      r[lower(k)] = v
-    end
-  end
-  return r
-end
 
 local function build_querystring_formatter(fmt)
   return function (query)
@@ -346,7 +331,6 @@ end
 function _M.access(service)
   local scheme, _, _, host, port, path = unpack(configuration.url(service.api_backend) or {})
   local backend_version = service.backend_version
-  local params = {}
   local usage
   local matched_patterns
 
@@ -362,7 +346,7 @@ function _M.access(service)
 
   local auth_params, cached_key = service:extract_credentials(method)
 
-  if not cached_key then 
+  if not cached_key then
     return error_no_credentials(service)
   end
 


### PR DESCRIPTION
Implements the changes proposed in: https://github.com/3scale/apicast/pull/154 (those not treated in other PRs/issues)

The main idea behind this is to reduce to minimum the following comparison, which appeared in multiple locations:
```
if backend_version == '1' then
  ...
elseif backend_version == '2' then
  ...
elseif backend_version == 'oauth' then
  ...
else
```

Also, this fixes the `extract_parameters`, which now returns the credentials according to the service configuration.