### PR TITLE
Perf improvement: Avoid unnecessary calls to regexpify() in configuration.lua

### DIFF
--- a/apicast/src/configuration.lua
+++ b/apicast/src/configuration.lua
@@ -47,7 +47,7 @@ end
 
 local function check_rule(req, rule, usage_t, matched_rules)
   local param = {}
-  local pattern = regexpify(rule.pattern)
+  local pattern = rule.regexpified_pattern
   local match = ngx.re.match(req.path, format("^%s", pattern), 'oj')
 
   if match and req.method == rule.method then
@@ -208,6 +208,7 @@ function _M.parse_service(service)
         return {
           method = proxy_rule.http_method,
           pattern = proxy_rule.pattern,
+          regexpified_pattern = regexpify(proxy_rule.pattern),
           parameters = proxy_rule.parameters,
           querystring_params = function(args)
             return check_querystring_params(proxy_rule.querystring_parameters or {}, args)


### PR DESCRIPTION
`regexpify()` is being called in every request for each of the rules defined.

The rules do not change, so we can just call `regexpify()` when parsing the config file to construct a service.

I have profiled APIcast using stapxx and it was clear that this was a problem. With around 100 rules and 3k rps, `regexpify()` was consuming like 50% of the CPU time.