### PR TITLE
update readme to use oc cluster up

### DIFF
--- a/doc/openshift-guide.md
+++ b/doc/openshift-guide.md
@@ -62,9 +62,12 @@ You should now see a section **Production: Self-managed Gateway** at the bottom 
 
 ### Setup OpenShift
 
-There are many ways you can install Openshift.
-- [Running Openshift using Vagrant] (https://support.3scale.net/guides/infrastructure/docker-openshift)
-- [Running Openshift as all-in-one container] (https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md) (current tutorial)
+There are many ways you can install OpenShift.
+- All-In-One Virtual Machine using Vagrant &ndash; https://www.openshift.org/vm
+- Using `oc cluster up` command &ndash; https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md (used in this tutorial)
+- Using Ansible Playbooks (advanced installation):
+  - OpenShift Container Platform 3.3 Installation and Configuration documentation &ndash; https://docs.openshift.com/container-platform/3.3/install_config/index.html
+  - For reference architecture guides for OpenShift 3.3 please refer to the following articles: [AWS](https://access.redhat.com/articles/2623521), [Google Cloud Engine](https://access.redhat.com/articles/2751521), [VMware vCenter 6](https://access.redhat.com/articles/2745171)
 
 In this tutorial the OpenShift cluster will be installed using: 
 - CentOS 7

--- a/doc/openshift-guide.md
+++ b/doc/openshift-guide.md
@@ -70,14 +70,14 @@ There are many ways you can install Openshift.
 
 ## Installation
 The openshift cluster was installed and tested on 
-<pre><code>
+```
 CentOS version - CentOS Linux release 7.2.1511 (Core)
 Docker - 1.10.3
 Openshift Origin command line interface (CLI) - v1.3.1
-</code></pre>
+```
 
 1. Install Docker on CentOS
-<pre><code>yum -y install docker docker-registry</code></pre>
+```yum -y install docker docker-registry```
 
 2. Configure the Docker daemon with an insecure registry parameter of `172.30.0.0/16`
    - Edit the `/etc/sysconfig/docker` file and add or uncomment the following line:
@@ -89,7 +89,7 @@ Openshift Origin command line interface (CLI) - v1.3.1
      ```
      $ sudo systemctl restart docker
      ```
-3. Download the Linux `oc` binary from
+3. Download the client tools release
    [openshift-origin-client-tools-VERSION-linux-64bit.tar.gz](https://github.com/openshift/origin/releases)
    and place it in your path.
 
@@ -97,7 +97,7 @@ Openshift Origin command line interface (CLI) - v1.3.1
 
 
 4. Open a terminal with a user that has permission to run Docker commands and run:
-<pre><code>
+```
 $oc cluster up
 -- Checking OpenShift client ... OK
 -- Checking Docker client ... OK
@@ -136,7 +136,7 @@ $oc cluster up
 
    To login as administrator:
        oc login -u system:admin
-</code></pre>
+```
 
 ## Tutorial Steps
 

--- a/doc/openshift-guide.md
+++ b/doc/openshift-guide.md
@@ -173,7 +173,7 @@ $oc cluster up
 
 4. Create an application for your 3scale API Gateway from the template:
 
- <pre><code>oc new-app -f https://raw.githubusercontent.com/3scale/apicast/v2/openshift/apicast-template.yml</code></pre>
+ <pre><code>oc new-app -f https://github.com/3scale/apicast/releases/download/v2.0.0-rc1/openshift-template.yml</code></pre>
 
  You should see a message indicating _deploymentconfig_ and _service_ have been successfully created.
 

--- a/doc/openshift-guide.md
+++ b/doc/openshift-guide.md
@@ -63,24 +63,31 @@ You should now see a section **Production: Self-managed Gateway** at the bottom 
 ### Setup OpenShift
 
 There are many ways you can install OpenShift.
-- All-In-One Virtual Machine using Vagrant &ndash; https://www.openshift.org/vm
 - Using `oc cluster up` command &ndash; https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md (used in this tutorial)
+- All-In-One Virtual Machine using Vagrant &ndash; https://www.openshift.org/vm
 - Using Ansible Playbooks (advanced installation):
   - OpenShift Container Platform 3.3 Installation and Configuration documentation &ndash; https://docs.openshift.com/container-platform/3.3/install_config/index.html
   - For reference architecture guides for OpenShift 3.3 please refer to the following articles: [AWS](https://access.redhat.com/articles/2623521), [Google Cloud Engine](https://access.redhat.com/articles/2751521), [VMware vCenter 6](https://access.redhat.com/articles/2745171)
 
-In this tutorial the OpenShift cluster will be installed using: 
+In this tutorial the OpenShift cluster will be installed using:
+
 - CentOS 7
 - Docker v1.10.3
 - Openshift Origin command line interface (CLI) - v1.3.1
 
+1. Install Docker
 
-1. Install Docker on CentOS
+  For CentOS you can use the following commands to install Docker:
 
-```bash
-yum -y update
-yum -y install docker docker-registry
-```
+  ```bash
+  yum -y update
+  yum -y install docker docker-registry
+  ```
+
+  For other operating systems please refer to the Docker documentation on:
+    - [Installing Docker on Linux distributions](https://docs.docker.com/engine/installation/linux/)
+    - [Docker for Mac](https://docs.docker.com/docker-for-mac/)
+    - [Docker for Windows](https://docs.docker.com/docker-for-windows/)
 
 2. Configure the Docker daemon with an insecure registry parameter of `172.30.0.0/16`
    - Edit the `/etc/sysconfig/docker` file and add or uncomment the following line:

--- a/doc/openshift-guide.md
+++ b/doc/openshift-guide.md
@@ -99,54 +99,49 @@ In this tutorial the OpenShift cluster will be installed using:
      ```
      $ sudo systemctl restart docker
      ```
+
 3. Download the client tools release
    [openshift-origin-client-tools-VERSION-linux-64bit.tar.gz](https://github.com/openshift/origin/releases)
    and place it in your path.
 
-   > Please be aware that the 'oc cluster' set of commands are only available in the 1.3+ or newer releases.
-
+    **Note**: Please be aware that the 'oc cluster' set of commands are only available in the 1.3+ or newer releases.
 
 4. Open a terminal with a user that has permission to run Docker commands and run:
-```
-$oc cluster up
--- Checking OpenShift client ... OK
--- Checking Docker client ... OK
--- Checking Docker version ... OK
--- Checking for existing OpenShift container ... OK
--- Checking for openshift/origin:v1.3.1 image ... OK
--- Checking Docker daemon configuration ... OK
--- Checking for available ports ... OK
-127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
--- Checking type of volume mount ...
-127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
-   Using nsenter mounter for OpenShift volumes
-127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
--- Creating host directories ... OK
--- Finding server IP ...
-   Using 10.0.1.163 as the server IP
--- Starting OpenShift container ...
-   Creating initial OpenShift configuration
-   Starting OpenShift using container 'origin'
-   Waiting for API server to start listening
-   OpenShift server started
--- Installing registry ... OK
--- Installing router ... OK
--- Importing image streams ... OK
--- Importing templates ... OK
--- Login to server ... OK
--- Creating initial project "myproject" ... OK
--- Server Information ...
-   OpenShift server started.
-   The server is accessible via web console at:
-       https://10.0.1.163:8443
+  ```
+  oc cluster up
+  ```
 
-   You are logged in as:
-       User:     developer
-       Password: developer
+  At the bottom of the output you will find information about the deployed cluster:
+  ```
+  -- Server Information ... 
+     OpenShift server started.
+     The server is accessible via web console at:
+         https://172.30.0.112:8443
+  
+     You are logged in as:
+         User:     developer
+         Password: developer
+  
+     To login as administrator:
+         oc login -u system:admin
+  ```
 
-   To login as administrator:
-       oc login -u system:admin
+ Note the IP address that is assigned to your OpenShift server, we will refer to it in the tutorial as `OPENSHIFT-SERVER-IP`.
+ You should be able to access the OpenShift web console by going to https://OPENSHIFT-SERVER-IP:8443/console/ in your web browser.
+
+ **Warning**: You may receive a warning about an untrusted web-site. This is expected, as we are trying to access to the web console through secure protocol, without having configured a valid certificate. While you should avoid this in production environment, for this test setup you can go ahead and create an exception for this address.
+
+#### Setting up OpenShift cluster on a remote server
+
+In case you are deploying the OpenShift cluster on a remote server, you will need to explicitly specify a public hostname and a routing suffix on starting the cluster, in order to be able to access to the OpenShift web console remotely.
+
+For example, if you are deploying on an AWS EC2 instance, you should specify the following options:
+
+```bash
+oc cluster up --public-hostname=ec2-54-321-67-89.compute-1.amazonaws.com --routing-suffix=54.321.67.89.xip.io
 ```
+
+where `ec2-54-321-67-89.compute-1.amazonaws.com` is the Public Domain, and `54.321.67.89` is the IP of the instance. You will then be able to access the OpenShift web console at https://ec2-54-321-67-89.compute-1.amazonaws.com:8443.
 
 ## Tutorial Steps
 
@@ -154,7 +149,7 @@ $oc cluster up
 
 1. Login into OpenShift using the `oc` command from the OpenShift Client tools you downloaded and installed in previous step. The default login credentials are _username = "admin"_ and _password = "admin"_
 
- <pre><code>oc login https://OPENSHIFT-VM-IP:8443</code></pre>
+ <pre><code>oc login https://OPENSHIFT-SERVER-IP:8443</code></pre>
 
  **Warning**: You may get a security warning and asked whether you wish to continue with an insecure selection. Enter "yes" to proceed.
 
@@ -166,7 +161,9 @@ $oc cluster up
 
  The response should look like this:
 
- ```Now using project "3scalegateway" on server ""https://10.0.1.163:8443""```
+ ```
+ Now using project "3scalegateway" on server "https://172.30.0.112:8443".
+ ```
 
  Ignore the suggested next steps in the text output at the command prompt and proceed to the next step below.
 
@@ -186,9 +183,7 @@ $oc cluster up
 
 ### Deploying 3scale API Gateway
 
-1. Open the web console for your OpenShift Origin VM in your browser: https://OPENSHIFT-VM-IP:8443/console/
-
- **Warning**: You may receive a warning about an untrusted web-site. As this is the Origin VM running on your local machine there are no real risks. Select "Accept the Risks" in the browser and proceed to view the Web console.
+1. Open the web console for your OpenShift Origin VM in your browser: https://OPENSHIFT-SERVER-IP:8443/console/
 
  You should see the login screen:
  <img src="https://support.3scale.net/images/screenshots/guides-openshift-login-screen.png" alt="OpenShift Login Screen">

--- a/doc/openshift-guide.md
+++ b/doc/openshift-guide.md
@@ -190,7 +190,7 @@ $oc cluster up
 
  You will see a list of projects, including the _"gateway"_ project you created from the command line above.
 
- <img src="https://support.3scale.net/images/screenshots/guides-openshift-project-list-after.png" alt="Openshift Projects" >
+ <img src="https://support-preview.3scale.net/images/screenshots/guides-openshift-project-list-after.png" alt="Openshift Projects" >
 
 3. Click on _"gateway"_ and you will be shown the _Overview_ tab.
 
@@ -198,17 +198,19 @@ $oc cluster up
 
  When the build completes, the UI will refresh and show two instances of the API Gateway ( _2 pods_ ) that have been started by OpenShift, as defined in the template.
 
-  <img src="https://support.3scale.net/images/screenshots/guides-openshift-building-threescale-gateway.png" alt="Building the Gateway" >
+  <img src="https://support-preview.3scale.net/images/screenshots/guides-openshift-building-threescale-gateway.png" alt="Building the Gateway" >
 
  Each instance of the 3scale API Gateway, upon starting, downloads the required configuration from 3scale using the settings you provided on the **Integration** page of your 3scale Admin Portal.
 
  OpenShift will maintain two API Gateway instances and monitor the health of both; any unhealthy API Gateway will automatically be replaced with a new one.
 
 4. In order to allow your API gateways to receive traffic, you'll need to create a route. Start by clicking on **Create Route**.
+
+ <img src="https://support-preview.3scale.net/images/screenshots/guides-openshift-create-route.png" alt="Create Route" >
  
  Enter the same host you set in 3scale above in the section **Public Base URL** (without the _http://_ and without the port) , e.g. `gateway.openshift.demo`, then click the **Create** button.
 
- <img src="https://support.3scale.net/images/screenshots/guides-openshift-create-route-config.png" alt="Create Route" >
+ <img src="https://support-preview.3scale.net/images/screenshots/guides-openshift-create-route-config.png" alt="Configure Route" >
 
  Create a new route for every 3scale Service you define.
 

--- a/doc/openshift-guide.md
+++ b/doc/openshift-guide.md
@@ -294,6 +294,20 @@ If you have multiple services (APIs) in 3scale, you will need to configure the r
  curl "http://YOUR-PUBLIC-IP/categories?user_key=YOUR_USER_KEY" -H "Host: video-api.openshift.demo"
  ```
 
+### Changing APIcast parameters
+
+APIcast v2 gateway has a number of parameters that can enable/disable different features or change the behavior. This parameters are defined in the OpenShift template, you can find the complete list in the template YAML file. The template parameters are mapped to environment variables that will be set for each running pod.
+
+You can specify the values for the parameters when creating a new application with `oc new-app` command using the `-p | -- param` argument, for example:
+
+<pre><code>oc new-app -f https://github.com/3scale/apicast/releases/download/v2.0.0-rc1/openshift-template.yml -p APICAST_LOG_LEVEL=debug</code></pre>
+
+In order to change the parameters for an existing application, you can modify the environment variables values. Go to **Applications > Deployments > threescalegw** and select the _Environment_ tab.
+
+<img src="https://support-preview.3scale.net/images/screenshots/guides-openshift-environment.png" alt="OpenShift environment">
+
+After modifying the values, click on **Save** button at the bottom, and then **Deploy** to apply the changes in the running API Gateway.
+
 ## Success!
 
 Your API is now protected by two instances of the 3scale API Gateway running on Red Hat OpenShift, following all the configuration that you set up in the 3scale Admin Portal.

--- a/doc/openshift-guide.md
+++ b/doc/openshift-guide.md
@@ -8,23 +8,32 @@ To follow the tutorial steps below, you'll first need to address the following p
 
 ### 3scale account configuration
 
-These steps will guide you to finding information you will need later to complete the tutorial steps: your _3scale Admin URL_, your _Provider Key_, and the _Private Base URL_ of your API.
+These steps will guide you to finding information you will need later to complete the tutorial steps: your _3scale Admin URL_, the _Access Token_, and the _Private Base URL_ of your API.
 
 You should have a 3scale API provider account (you can sign up for a free trial <a href="https://www.3scale.net/signup/">here</a>) and have an API configured in the 3scale Admin Portal. If you do not have an API running and configured in your 3scale account, please follow the instructions in our <a href="https://support.3scale.net/guides/quickstart">Quickstart</a> to do so.
 
 Log in to your 3scale Admin Portal with the URL provided to you. It will look something like this: `https://MYDOMAIN-admin.3scale.net`
 
-Navigate to the **Account** tab (top-right). From the **Overview** sub-tab note down your _3scale Provider Key_, referred to in the UI as _API Key_. Later in this tutorial we refer to this as your *THREESCALE_PROVIDER_KEY*.
+#### Create an access token
 
-<img src="https://support.3scale.net/images/screenshots/guides-openshift-provider-key.png" alt="Provider Key">
+You will need to create an _Access Token_ that the API gateway will use to download the configuration from your Admin Portal.
+Navigate to the **Personal Settings** (top-right), select the **Tokens** tab and click on **Add Access Token**.
 
-**Warning**: Keep your _3scale Provider Key_ private. Do not share it with anyone and do not put into code repositories or into any document that may reveal it to others.
+<img src="https://support-preview.3scale.net/images/screenshots/guides-openshift-tokens.png" alt="Tokens">
+
+Specify a name for the token, select _Account Management API_ as Scope, select the Permission (_Read Only_ will be enough) and click on **Create Access token**.
+
+When the token is generated, make sure you copy it somewhere, as you won't be able to see it again. Later in this tutorial we refer to this token as *ACCESS_TOKEN*.
+
+**Warning**: Keep your _Access Token_ private. Do not share it with anyone and do not put into code repositories or into any document that may reveal it to others. However, in case you suspect unauthorized use of the token, you can always revoke access by deleting the token.
 
 In the 3scale Admin Portal you should either have an API of your own running and configured or use the Echo API that was setup by the onboarding wizard. This tutorial will use the Echo API as an example.
 
+#### Configure your API integration
+
 Navigate to the **Dashboard > API** tab, if you have more than one API in your account, select the API you want to manage with the API Gateway. Select the **Integration** link at top-left.
 
-You need to make sure that the _Deployment Option_ is set to _Self-managed Gateway_. If it's not the case, click on **edit integration settings** on the top right corner of the integration page and select _Self-managed Gateway_ as production deployment option. For authentication this tutorial uses _API Key (user\_key)_ mode, so it is recommended that you select this mode as well.
+You need to make sure that the _Deployment Option_ is set to _Self-managed Gateway_. If it's not the case, click on **edit integration settings** on the top right corner of the integration page and select _Self-managed Gateway_ as production deployment option. For authentication this tutorial uses _API Key (user\_key)_ mode, specified in query parameters, so it is recommended that you select this mode as well.
 
 If you're setting this up for the first time, you'll need to test the integration to confirm that your private (unmanaged) API is working before proceeding. If you've already configured your API and sent test traffic, feel free to skip this step.
 
@@ -167,9 +176,9 @@ where `ec2-54-321-67-89.compute-1.amazonaws.com` is the Public Domain, and `54.3
 
  Ignore the suggested next steps in the text output at the command prompt and proceed to the next step below.
 
-3. Create a new Secret to reference your project by replacing *THREESCALE_PROVIDER_KEY* and MYDOMAIN with yours.
+3. Create a new Secret to reference your project by replacing *ACCESS_TOKEN* and MYDOMAIN with yours.
   
- <pre><code>oc secret new-basicauth threescale-portal-endpoint-secret --password=https://THREESCALE_PROVIDER_KEY@MYDOMAIN-admin.3scale.net</code></pre>
+ <pre><code>oc secret new-basicauth threescale-portal-endpoint-secret --password=https://ACCESS_TOKEN@MYDOMAIN-admin.3scale.net</code></pre>
 
  The response should look like this:
 

--- a/doc/openshift-guide.md
+++ b/doc/openshift-guide.md
@@ -1,8 +1,6 @@
 # Using 3scale API Gateway on Red Hat OpenShift
 
-This tutorial describes how to use the dockerized 3scale API Gateway v2 (APIcast) that is packaged for easy installation and operation on Red Hat OpenShift V3.
-
-In this tutorial we will use OpenShift cluster which runs as an all-in-one container on a Docker host. The Docker host may be a local VM (ie. using docker-machine on OS X and Windows clients), remote machine, or the local Unix host. It will allow you to deploy an OpenShift platform in a single command.
+This tutorial describes how to use APIcast v2 &ndash; the dockerized 3scale API Gateway that is packaged for easy installation and operation on Red Hat OpenShift V3.
 
 ## Tutorial Prerequisites
 
@@ -22,15 +20,15 @@ Navigate to the **Account** tab (top-right). From the **Overview** sub-tab note 
 
 **Warning**: Keep your _3scale Provider Key_ private. Do not share it with anyone and do not put into code repositories or into any document that may reveal it to others.
 
-In the 3scale Admin Portal you should either have an API of your own running and configured or use the Echo API that was setup by the onboarding wizard. This tutorial will use the Echo API as an example throughout.
+In the 3scale Admin Portal you should either have an API of your own running and configured or use the Echo API that was setup by the onboarding wizard. This tutorial will use the Echo API as an example.
 
 Navigate to the **Dashboard > API** tab, if you have more than one API in your account, select the API you want to manage with the API Gateway. Select the **Integration** link at top-left.
 
-If you're setting this up for the first time, you'll need to test to confirm that your private (unmanaged) API is working before proceeding. If you've already configured your API and sent test traffic, feel free to skip this step.
+If you're setting this up for the first time, you'll need to test the integration to confirm that your private (unmanaged) API is working before proceeding. If you've already configured your API and sent test traffic, feel free to skip this step.
 
 <img src="https://support.3scale.net/images/screenshots/guides-openshift-private-base-url.png" alt="Private base URL">
 
-In the screenshot above, this API is configured to use the 3scale provided Echo API to help you get started. You can use this or configure the API to refer to your real API's _Private Base URL_.
+In the screenshot above, this API is configured to use the 3scale provided Echo API to help you get started. You can use this or configure the _Private Base URL_ to refer to your real API.
 
 Test your private (unmanaged) API is working using this _curl_ command:
     
@@ -68,16 +66,18 @@ There are many ways you can install Openshift.
 - [Running Openshift using Vagrant] (https://support.3scale.net/guides/infrastructure/docker-openshift)
 - [Running Openshift as all-in-one container] (https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md) (current tutorial)
 
-## Installation
-The openshift cluster was installed and tested on 
-```
-CentOS version - CentOS Linux release 7.2.1511 (Core)
-Docker - 1.10.3
-Openshift Origin command line interface (CLI) - v1.3.1
-```
+In this tutorial the OpenShift cluster will be installed using: 
+- CentOS 7
+- Docker v1.10.3
+- Openshift Origin command line interface (CLI) - v1.3.1
+
 
 1. Install Docker on CentOS
-```yum -y install docker docker-registry```
+
+```bash
+yum -y update
+yum -y install docker docker-registry
+```
 
 2. Configure the Docker daemon with an insecure registry parameter of `172.30.0.0/16`
    - Edit the `/etc/sysconfig/docker` file and add or uncomment the following line:
@@ -185,24 +185,21 @@ $oc cluster up
 
 2. Login using your credentials created or obtained in the _Setup OpenShift_ section above.
 
- You will see a list of projects, including the _"gateway"_ project you created from the command line above
+ You will see a list of projects, including the _"gateway"_ project you created from the command line above.
 
  <img src="https://support.3scale.net/images/screenshots/guides-openshift-project-list-after.png" alt="Openshift Projects" >
 
-3. Click on _"gateway"_ (top left in the breadcrumbs) and you will be shown the _Overview_ tab.
+3. Click on _"gateway"_ and you will be shown the _Overview_ tab.
 
- OpenShift has now downloaded the code for the API Gateway and has started a build to construct it:
-
- <img src="https://support.3scale.net/images/screenshots/guides-openshift-building-threescale-gateway.png" alt="Building the Gateway" >
- **Warning**: If you experience some unexpected behavior or the outcome of these steps is not as shown here, this can be caused by a variety of reasons and restarting the VM might help.
+ OpenShift downloads the code for the API Gateway and starts the deployment. You may see the message _Deployment #1 running_ when the deployment is in progress.
 
  When the build completes, the UI will refresh and show two instances of the API Gateway ( _2 pods_ ) that have been started by OpenShift, as defined in the template.
 
- Each instance of the 3scale API Gateway, upon starting, downloads the required configuration files and code from 3scale using the configuration settings you provided on the **Integration** tab of your 3scale Admin Portal.
+  <img src="https://support.3scale.net/images/screenshots/guides-openshift-building-threescale-gateway.png" alt="Building the Gateway" >
+
+ Each instance of the 3scale API Gateway, upon starting, downloads the required configuration from 3scale using the settings you provided on the **Integration** page of your 3scale Admin Portal.
 
  OpenShift will maintain two API Gateway instances and monitor the health of both; any unhealthy API Gateway will automatically be replaced with a new one.
-
- <img src="https://support.3scale.net/images/screenshots/guides-openshift-create-route.png" alt="Create Route" >
 
 4. In order to allow your API gateways to receive traffic, you'll need to create a route. Start by clicking on **Create Route**.
  

--- a/doc/openshift-guide.md
+++ b/doc/openshift-guide.md
@@ -62,7 +62,7 @@ Now, scroll down to the section **Production: Self-managed Gateway** at the bott
 
 ### Setup OpenShift
 
-There are many ways you can install OpenShift.
+There are many ways you can install OpenShift:
 - Using `oc cluster up` command &ndash; https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md (used in this tutorial)
 - All-In-One Virtual Machine using Vagrant &ndash; https://www.openshift.org/vm
 - Using Ansible Playbooks (advanced installation):
@@ -224,11 +224,26 @@ where `ec2-54-321-67-89.compute-1.amazonaws.com` is the Public Domain, and `54.3
 
  <pre><code>curl "http://gateway.openshift.demo/?user_key=YOUR_USER_KEY"</code></pre>
 
- If you wish to see the logs of the API Gateways you can do so by clicking **Applications > Pods** and then select one of the pods and then selecting **Logs**.
+ In case you are running the OpenShift cluster running locally, you will need to add the hostname `gateway.openshift.demo` for your `OPENSHIFT-SERVER-IP` to the _/etc/hosts_ file, for example:
+ ```
+ 172.30.0.112 gateway.openshift.demo
+ ```
 
-6. Test it does not authorize an invalid call to your API.
+ Alternatively, you can specify the hostname of the gateway in the `Host` header when making the request:
+
+ ```
+ curl "http://OPENSHIFT-SERVER-IP/?user_key=YOUR_USER_KEY" -H "Host: gateway.openshift.demo"
+ ```
+
+ This last option will also work in case your OpenShift cluster is deployed on a remote server. Just use the public IP of the machine where OpenShift is deployed, and specify the hostname from the _Public Base URL_ in the `Host` header.
+
+ This way OpenShift and the API gateway will route the request correctly.
+
+6. Test that the API gateway does not authorize an invalid call to your API.
 
  <pre><code>curl "http://gateway.openshift.demo/?user_key=INVALID_KEY"</code></pre>
+
+7. If you wish to see the logs of the API Gateways you can do so by clicking **Applications > Pods** and then select one of the pods and then selecting **Logs**.
 
 ### Applying changes to the API gateway
 
@@ -250,20 +265,20 @@ If you have multiple services (APIs) in 3scale, you will need to configure the r
 
 3. You will need to redeploy the gateway to apply the changes you've made in the 3scale admin portal. Go to **Applications > Deployments > threescalegw** and click on **Deploy**.
 
-4. In case you are running the OpenShift cluster running locally, add the hostnames for your `OPENSHIFT-SERVER-IP` to the _/etc/hosts_ file:
- ```
- 172.30.0.112 search-api.openshift.demo
- 172.30.0.112 video-api.openshift.demo
- ```
-
-5. Now you can make calls to both APIs, and they will be routed to either Search API or Video API depending on the hostname. For example:
+4. Now you can make calls to both APIs, and they will be routed to either Search API or Video API depending on the hostname. For example:
 
  ```
  curl "http://search-api.openshift.demo/find?query=openshift&user_key=YOUR_USER_KEY"
  curl "http://video-api.openshift.demo/categories?user_key=YOUR_USER_KEY"
  ```
 
- In case your OpenShift cluster is hosted remotely and you don't yet have the custom domain name set up for you APIs, you can specify the host configured in _Public Base URL_ in the `Host` header in order to get it routed corectly by OpenShift and the API gateway:
+ In case you are running the OpenShift cluster running locally, in order for the above calls to work properly you will need to add the hostnames for your `OPENSHIFT-SERVER-IP` to the _/etc/hosts_ file:
+ ```
+ 172.30.0.112 search-api.openshift.demo
+ 172.30.0.112 video-api.openshift.demo
+ ```
+
+ In case your OpenShift cluster is hosted remotely, you can specify the host configured in _Public Base URL_ in the `Host` header in order to get it routed corectly by OpenShift and the API gateway:
 
  ```
  curl "http://YOUR-PUBLIC-IP/find?query=openshift&user_key=YOUR_USER_KEY" -H "Host: search-api.openshift.demo"
@@ -272,14 +287,13 @@ If you have multiple services (APIs) in 3scale, you will need to configure the r
 
 ## Success!
 
-Your API is now protected by two instances of the 3scale API Gateway running on Red Hat OpenShift, following all the configuration that you set-up in the 3scale Admin Portal.
-
-You may wish to now shutdown the OpenShift Origin VM to save resources. 
+Your API is now protected by two instances of the 3scale API Gateway running on Red Hat OpenShift, following all the configuration that you set up in the 3scale Admin Portal.
 
 ## Next Steps
 
 Now that you have an API Gateway up and running on your local machine you can:
 
-1. Explore how to configure access policies for your API, and engage developers with a Developer Portal by following the <a href="https://support.3scale.net/guides/quickstart">Quickstart</a>.
-2. Whenever you make changes to your API definition in the 3scale Admin Portal &ndash; in particular the 3scale metrics/methods and mapping rules &ndash; you should create a new deployment in OpenShift. This will start new instances that will download and run your new API definition. Then OpenShift will shut down gracefully the previous instances.
-3. Run OpenShift V3 on your dedicated datacenter or on your favorite cloud platform and then follow the same instructions to open up your API to the world.
+1. Explore how to configure access policies for your API, and engage developers with a Developer Portal by following the <a href="https://support.3scale.net/guides/quickstart">Quickstart</a> guide.
+2. Run OpenShift V3 on your dedicated datacenter or on your favorite cloud platform using the advanced installation documentation [listed above](#setup-openshift).
+3. Register a custom domain name for your API services, and configure your API integration in 3scale Admin Portal, and in OpenShift by adding new routes.
+4. Learn more about OpenShift from the [OpenShift documentation](https://docs.openshift.com/container-platform/3.3/welcome/index.html)

--- a/doc/openshift-guide.md
+++ b/doc/openshift-guide.md
@@ -186,7 +186,7 @@ where `ec2-54-321-67-89.compute-1.amazonaws.com` is the Public Domain, and `54.3
 
 4. Create an application for your 3scale API Gateway from the template:
 
- <pre><code>oc new-app -f https://github.com/3scale/apicast/releases/download/v2.0.0-rc1/openshift-template.yml</code></pre>
+ <pre><code>oc new-app -f https://raw.githubusercontent.com/3scale/apicast/v2/openshift/apicast-template.yml</code></pre>
 
  You should see a message indicating _deploymentconfig_ and _service_ have been successfully created.
 
@@ -298,9 +298,9 @@ If you have multiple services (APIs) in 3scale, you will need to configure the r
 
 APIcast v2 gateway has a number of parameters that can enable/disable different features or change the behavior. This parameters are defined in the OpenShift template, you can find the complete list in the template YAML file. The template parameters are mapped to environment variables that will be set for each running pod.
 
-You can specify the values for the parameters when creating a new application with `oc new-app` command using the `-p | -- param` argument, for example:
+You can specify the values for the parameters when creating a new application with `oc new-app` command using the `-p | --param` argument, for example:
 
-<pre><code>oc new-app -f https://github.com/3scale/apicast/releases/download/v2.0.0-rc1/openshift-template.yml -p APICAST_LOG_LEVEL=debug</code></pre>
+<pre><code>oc new-app -f https://raw.githubusercontent.com/3scale/apicast/v2/openshift/apicast-template.yml -p APICAST_LOG_LEVEL=debug</code></pre>
 
 In order to change the parameters for an existing application, you can modify the environment variables values. Go to **Applications > Deployments > threescalegw** and select the _Environment_ tab.
 

--- a/doc/openshift-guide.md
+++ b/doc/openshift-guide.md
@@ -183,7 +183,7 @@ where `ec2-54-321-67-89.compute-1.amazonaws.com` is the Public Domain, and `54.3
 
 ### Deploying 3scale API Gateway
 
-1. Open the web console for your OpenShift Origin VM in your browser: https://OPENSHIFT-SERVER-IP:8443/console/
+1. Open the web console for your OpenShift cluster in your browser: https://OPENSHIFT-SERVER-IP:8443/console/
 
  You should see the login screen:
  <img src="https://support.3scale.net/images/screenshots/guides-openshift-login-screen.png" alt="OpenShift Login Screen">
@@ -230,6 +230,14 @@ where `ec2-54-321-67-89.compute-1.amazonaws.com` is the Public Domain, and `54.3
 
  <pre><code>curl "http://gateway.openshift.demo/?user_key=INVALID_KEY"</code></pre>
 
+### Applying changes to the API gateway
+
+Of course, your API configuration is not static. In future you may wish to apply changes to it, for example, choose another authentication method, add new methods and metrics, update the mapping rules, or make any other change on the **Integration** page for your API. In this case you will need to redeploy the API gateway to make the changes effective. In order to do this, go to **Applications > Deployments > threescalegw** and click on **Deploy**.
+
+<img src="https://support-preview.3scale.net/images/screenshots/guides-openshift-deploy.png" alt="Deploy OpenShift API Gateway" >
+
+New pods will be created using the updated configuration, and the old ones will be retired. OpenShift supports different deployment strategies, you can learn more about them in the [OpenShift documentation](https://docs.openshift.com/container-platform/3.3/dev_guide/deployments/deployment_strategies.html)
+
 ### Multiple services
 
 If you have multiple services (APIs) in 3scale, you will need to configure the routing properly:
@@ -238,7 +246,7 @@ If you have multiple services (APIs) in 3scale, you will need to configure the r
 
 2. In OpenShift create routes for the gateway service ("threescalegw"): `http://search-api.openshift.demo` and `http://video-api.openshift.demo`. From **Applications > Routes** you can create a new route or modify and existing one. Note that you can't change the hostname for already created routes, but you can delete an existing route and add a new one.
 
- <div class="screenshot"><img data-normal="/images/screenshots/guides-openshift-create-more-routes.png" alt="Create routes for multiple services" ></div>
+ <img src="https://support-preview.3scale.net/images/screenshots/guides-openshift-create-more-routes.png" alt="Create routes for multiple services" >
 
 3. You will need to redeploy the gateway to apply the changes you've made in the 3scale admin portal. Go to **Applications > Deployments > threescalegw** and click on **Deploy**.
 


### PR DESCRIPTION
Replaced vagrant instructions with `oc cluster up`. 