### PR TITLE
try to guess port from scheme when not provided

### DIFF
--- a/apicast/src/provider.lua
+++ b/apicast/src/provider.lua
@@ -371,7 +371,6 @@ function _M.call(host)
 end
 
 function _M.access(service)
-  local scheme, _, _, host, port, path = unpack(resty_url.split(service.api_backend) or {})
   local backend_version = service.backend_version
   local params = {}
   local usage
@@ -429,12 +428,6 @@ function _M.access(service)
   end
 
   _M.authorize(backend_version, service)
-
-  -- set upstream
-  ngx.var.proxy_pass = scheme .. '://upstream' .. (path or '')
-  ngx.req.set_header('Host', service.hostname_rewrite or host or ngx.var.host)
-
-  ngx.ctx.upstream = ngx.ctx.resolver:get_servers(host, { port = port })
 end
 
 

--- a/apicast/src/resty/url.lua
+++ b/apicast/src/resty/url.lua
@@ -1,0 +1,35 @@
+local _M = {
+  _VERSION = '0.1'
+}
+
+function _M.default_port(scheme)
+  if scheme == 'http' then
+    return 80
+  elseif scheme == 'https' then
+    return 443
+  end
+end
+
+function _M.split(url)
+  if not url then
+    return nil, 'missing endpoint'
+  end
+
+  local match = ngx.re.match(url, "^(https?):\\/\\/(?:(.+)@)?([^\\/\\s]+?)(?::(\\d+))?(\\/.+)?$", 'oj')
+
+  if not match then
+    return nil, 'invalid endpoint' -- TODO: maybe improve the error message?
+  end
+
+  local scheme, userinfo, host, port, path = unpack(match)
+
+  if path == '/' then path = nil end
+
+  match = userinfo and ngx.re.match(tostring(userinfo), "^([^:\\s]+)?(?::(.*))?$", 'oj')
+  local user, pass = unpack(match or {})
+
+  return { scheme, user or false, pass or false, host, port or false, path or nil }
+end
+
+
+return _M

--- a/spec/configuration_spec.lua
+++ b/spec/configuration_spec.lua
@@ -87,24 +87,6 @@ describe('Configuration object', function()
     end)
   end)
 
-  describe('.url', function()
-    it('works with port', function()
-      assert.same({'https', false, false, 'example.com', '8443'}, configuration.url('https://example.com:8443'))
-    end)
-
-    it('works with user', function()
-      assert.same({'https', 'user', false, 'example.com', false }, configuration.url('https://user@example.com'))
-    end)
-
-    it('works with user and password', function()
-      assert.same({'https', 'user', 'password', 'example.com', false }, configuration.url('https://user:password@example.com'))
-    end)
-
-    it('works with port and path', function()
-      assert.same({'http', false, false, 'example.com', '8080', '/path'}, configuration.url('http://example.com:8080/path'))
-    end)
-  end)
-
   describe('.filter_services', function()
     local filter_services = configuration.filter_services
 

--- a/spec/provider_spec.lua
+++ b/spec/provider_spec.lua
@@ -42,4 +42,15 @@ describe('Provider', function()
     assert.same(example, provider.find_service('example.com'))
     assert.falsy(provider.find_service('unknown'))
   end)
+
+  describe('.get_upstream', function()
+    local get_upstream = provider.get_upstream
+
+    it('sets correct upstream port', function()
+      assert.same(443, get_upstream({ api_backend = 'https://example.com' }).port)
+      assert.same(80, get_upstream({ api_backend = 'http://example.com' }).port)
+      assert.same(8080, get_upstream({ api_backend = 'http://example.com:8080' }).port)
+    end)
+  end)
+
 end)

--- a/spec/resty/url_spec.lua
+++ b/spec/resty/url_spec.lua
@@ -1,0 +1,41 @@
+local url = require 'resty.url'
+
+describe('resty.url', function()
+
+  describe('.default_port', function()
+    local default_port = url.default_port
+
+    it('returns 80 for http', function()
+      assert.equal(80, default_port('http'))
+    end)
+
+    it('returns 443 for https', function()
+      assert.equal(443, default_port('https'))
+    end)
+
+    it('returns nil for everything else', function()
+      assert.falsy(default_port('ftp'))
+    end)
+  end)
+
+  describe('.split', function()
+    local split = url.split
+
+    it('works with port', function()
+      assert.same({'https', false, false, 'example.com', '8443'}, split('https://example.com:8443'))
+    end)
+
+    it('works with user', function()
+      assert.same({'https', 'user', false, 'example.com', false }, split('https://user@example.com'))
+    end)
+
+    it('works with user and password', function()
+      assert.same({'https', 'user', 'password', 'example.com', false }, split('https://user:password@example.com'))
+    end)
+
+    it('works with port and path', function()
+      assert.same({'http', false, false, 'example.com', '8080', '/path'}, split('http://example.com:8080/path'))
+    end)
+  end)
+
+end)


### PR DESCRIPTION
fixes https://github.com/3scale/apicast/issues/183

unfortunately I could not figure out an easy way to write the integration test as it would have to run as a root and listen on port 80 or 443

but at least we have a test with https on explicit port, should be easy to add more special cases (like http2)