### PR TITLE
get config from the v2 api

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,4 +2,4 @@ std = 'min'
 
 files["spec"] = {std = "+busted"}
 
-globals = { 'ngx', 'unpack' }
+globals = { 'ngx', 'unpack', 'rawlen' }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - A CHANGELOG.md to track important changes
 - User-Agent header with APIcast version and system information [PR #214](https://github.com/3scale/apicast/pull/214)
+- Try to load configuration from V2 API [PR #193](https://github.com/3scale/apicast/pull/193)
 
 ### Changed
 - Require openresty 1.11.2 [PR #194](https://github.com/3scale/apicast/pull/194)

--- a/apicast/src/configuration_loader.lua
+++ b/apicast/src/configuration_loader.lua
@@ -1,6 +1,7 @@
 local mock_loader = require 'configuration_loader.mock'
 local file_loader = require 'configuration_loader.file'
 local remote_loader_v1 = require 'configuration_loader.remote_v1'
+local remote_loader_v2 = require 'configuration_loader.remote_v2'
 local util = require 'util'
 
 local tostring = tostring
@@ -12,7 +13,7 @@ local _M = {
 }
 
 function _M.boot(host)
-  return mock_loader.call() or file_loader.call() or remote_loader_v1.call(host) or error('missing configuration')
+  return mock_loader.call() or file_loader.call() or remote_loader_v2.call() or remote_loader_v1.call(host) or error('missing configuration')
 end
 
 _M.save = mock_loader.save

--- a/apicast/src/configuration_loader/remote_v2.lua
+++ b/apicast/src/configuration_loader/remote_v2.lua
@@ -1,0 +1,132 @@
+local getenv = os.getenv
+local setmetatable = setmetatable
+local format = string.format
+local ipairs = ipairs
+local insert = table.insert
+
+local resty_url = require 'resty.url'
+local http_ng = require "resty.http_ng"
+local user_agent = require 'user_agent'
+local cjson = require 'cjson'
+
+local _M = {
+  _VERSION = '0.1'
+}
+local mt = {
+  __index = _M
+}
+
+function _M.new(url, options)
+  local endpoint = url or getenv('THREESCALE_PORTAL_ENDPOINT')
+  local opts = options or {}
+
+  local http_client = http_ng.new{
+    backend = opts.client,
+    options = {
+      headers = { ['User-Agent'] = user_agent() },
+      ssl = { verify = false }
+    }
+  }
+
+  return setmetatable({
+    endpoint = endpoint,
+    options = opts,
+    http_client = http_client
+  }, mt)
+end
+
+function _M:call(environment)
+  if not self then
+    return _M.new():call()
+  end
+
+  local http_client = self.http_client
+
+  if not http_client then
+    return nil, 'not initialized'
+  end
+
+  local env = environment or getenv('THREESCALE_DEPLOYMENT_ENV')
+  if not env then
+    return nil, 'missing environment'
+  end
+  local configs = {}
+
+  local res, err = self:services()
+
+  if not res and err then
+    return nil, err
+  end
+
+  local config
+  for _, object in ipairs(res) do
+    config, err = self:config(object.service, env, 'latest')
+
+    if config then
+      insert(configs, config)
+    else
+      return nil, err
+    end
+  end
+
+  for i, c in ipairs(configs) do
+    configs[i] = c.content
+  end
+
+  return cjson.encode({ services = configs })
+end
+
+function _M:services()
+  local http_client = self.http_client
+
+  if not http_client then
+    return nil, 'not initialized'
+  end
+
+  local url = resty_url.join(self.endpoint, '/admin/api/services.json')
+
+  local res, err = http_client.get(url)
+
+  if not res and err then
+    return nil, err
+  end
+
+  if res.status == 200 then
+    local json = cjson.decode(res.body)
+
+    return json.services
+  else
+    return nil, 'invalid status'
+  end
+end
+
+function _M:config(service, environment, version)
+  local http_client = self.http_client
+
+  if not http_client then return nil, 'not initialized' end
+
+  local id = service and service.id
+
+  if not id then return nil, 'invalid service, missing id' end
+  if not environment then return nil, 'missing environment' end
+  if not version then return nil, 'missing version' end
+
+  local url = resty_url.join(self.endpoint, '/admin/api/services/', id , '/proxy/configs/', environment, '/', format('%s.json', version))
+
+  local res, err = http_client.get(url)
+
+  if not res and err then
+    return nil, err
+  end
+
+  if res.status == 200 then
+    local json = cjson.decode(res.body)
+
+    return json.proxy_config
+  else
+    return nil, 'invalid status'
+  end
+end
+
+
+return _M

--- a/apicast/src/configuration_store.lua
+++ b/apicast/src/configuration_store.lua
@@ -3,6 +3,7 @@ local ipairs = ipairs
 local pairs = pairs
 local tostring = tostring
 local insert = table.insert
+local concat = table.concat
 local next = next
 
 local util = require 'util'
@@ -81,10 +82,10 @@ function _M.add(self, service)
     return nil, 'not initialized'
   end
 
+  local id = tostring(service.id)
+
   for _,host in ipairs(service.hosts) do
     local index = hosts[host] or {}
-    local id = tostring(service.id)
-
     local exists = not _M.path_routing and next(index)
 
     index[id] = service
@@ -95,6 +96,8 @@ function _M.add(self, service)
       ngx.log(ngx.WARN, 'host ', host, ' for service ', id, ' already defined by service ', exists)
     end
   end
+
+  ngx.log(ngx.INFO, 'added service ', id, ' configuration with hosts: ', concat(service.hosts, ', '))
 end
 
 return _M

--- a/apicast/src/resty/http_ng.lua
+++ b/apicast/src/resty/http_ng.lua
@@ -1,0 +1,193 @@
+local type = type
+local unpack = unpack
+local assert = assert
+local tostring = tostring
+local setmetatable = setmetatable
+local rawset = rawset
+
+------------
+--- HTTP
+-- HTTP client
+-- @module middleware
+
+--- HTTP
+-- @type HTTP
+
+local resty_backend = require 'resty.http_ng.backend.resty'
+local json = require 'cjson'
+local request = require 'resty.http_ng.request'
+local http = { request = request }
+
+
+http.method = function(method, client)
+  assert(method)
+  assert(client)
+
+  return function(url, options)
+    if type(url) == 'table' and not options then
+      options = url
+      url = unpack(url)
+    end
+
+    assert(url, 'url as first parameter is required')
+
+    local req = http.request.new({
+      url         = url,
+      method      = method,
+      options     = options,
+      client      = client,
+      serializer  = client.serializer or http.serializers.default
+    })
+    return client.backend.send(req)
+  end
+end
+
+http.method_with_body = function(method, client)
+  assert(method)
+  assert(client)
+
+  return function(url, body, options)
+    if type(url) == 'table' and not body and not options then
+      options = url
+      url, body = unpack(url)
+    end
+
+    assert(url, 'url as first parameter is required')
+    assert(body, 'body as second parameter is required')
+
+    local req = http.request.new{ url = url, method = method, body = body,
+                                  options = options, client = client,
+                                  serializer = client.serializer or http.serializers.default  }
+    return client.backend.send(req)
+  end
+end
+
+--- Make GET request.
+-- @param[type=string] url
+-- @param[type=options] options
+-- @return[type=response] a response
+-- @function http.get
+http.get = http.method
+
+--- Make HEAD request.
+-- @param[type=string] url
+-- @param[type=options] options
+-- @return[type=response] a response
+-- @function http.head
+http.head = http.method
+
+--- Make DELETE request.
+-- @param[type=string] url
+-- @param[type=options] options
+-- @return[type=response] a response
+-- @function http.delete
+http.delete = http.method
+
+--- Make OPTIONS request.
+-- @param[type=string] url
+-- @param[type=options] options
+-- @return[type=response] a response
+-- @function http.options
+http.options = http.method
+
+--- Make PUT request.
+-- The **body** is serialized by @{HTTP.urlencoded} unless you used different serializer.
+-- @param[type=string] url
+-- @param[type=string|table] body
+-- @param[type=options] options
+-- @return[type=response] a response
+-- @function http.put
+http.put = http.method_with_body
+
+--- Make POST request.
+-- The **body** is serialized by @{HTTP.urlencoded} unless you used different serializer.
+-- @param[type=string] url
+-- @param[type=string|table] body
+-- @param[type=options] options
+-- @return[type=response] a response
+-- @function http.post
+http.post = http.method_with_body
+
+--- Make PATCH request.
+-- The **body** is serialized by @{HTTP.urlencoded} unless you used different serializer.
+-- @param[type=string] url
+-- @param[type=string|table] body
+-- @param[type=options] options
+-- @return[type=response] a response
+-- @function http.patch
+http.patch = http.method_with_body
+
+http.trace = http.method_with_body
+
+http.serializers = {}
+
+--- Urlencoded serializer
+-- Serializes your data to `application/x-www-form-urlencoded` format
+-- and sets correct Content-Type header.
+-- @http HTTP.urlencoded
+-- @usage http.urlencoded.post(url, { example = 'table' })
+http.serializers.urlencoded = function(req)
+  req.body = ngx.encode_args(req.body)
+  req.headers.content_type = req.headers.content_type or 'application/x-www-form-urlencoded'
+  http.serializers.string(req)
+end
+
+http.serializers.string = function(req)
+  req.body = tostring(req.body)
+  req.headers['Content-Length'] = #req.body
+end
+
+--- JSON serializer
+-- Converts the body to JSON unless it is already a string
+-- and sets correct Content-Type `application/json`.
+-- @http HTTP.json
+-- @usage http.json.post(url, { example = 'table' })
+-- @see http.post
+http.serializers.json = function(req)
+  if type(req.body) ~= 'string' then
+    req.body = json.encode(req.body)
+  end
+  req.headers.content_type = req.headers.content_type or 'application/json'
+  http.serializers.string(req)
+end
+
+http.serializers.default = function(req)
+  if req.body then
+    if type(req.body) ~= 'string' then
+      http.serializers.urlencoded(req)
+    else
+      http.serializers.string(req)
+    end
+  end
+end
+
+local function add_http_method(client, method)
+  local generator = http[method:lower()]
+
+  if generator then
+    local func = generator(method:upper(), client)
+    rawset(client, method, func)
+    return func
+  end
+end
+
+local function chain_serializer(client, format)
+  local serializer = http.serializers[format]
+
+  if serializer then
+    return http.new{ backend = client.backend, serializer = serializer }
+  end
+end
+
+local function generate_client_method(client, method_or_format)
+  return add_http_method(client, method_or_format) or chain_serializer(client, method_or_format)
+end
+
+function http.new(client)
+  client = client or { }
+  client.backend = client.backend or resty_backend
+
+  return setmetatable(client, { __index  = generate_client_method  })
+end
+
+return http

--- a/apicast/src/resty/http_ng/backend/async_resty.lua
+++ b/apicast/src/resty/http_ng/backend/async_resty.lua
@@ -1,0 +1,100 @@
+local setmetatable = setmetatable
+local rawset = rawset
+local pairs = pairs
+local unpack = unpack
+local assert = assert
+local print = print
+local type = type
+local rawlen = rawlen
+local next = next
+local wait = ngx.thread.wait
+local spawn = ngx.thread.spawn
+
+local _M = {}
+
+local response = require 'resty.http_ng.response'
+local http = require 'resty.http'
+
+_M.async = function(req)
+  local httpc = http.new()
+
+  local parsed_uri = assert(httpc:parse_uri(req.url))
+
+  local scheme, host, port, path = unpack(parsed_uri)
+  if not req.path then req.path = path end
+
+  if #req.path == 0 then req.path = '/' end
+
+  local ok, err = httpc:connect(host, port)
+
+  if not ok then
+    print('error connecting ', host, ':', port, ' : ', err)
+    return response.error(err, req)
+  end
+
+  if scheme == 'https' then
+    local verify = req.options and req.options.ssl and req.options.ssl.verify
+    if type(verify) == 'nil' then verify = true end
+
+    local session
+    session, err = httpc:ssl_handshake(false, host, verify)
+
+    if not session then
+      return response.error(err, req)
+    end
+  end
+
+  local res
+  res, err = httpc:request(req)
+
+  if res then
+    return response.new(res.status, res.headers, function() return (res:read_body()) end)
+  else
+    return response.error(err, req)
+  end
+end
+
+local function future(thread)
+  local ok, res
+
+  local function load(table)
+    if not ok and not res then
+      ok, res = wait(thread)
+
+      rawset(table, 'ok', ok)
+
+      if not ok then res = response.error(res) end
+
+      for k,v in pairs(res) do
+        if k == 'headers' then
+          rawset(table, k, response.headers.new(v))
+        else
+          rawset(table, k, v)
+        end
+      end
+    end
+  end
+
+  return setmetatable({}, {
+    __len = function(table)
+      load(table)
+      return rawlen(table)
+    end,
+    __pairs = function(table)
+      load(table)
+      rawset(table, 'body', res.body)
+      return next, table, nil
+    end,
+    __index = function (table, key)
+      load(table)
+      return res[key]
+    end
+  })
+end
+
+_M.send = function(request)
+  local thread = spawn(_M.async, request)
+  return future(thread)
+end
+
+return _M

--- a/apicast/src/resty/http_ng/backend/ngx.lua
+++ b/apicast/src/resty/http_ng/backend/ngx.lua
@@ -1,0 +1,36 @@
+local backend = {}
+local response = require 'resty.http_ng.response'
+
+local METHODS = {
+  ["GET"]      = ngx.HTTP_GET,
+  ["HEAD"]     = ngx.HTTP_HEAD,
+  ["PATCH"]    = ngx.HTTP_PATCH,
+  ["PUT"]      = ngx.HTTP_PUT,
+  ["POST"]     = ngx.HTTP_POST,
+  ["DELETE"]   = ngx.HTTP_DELETE,
+  ["OPTIONS"]  = ngx.HTTP_OPTIONS
+}
+
+local PROXY_LOCATION = '/___http_call'
+
+backend.capture = ngx.location.capture
+backend.send = function(request)
+  local res = backend.capture(PROXY_LOCATION, {
+    method = METHODS[request.method],
+    body = request.body,
+    ctx = {
+      headers = request.headers
+    },
+    vars = {
+      _url = request.url
+    }
+  })
+
+  -- if res.truncated then
+    -- Do what? what error message it should say?
+  -- end
+
+  return response.new(res.status, res.header, res.body)
+end
+
+return backend

--- a/apicast/src/resty/http_ng/backend/resty.lua
+++ b/apicast/src/resty/http_ng/backend/resty.lua
@@ -1,0 +1,24 @@
+local backend = {}
+local response = require 'resty.http_ng.response'
+local http = require 'resty.http'
+
+backend.send = function(request)
+  local httpc = http.new()
+  local ssl_verify = request.options and request.options.ssl and request.options.ssl.verify
+
+  local res, err = httpc:request_uri(request.url, {
+    method = request.method,
+    body = request.body,
+    headers = request.headers,
+    ssl_verify = ssl_verify
+  })
+
+  if res then
+    return response.new(res.status, res.headers, res.body)
+  else
+    return response.error(err)
+  end
+end
+
+
+return backend

--- a/apicast/src/resty/http_ng/backend/test.lua
+++ b/apicast/src/resty/http_ng/backend/test.lua
@@ -12,16 +12,19 @@ local _M = {}
 local function contains(expected, actual)
   if actual == expected then return true end
   local t1,t2 = type(actual), type(expected)
-  if t1 ~= t2 then return false end
+  if t1 ~= t2 then return false, format("can't compare %q with %q", t1, t2) end
 
   if t1 == 'table' then
     for k,v in pairs(expected) do
-      if not contains(actual[k], v) then return false, format('[%q] %q does not match %q', k, actual[k], v) end
+      local ok, err = contains(v, actual[k])
+      if not ok then
+        return false, format('[%q] %s', k, err)
+      end
     end
     return true
   end
 
-  return false
+  return false, format('%q does not match %q', actual, expected)
 end
 
 

--- a/apicast/src/resty/http_ng/backend/test.lua
+++ b/apicast/src/resty/http_ng/backend/test.lua
@@ -5,6 +5,7 @@ local setmetatable = setmetatable
 local insert = table.insert
 local remove = table.remove
 local error = error
+local format = string.format
 
 local _M = {}
 
@@ -15,7 +16,7 @@ local function contains(expected, actual)
 
   if t1 == 'table' then
     for k,v in pairs(expected) do
-      if not contains(actual[k], v) then return false end
+      if not contains(actual[k], v) then return false, format('[%q] %q does not match %q', k, actual[k], v) end
     end
     return true
   end
@@ -55,7 +56,8 @@ _M.new = function()
     local expectation = remove(expectations, 1)
 
     if not expectation then error('no expectation') end
-    if not _M.expectation.match(expectation, request) then error('expectation does not match') end
+    local match, err = _M.expectation.match(expectation, request)
+    if not match then error('expectation does not match: ' .. err) end
 
     insert(requests, request)
 

--- a/apicast/src/resty/http_ng/backend/test.lua
+++ b/apicast/src/resty/http_ng/backend/test.lua
@@ -1,0 +1,72 @@
+local pairs = pairs
+local type = type
+local assert = assert
+local setmetatable = setmetatable
+local insert = table.insert
+local remove = table.remove
+local error = error
+
+local _M = {}
+
+local function contains(expected, actual)
+  if actual == expected then return true end
+  local t1,t2 = type(actual), type(expected)
+  if t1 ~= t2 then return false end
+
+  if t1 == 'table' then
+    for k,v in pairs(expected) do
+      if not contains(actual[k], v) then return false end
+    end
+    return true
+  end
+
+  return false
+end
+
+
+_M.expectation = {}
+
+_M.expectation.new = function(request)
+  assert(request, 'needs expected request')
+  local expectation = { request = request }
+
+  -- chain function to add a response to expectation
+  local mt = { respond_with = function(response) expectation.response = response end }
+
+  return setmetatable(expectation, {__index = mt})
+end
+
+_M.expectation.match = function(expectation, request)
+  return contains(expectation.request, request)
+end
+
+_M.new = function()
+  local requests = {}
+  local expectations = {}
+  local backend = {}
+
+  backend.expect = function(request)
+    local expectation = _M.expectation.new(request)
+    insert(expectations, expectation)
+    return expectation
+  end
+
+  backend.send = function(request)
+    local expectation = remove(expectations, 1)
+
+    if not expectation then error('no expectation') end
+    if not _M.expectation.match(expectation, request) then error('expectation does not match') end
+
+    insert(requests, request)
+
+    return expectation.response
+  end
+
+  backend.verify_no_outstanding_expectations = function()
+    assert(#expectations == 0, 'has ' .. #expectations .. ' outstanding expectations')
+  end
+
+  return backend
+end
+
+return _M

--- a/apicast/src/resty/http_ng/headers.lua
+++ b/apicast/src/resty/http_ng/headers.lua
@@ -1,0 +1,50 @@
+local insert = table.insert
+local concat = table.concat
+local assert = assert
+local pairs = pairs
+local rawset = rawset
+local rawget = rawget
+local setmetatable = setmetatable
+
+local headers = {}
+local headers_mt = {
+  __newindex = function(table, key, value)
+    rawset(table, headers.normalize_key(key), value)
+    return value
+  end,
+  __index = function(table, key)
+    return rawget(table, headers.normalize_key(key))
+  end
+}
+
+local capitalize = function(string)
+  local str = string:gsub('^%w', function(first) return first:upper() end)
+  return str
+end
+
+headers.normalize_key = function(key)
+  local parts = {}
+  key:gsub('[^_-]+', function(part)
+    insert(parts, capitalize(part))
+  end)
+  return concat(parts, '-')
+end
+
+headers.normalize = function(http_headers)
+  http_headers = http_headers or {}
+
+  local normalized = {}
+  for k,v in pairs(http_headers) do
+    normalized[headers.normalize_key(k)] = v
+  end
+
+  return normalized
+end
+
+headers.new = function(h)
+  local normalized = assert(headers.normalize(h or {}))
+
+  return setmetatable(normalized, headers_mt)
+end
+
+return headers

--- a/apicast/src/resty/http_ng/request.lua
+++ b/apicast/src/resty/http_ng/request.lua
@@ -1,0 +1,57 @@
+local match = string.match
+local assert = assert
+local setmetatable = setmetatable
+
+------------
+-- @module middleware
+
+--- options
+-- @type HTTP
+
+--- Options that can be passed to @{http} calls.
+-- @table options
+-- @field[type=table] headers table of HTTP headers
+-- @field[type=table] ssl table with ssl options
+-- @usage http.get(uri, { ssl = { verify = false }})
+-- @usage http.get(uri, { headers = { my_header = 'value' }})
+
+local request = { }
+
+request.headers = require 'resty.http_ng.headers'
+
+function request.extract_headers(req)
+  local options = req.options or {}
+  local headers = request.headers.new(options.headers)
+
+  headers.user_agent = headers.user_agent or 'APIcast (+https://www.apicast.io)'
+  headers.host = headers.host or match(req.url, "^.+://([^/]+)")
+  headers.connection = headers.connection or 'Keep-Alive'
+
+  options.headers = nil
+
+  return headers
+end
+
+function request.new(req)
+  assert(req)
+  assert(req.url)
+  assert(req.method)
+
+  req.options = req.options or {}
+  req.client = req.client or {}
+
+  req.headers = request.extract_headers(req)
+  req.options.ssl = req.options.ssl or { verify = true }
+
+  setmetatable(req, {
+    __index =  {
+      serialize = req.serializer or function() end
+    }
+  })
+
+  req.serialize(req)
+
+  return req
+end
+
+return request

--- a/apicast/src/resty/http_ng/response.lua
+++ b/apicast/src/resty/http_ng/response.lua
@@ -1,0 +1,56 @@
+local assert = assert
+local rawget = rawget
+local rawset = rawset
+local type = type
+local setmetatable = setmetatable
+------------
+-- @module middleware
+
+--- response
+-- @type HTTP
+
+--- Response returned by http.get and similar calls
+-- @table response
+-- @field[type=int] status HTTP Status Code
+-- @field[type=table] headers HTTP Headers
+-- @field[type=string] body response body
+-- @field[type=bool] ok
+
+
+local response = {}
+response.headers = require 'resty.http_ng.headers'
+
+
+function response.new(status, headers, body)
+  assert(status)
+  assert(body)
+
+  local mt = {}
+  mt['__index'] = function(table, key)
+    local generator = rawget(mt, key)
+    if generator then
+      rawset(table, key, generator(table))
+    end
+    return rawget(table, key)
+  end
+
+  local res = {
+    status = status,
+    headers = response.headers.new(headers),
+    ok = true
+  }
+
+  if type(body) == 'string' then
+    res.body = body
+  elseif type(body) == 'function' then
+    mt.body = body
+  end
+
+  return setmetatable(res, mt)
+end
+
+function response.error(message, request)
+  return { ok = false, error = message, request = request, status = 0, headers = {} }
+end
+
+return response

--- a/apicast/src/resty/resolver.lua
+++ b/apicast/src/resty/resolver.lua
@@ -122,6 +122,9 @@ end
 
 
 local function new_server(answer, port)
+  local address = answer.address
+  if not address then return nil, 'server missing address' end
+
   return {
     address = answer.address,
     ttl = answer.ttl,

--- a/apicast/src/resty/url.lua
+++ b/apicast/src/resty/url.lua
@@ -15,7 +15,7 @@ function _M.split(url)
     return nil, 'missing endpoint'
   end
 
-  local match = ngx.re.match(url, "^(https?):\\/\\/(?:(.+)@)?([^\\/\\s]+?)(?::(\\d+))?(\\/.+)?$", 'oj')
+  local match = ngx.re.match(url, "^(https?):\\/\\/(?:(.+)@)?([^\\/\\s]+?)(?::(\\d+))?(\\/.*)?$", 'oj')
 
   if not match then
     return nil, 'invalid endpoint' -- TODO: maybe improve the error message?

--- a/apicast/src/resty/url.lua
+++ b/apicast/src/resty/url.lua
@@ -31,5 +31,10 @@ function _M.split(url)
   return { scheme, user or false, pass or false, host, port or false, path or nil }
 end
 
+function _M.join(...)
+  local t = table.pack(...)
+  return table.concat(t, '')
+end
+
 
 return _M

--- a/bin/busted
+++ b/bin/busted
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-exec resty bin/busted.lua "$@"
+exec resty --http-include spec/fixtures/echo.conf bin/busted.lua "$@"

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -1,0 +1,149 @@
+local _M = require 'configuration_loader.remote_v2'
+local test_backend_client = require 'resty.http_ng.backend.test'
+local cjson = require 'cjson'
+local user_agent = require 'user_agent'
+
+describe('Configuration Rmote Loader V2', function()
+
+  local test_backend
+  local loader
+
+  before_each(function() test_backend = test_backend_client.new() end)
+  before_each(function()
+    loader = _M.new('http://example.com', { client = test_backend })
+  end)
+
+  after_each(function() test_backend.verify_no_outstanding_expectations() end)
+
+  describe('http_client #http', function()
+    it('has correct user agent', function()
+      test_backend.expect{ url = 'http://example.com/t', headers = { ['User-Agent'] = tostring(user_agent) } }
+        .respond_with{ status = 200  }
+
+      local res, err = loader.http_client.get('http://example.com/t')
+
+      assert.falsy(err)
+      assert.equal(200, res.status)
+    end)
+  end)
+
+  describe(':services', function()
+    it('retuns list of services', function()
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json' }.
+        respond_with{ status = 200, body = cjson.encode({ services = {
+            { service = { id = 1 }},
+            { service = { id = 2 }}
+          }})
+        }
+
+      local services = loader:services()
+
+      assert.truthy(services)
+      assert.equal(2, #services)
+    end)
+  end)
+
+  describe(':config', function()
+    it('loads a configuration', function()
+      test_backend.expect{ url = 'http://example.com/admin/api/services/42/proxy/configs/sandbox/latest.json' }.
+        respond_with{ status = 200, body = cjson.encode(
+          {
+            proxy_config = {
+              version = 13,
+              environment = 'sandbox',
+              content = { id = 42, backend_version = 1 }
+            }
+          }
+        ) }
+      local service = { id = 42 }
+
+      local config = loader:config(service, 'sandbox', 'latest')
+
+      assert.truthy(config)
+      assert.equal('table', type(config.content))
+      assert.equal(13, config.version)
+      assert.equal('sandbox', config.environment)
+    end)
+  end)
+
+  describe(':call', function()
+    it('returns configuration for all services', function()
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json' }.
+        respond_with{ status = 200, body = cjson.encode({ services = {
+            { service = { id = 1 }},
+            { service = { id = 2 }}
+          }})
+        }
+      test_backend.expect{ url = 'http://example.com/admin/api/services/1/proxy/configs/staging/latest.json' }.
+        respond_with{ status = 200, body = cjson.encode(
+          {
+            proxy_config = {
+              version = 13,
+              environment = 'staging',
+              content = { id = 1, backend_version = 1 }
+            }
+          }
+        )}
+      test_backend.expect{ url = 'http://example.com/admin/api/services/2/proxy/configs/staging/latest.json' }.
+        respond_with{ status = 200, body = cjson.encode(
+          {
+            proxy_config = {
+              version = 42,
+              environment = 'staging',
+              content = { id = 2, backend_version = 2 }
+            }
+          }
+        )}
+
+      local config = assert(loader:call('staging'))
+
+      assert.truthy(config)
+      assert.equals('string', type(config))
+
+      assert.equals(2, #(cjson.decode(config).services))
+    end)
+
+    it('does not crash on error when getting services', function()
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json' }.
+        respond_with{ status = 404 }
+
+      local config, err = loader:call('staging')
+
+      assert.falsy(config)
+      assert.equal('invalid status', err)
+    end)
+
+    it('does not crash on error when getting config', function()
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json' }.
+        respond_with{ status = 200, body = cjson.encode({ services = {
+            { service = { id = 1 }},
+            { service = { id = 2 }}
+          }})
+        }
+      test_backend.expect{ url = 'http://example.com/admin/api/services/1/proxy/configs/staging/latest.json' }.
+        respond_with{ status = 200, body = cjson.encode(
+          {
+            proxy_config = {
+              version = 13,
+              environment = 'staging',
+              content = { id = 1, backend_version = 1 }
+            }
+          }
+        )}
+      test_backend.expect{ url = 'http://example.com/admin/api/services/2/proxy/configs/staging/latest.json' }.
+        respond_with{ status = 404 }
+
+      local config, err = loader:call('staging')
+
+      assert.falsy(config)
+      assert.equal('invalid status', err)
+    end)
+  end)
+
+  describe('.call', function()
+    it('gets environment from ENV', function()
+      local _, err = loader.call()
+      assert.equal('missing environment', err)
+    end)
+  end)
+end)

--- a/spec/fake_backend_helper.lua
+++ b/spec/fake_backend_helper.lua
@@ -1,0 +1,16 @@
+local fake_backend = {}
+
+function fake_backend.new()
+  local backend = { requests = {} }
+
+  backend.send = function(request)
+    backend.requests[#backend.requests + 1] = request
+    backend.last_request = request
+    return { status = 200 }
+  end
+
+  return backend
+end
+
+
+return fake_backend

--- a/spec/fixtures/echo.conf
+++ b/spec/fixtures/echo.conf
@@ -1,0 +1,11 @@
+server {
+    listen 1984 default_server;
+    server_name _;
+
+    location / {
+        echo_duplicate 1 $echo_client_request_headers;
+        echo "\r";
+        echo_read_request_body;
+        echo $request_body;
+    }
+}

--- a/spec/resty/http_ng/backend/async_resty_spec.lua
+++ b/spec/resty/http_ng/backend/async_resty_spec.lua
@@ -1,0 +1,61 @@
+local backend = require 'resty.http_ng.backend.async_resty'
+
+describe('resty backend', function()
+
+  describe('GET method #network', function()
+    local method = 'GET'
+
+    it('accesses the url', function()
+      local response = backend.send{method = method, url = 'http://example.com/'}
+      assert.truthy(response)
+      assert.falsy(response.error)
+      assert.truthy(response.ok)
+      assert.equal(200, response.status)
+      assert.equal('string', type(response.body))
+    end)
+
+    it('works with ssl', function()
+      local response, err = backend.send{
+        method = method, url = 'https://google.com/',
+        -- This is needed because of https://groups.google.com/forum/#!topic/openresty-en/SuqORBK9ys0
+        -- So far OpenResty can't use system certificated on demand.
+        options = { ssl = { verify = false } }
+      }
+      assert.falsy(err)
+      assert.falsy(response.error)
+      assert.truthy(response.ok)
+      assert(response.headers.location:match('^https://'))
+      assert.equal('string', type(response.body))
+    end)
+  end)
+
+  describe('when there is no error', function()
+    local response
+    before_each(function()
+      response = backend.send{ method = 'GET', url = 'http://127.0.0.1:1984' }
+    end)
+
+    it('is ok', function()
+      assert.equal(true, response.ok)
+    end)
+
+    it('has no error', function()
+      assert.equal(nil, response.error)
+    end)
+  end)
+
+  describe('when there is error', function()
+    local response
+    before_each(function()
+      response = backend.send{ method = 'GET', url = 'http://127.0.0.1:1' }
+    end)
+
+    it('is not ok', function()
+      assert.equal(false, response.ok)
+    end)
+
+    it('has error', function()
+      assert.same('string', type(response.error)) -- depending on the openresty version it can be "timeout" or "connection refused"
+    end)
+  end)
+end)

--- a/spec/resty/http_ng/backend/ngx_spec.lua
+++ b/spec/resty/http_ng/backend/ngx_spec.lua
@@ -1,0 +1,31 @@
+local backend = require 'resty.http_ng.backend.ngx'
+
+describe('ngx backend',function()
+  describe('GET method', function()
+    local method = 'GET'
+
+    it('accesses the url', function()
+      backend.capture = function(location, options)
+        assert.equal('/___http_call', location)
+        assert.equal(ngx.HTTP_GET, options.method)
+        assert.are.same({_url = 'http://localhost:8081'}, options.vars)
+        return { status = 200, body = '' }
+      end
+      local response = backend.send{method = method, url = 'http://localhost:8081' }
+      assert.truthy(response)
+    end)
+
+    it('sends headers', function()
+      backend.capture = function(location, options)
+        assert.equal('/___http_call', location)
+        assert.equal(ngx.HTTP_GET, options.method)
+        assert.are.same({Host = 'fake.example.com'}, options.ctx.headers)
+        return { status = 200, body = '' }
+      end
+      local response = backend.send{method = method, url = 'http://localhost:8081/path', headers = {Host = 'fake.example.com'} }
+      assert.truthy(response)
+    end)
+  end)
+
+
+end)

--- a/spec/resty/http_ng/backend/resty_spec.lua
+++ b/spec/resty/http_ng/backend/resty_spec.lua
@@ -1,0 +1,28 @@
+local backend = require 'resty.http_ng.backend.resty'
+
+describe('resty backend', function()
+
+  describe('GET method #network', function()
+    local method = 'GET'
+
+    it('accesses the url', function()
+      local response, err = backend.send{method = method, url = 'http://example.com/'}
+      assert.falsy(err)
+      assert.falsy(response.error)
+      assert.truthy(response.ok)
+    end)
+
+    it('works with ssl', function()
+      local response, err = backend.send{
+        method = method, url = 'https://google.com/',
+        -- This is needed because of https://groups.google.com/forum/#!topic/openresty-en/SuqORBK9ys0
+        -- So far OpenResty can't use system certificated on demand.
+        options = { ssl = { verify = false } }
+      }
+      assert.falsy(err)
+      assert.falsy(response.error)
+      assert.truthy(response.ok)
+      assert(response.headers.location:match('^https://'))
+    end)
+  end)
+end)

--- a/spec/resty/http_ng/backend/test_spec.lua
+++ b/spec/resty/http_ng/backend/test_spec.lua
@@ -30,7 +30,7 @@ describe('test backend',function()
     it('matches expectation', function()
       backend.expect{method = 'POST'}
       local req = request.new{method = 'GET', url = 'http://example.com' }
-      assert.has.error(function() backend.send(req) end, 'expectation does not match')
+      assert.has.error(function() backend.send(req) end, 'expectation does not match: ["method"] "GET" does not match "POST"')
     end)
   end)
 end)

--- a/spec/resty/http_ng/backend/test_spec.lua
+++ b/spec/resty/http_ng/backend/test_spec.lua
@@ -1,0 +1,36 @@
+local test_backend = require 'resty.http_ng.backend.test'
+local request = require 'resty.http_ng.request'
+
+local backend
+
+describe('test backend',function()
+  before_each(function() backend = test_backend.new() end)
+
+  describe('matching expectations', function()
+    it('allows setting expectations', function()
+      backend.expect{method = 'GET'}.respond_with{status = 301 }
+
+      local req = request.new{method = 'GET', url = 'http://example.com' }
+      local response = backend.send(req)
+
+      assert.truthy(response)
+    end)
+
+    it('can verify outstanding requests', function()
+      assert.has.no_error(backend.verify_no_outstanding_expectations)
+      backend.expect{method = 'GET' }
+      assert.has.error(backend.verify_no_outstanding_expectations, 'has 1 outstanding expectations')
+    end)
+
+    it('expects a request', function()
+      local req = request.new{method = 'GET', url = 'http://example.com' }
+      assert.has.error(function() backend.send(req) end, 'no expectation')
+    end)
+
+    it('matches expectation', function()
+      backend.expect{method = 'POST'}
+      local req = request.new{method = 'GET', url = 'http://example.com' }
+      assert.has.error(function() backend.send(req) end, 'expectation does not match')
+    end)
+  end)
+end)

--- a/spec/resty/http_ng/request_spec.lua
+++ b/spec/resty/http_ng/request_spec.lua
@@ -1,0 +1,31 @@
+local request = require 'resty.http_ng.request'
+
+describe('request', function()
+  describe('headers', function()
+    it('normalizes case', function()
+      local headers = request.headers.new{ ['content-type'] = 'text/plain' }
+      assert.are.same({['Content-Type'] = 'text/plain'}, headers)
+    end)
+
+    it('changes them on set', function()
+      local headers = request.headers.new{}
+      assert.are.same({}, headers)
+
+      headers.host = 'example.com'
+      assert.are.same({Host = 'example.com'}, headers)
+      assert.equal(headers.Host, headers.host)
+    end)
+  end)
+
+  it('adds User-Agent header', function()
+    local req = request.new{url = 'http://example.com/path', method = 'GET' }
+
+    assert.equal('APIcast (+https://www.apicast.io)',req.headers['User-Agent'])
+  end)
+
+  it('adds Host header', function()
+    local req = request.new{url = 'http://example.com/path', method = 'GET' }
+
+    assert.equal('example.com',req.headers.Host)
+  end)
+end)

--- a/spec/resty/http_ng_spec.lua
+++ b/spec/resty/http_ng_spec.lua
@@ -20,6 +20,28 @@ describe('http_ng', function()
     end)
   end
 
+  it('OPTIONS method works with default options', function()
+    http = http_ng.new{backend = backend, options = { headers = { host = "foo" }}}
+    local response = http.OPTIONS('http://example.com')
+    local last_request = assert(backend.last_request)
+
+    assert.truthy(response)
+    assert.equal('OPTIONS', last_request.method)
+    assert.equal('http://example.com', last_request.url)
+    assert.equal('foo', last_request.headers.host)
+  end)
+
+  pending('options method works with default options', function()
+    http = http_ng.new{backend = backend, options = { headers = { host = "foo" }}}
+    local response = http.options('http://example.com')
+    local last_request = assert(backend.last_request)
+
+    assert.truthy(response)
+    assert.equal('OPTIONS', last_request.method)
+    assert.equal('http://example.com', last_request.url)
+    assert.equal('foo', last_request.headers.host)
+  end)
+
   for _,method in ipairs{ 'put', 'post', 'patch' } do
     it('makes ' .. method .. ' call to backend with body', function()
       local response = http[method]('http://example.com', 'body')
@@ -66,6 +88,34 @@ describe('http_ng', function()
       http.get('http://example.com', { headers = { host = 'overriden' }})
       local last_request = assert(backend.last_request)
       assert.equal('overriden', last_request.headers.host)
+    end)
+
+    it('overrides headers from initial options', function()
+      http = http_ng.new{backend = backend, options = { headers = { user_agent = 'foobar' } } }
+
+      http.get('http://example.com', { headers = { user_agent = 'overriden' }})
+
+      local last_request = assert(backend.last_request)
+      assert.equal('overriden', last_request.headers.user_agent)
+    end)
+
+    it('uses headers from initial options', function()
+      http = http_ng.new{backend = backend, options = { headers = { user_agent = 'foobar' } } }
+
+      http.get('http://example.com')
+
+      local last_request = assert(backend.last_request)
+      assert.equal('foobar', last_request.headers.user_agent)
+    end)
+
+    it('merges passed headers with initial options', function()
+      http = http_ng.new{backend = backend, options = { headers = { user_agent = 'foo' } } }
+
+      http.get('http://example.com', { headers = { host = 'bar' }})
+      local last_request = assert(backend.last_request)
+
+      assert.equal('foo', last_request.headers.user_agent)
+      assert.equal('bar', last_request.headers.host)
     end)
 
     it('passed headers for requests with body', function()

--- a/spec/resty/http_ng_spec.lua
+++ b/spec/resty/http_ng_spec.lua
@@ -1,0 +1,154 @@
+local http_ng = require 'resty.http_ng'
+local fake_backend = require 'fake_backend_helper'
+
+
+describe('http_ng', function()
+  local http, backend
+  before_each(function()
+    backend = fake_backend.new()
+    http = http_ng.new({backend = backend})
+  end)
+
+  for _,method in ipairs{ 'get', 'head', 'options', 'delete' } do
+    it('makes ' .. method .. ' call to backend', function()
+      local response = http[method]('http://example.com')
+      local last_request = assert(backend.last_request)
+
+      assert.truthy(response)
+      assert.equal(method:upper(), last_request.method)
+      assert.equal('http://example.com', last_request.url)
+    end)
+  end
+
+  for _,method in ipairs{ 'put', 'post', 'patch' } do
+    it('makes ' .. method .. ' call to backend with body', function()
+      local response = http[method]('http://example.com', 'body')
+      local last_request = assert(backend.last_request)
+
+      assert.truthy(response)
+      assert.equal(method:upper(), last_request.method)
+      assert.equal('http://example.com', last_request.url)
+      assert.equal('body', last_request.body)
+    end)
+  end
+
+  describe('x-www-form-urlencoded', function()
+    local body = { value = 'some' }
+
+    it('serializes table as form-urlencoded', function()
+      http.post('http://example.com', body)
+
+      local last_request = assert(backend.last_request)
+      assert.equal('application/x-www-form-urlencoded', last_request.headers.content_type)
+      assert.equal('value=some', last_request.body)
+    end)
+  end)
+
+  describe('array syntax', function()
+    it('works for get', function()
+      http.get{'http://example.com', headers = { custom = 'value'} }
+      local last_request = assert(backend.last_request)
+      assert.equal('value', last_request.headers.custom)
+    end)
+
+    it('works for post', function()
+      http.post{'http://example.com', 'body', headers = { custom = 'value'} }
+      local last_request = assert(backend.last_request)
+      assert.equal('value', last_request.headers.Custom)
+      assert.equal('body', last_request.body)
+    end)
+  end)
+
+  describe('headers', function()
+    local headers = { custom_header = 'value' }
+
+    it('can override Host header', function()
+      http.get('http://example.com', { headers = { host = 'overriden' }})
+      local last_request = assert(backend.last_request)
+      assert.equal('overriden', last_request.headers.host)
+    end)
+
+    it('passed headers for requests with body', function()
+      http.post('http://example.com', '', { headers = headers })
+      local last_request = assert(backend.last_request)
+      assert.equal('value', last_request.headers['Custom-Header'])
+    end)
+
+    it('passed headers for requests without body', function()
+      http.get('http://example.com', { headers = headers })
+      local last_request = assert(backend.last_request)
+      assert.equal('value', last_request.headers['Custom-Header'])
+    end)
+  end)
+
+  describe('json', function()
+    it('has serializer', function()
+      assert.equal(http_ng.serializers.json, http.json.serializer)
+    end)
+
+    it('doesnt have serializer', function()
+      assert.falsy(http.unknown)
+    end)
+
+    it('serializes body as json', function()
+      http.json.post('http://example.com', {table = 'value'})
+
+      assert.equal('{"table":"value"}', backend.last_request.body)
+      assert.equal(#'{"table":"value"}', backend.last_request.headers['Content-Length'])
+      assert.equal('application/json', backend.last_request.headers['Content-Type'])
+    end)
+
+    it('accepts json as a string', function()
+      http.json.post('http://example.com', '{"table" : "value"}')
+      assert.equal('{"table" : "value"}', backend.last_request.body)
+      assert.equal(#'{"table" : "value"}', backend.last_request.headers['Content-Length'])
+      assert.equal('application/json', backend.last_request.headers['Content-Type'])
+    end)
+
+    it('does not override passed headers', function()
+      http.json.post('http://example.com', '{}', { headers = { content_type = 'custom/format' }})
+      assert.equal('custom/format', backend.last_request.headers['Content-Type'])
+    end)
+  end)
+
+  describe('when there is no error', function()
+    local response
+    before_each(function()
+      http = http_ng.new{}
+      response = http.get('http://127.0.0.1:1984')
+    end)
+
+    it('is ok', function()
+      assert.equal(true, response.ok)
+    end)
+
+    it('has no error', function()
+      assert.equal(nil, response.error)
+    end)
+  end)
+
+  describe('when there is error #network', function()
+    local response
+    before_each(function()
+      http = http_ng.new{}
+      response = http.get('http://127.0.0.1:1')
+    end)
+
+    it('is not ok', function()
+      assert.equal(false, response.ok)
+    end)
+
+    it('has error', function()
+      assert.equal('string', type(response.error)) -- depending on the openresty version it can be "timeout" or "connection refused"
+    end)
+  end)
+
+  describe('works with api.twitter.com #network', function()
+
+    it('connects #twitter', function()
+      local client = http_ng.new{}
+      local response = client.get('http://api.twitter.com/')
+      assert(response.ok, 'response is not ok')
+    end)
+  end)
+end)

--- a/spec/resty/resolver_spec.lua
+++ b/spec/resty/resolver_spec.lua
@@ -43,6 +43,21 @@ describe('resty.resolver', function()
       assert.spy(dns.query).was.called_with(dns, '3scale.net', { qtype = 1 })
     end)
 
+    it('skips answers with no address', function()
+      dns.query = spy.new(function()
+        return {
+          { name = 'www.3scale.net' , cname = '3scale.net' },
+          { name = '3scale.net' , address = '127.0.0.1' }
+        }
+      end)
+
+      local servers, err = resolver:get_servers('www.3scale.net')
+
+      assert.falsy(err)
+      assert.equal(1, #servers)
+      assert.spy(dns.query).was.called_with(dns, 'www.3scale.net', {})
+    end)
+
     it('searches domains', function()
       dns.TYPE_A = 1
       dns.query = spy.new(function(_, qname)

--- a/spec/resty/url_spec.lua
+++ b/spec/resty/url_spec.lua
@@ -36,6 +36,10 @@ describe('resty.url', function()
     it('works with port and path', function()
       assert.same({'http', false, false, 'example.com', '8080', '/path'}, split('http://example.com:8080/path'))
     end)
+
+    it('removes the trailing slash', function()
+      assert.same({'http', false, false, 'api.twitter.com', false }, split('http://api.twitter.com/'))
+    end)
   end)
 
 

--- a/spec/resty/url_spec.lua
+++ b/spec/resty/url_spec.lua
@@ -38,4 +38,13 @@ describe('resty.url', function()
     end)
   end)
 
+
+  describe('.join', function()
+    local join = url.join
+
+    it('works with a slash', function()
+      assert.same('https://example.com/foo', join('https://example.com', '/foo'))
+    end)
+  end)
+
 end)

--- a/t/003-apicast.t
+++ b/t/003-apicast.t
@@ -531,7 +531,33 @@ all ok
 --- error_log
 host foo for service 2 already defined by service 1
 
-=== TEST 12: return headers with debugging info
+=== TEST 12: print message that service was added to the configuration
+Including it's host so it is easy to see that configuration was loaded.
+--- http_config
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+--- config
+location /t {
+  content_by_lua_block {
+    require('provider').configure({
+      services = {
+        { id = 1, proxy = { hosts = { 'foo', 'bar' } } },
+        { id = 2, proxy = { hosts = { 'baz', 'daz' } } },
+      }
+    })
+    ngx.say('all ok')
+  }
+}
+--- request
+GET /t
+--- response_body
+all ok
+--- log_level: info
+--- error_code: 200
+--- error_log
+added service 1 configuration with hosts: foo, bar
+added service 2 configuration with hosts: baz, daz
+
+=== TEST 13: return headers with debugging info
 When X-3scale-Debug header has value of the backend authentication.
 --- http_config
   include $TEST_NGINX_UPSTREAM_CONFIG;


### PR DESCRIPTION
Configuration environments (staging/production) using new API.

----- 
 
# TODO

- [x] figure out a way how to test APItools http client (http_ng) backend adapters
  - it needs to connect to a socket, so probably test-nginx ?
  - resty can import parts of the nginx configuration, for example to start a server