### PR TITLE
[resty-http_authorization] library to parse HTTP Authorization

### DIFF
--- a/apicast/src/resty/http_authorization.lua
+++ b/apicast/src/resty/http_authorization.lua
@@ -1,0 +1,46 @@
+local setmetatable = setmetatable
+local match = string.match
+
+local _M = {
+  _VERSION = '0.1',
+  parsers = { }
+}
+
+local mt = { __index = _M }
+
+function _M.parsers.Basic(param)
+  local user_pass = ngx.decode_base64(param)
+  local userid, password = match(user_pass, '^(.*):(.*)$')
+
+  return {
+    userid = userid,
+    password = password,
+    credentials = { 'userid', 'password' }
+  }
+end
+
+function _M.parsers.Bearer(param)
+  return {
+    token = param,
+    credentials = { 'token' }
+  }
+end
+
+function _M.parsers.null()
+  return {
+    credentials = { }
+  }
+end
+
+function _M.new(value)
+  local scheme, param = match(value or '', "^(%w+)%s*(.*)$")
+  local parse = _M.parsers[scheme] or _M.parsers.null
+  local parsed = setmetatable(parse(param), mt)
+
+  return setmetatable({
+    scheme = scheme,
+    param = param
+  }, { __index = parsed })
+end
+
+return _M

--- a/spec/resty/http_authorization_spec.lua
+++ b/spec/resty/http_authorization_spec.lua
@@ -1,0 +1,74 @@
+local authorization = require 'resty.http_authorization'
+
+describe('HTTP Authorization', function()
+
+  describe('.new', function()
+    it('works with empty values', function()
+      local auth = authorization.new()
+
+      assert.same(nil, auth.scheme)
+      assert.same(nil, auth.param)
+    end)
+
+    it('parses scheme', function()
+      local auth = authorization.new('Basic foobar')
+
+      assert.equal('Basic', auth.scheme)
+      assert.same({'userid', 'password'}, auth.credentials)
+    end)
+
+    it('parses param', function()
+      local auth = authorization.new('Bearer foobar')
+
+      assert.equal('foobar', auth.param)
+      assert.same({'token'}, auth.credentials)
+    end)
+
+    it('works with unknown scheme', function()
+      local auth = authorization.new('Whatever')
+
+      assert.equal('Whatever', auth.scheme)
+      assert.equal('', auth.param)
+      assert.same({}, auth.credentials)
+    end)
+  end)
+
+  describe('.parser', function()
+    describe('Basic', function()
+      it('extracts userid', function()
+        local auth = authorization.new('Basic dXNlcjpwYXNz') -- user:pass
+
+        assert.equal('user', auth.userid)
+      end)
+
+      it('extracts password', function()
+        local auth = authorization.new('Basic dXNlcjpwYXNz') -- user:pass
+
+        assert.equal('pass', auth.password)
+      end)
+
+      it('extracts empty password', function()
+        local auth = authorization.new('Basic dXNlcjo=') -- user:
+
+        assert.equal('', auth.password)
+        assert.equal('user', auth.userid)
+      end)
+
+      it('extracts empty userid', function()
+        local auth = authorization.new('Basic OnBhc3M=') -- :pass
+
+        assert.equal('', auth.userid)
+        assert.equal('pass', auth.password)
+      end)
+    end)
+
+    describe('Bearer', function()
+      it('extracts token', function()
+        local auth = authorization.new('Bearer dXNlcjpwYXNz')
+
+        assert.equal('dXNlcjpwYXNz', auth.token)
+      end)
+    end)
+  end)
+
+end)


### PR DESCRIPTION
This is a base for future HTTP Authorization header support.

Right now it supports: 

* Basic
* Bearer