### PR TITLE
[config] extract credentials handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 luacov.*.out
 local/
 t/servroot/
+doc/api/

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ script:
 - make test-builder-image
 - make prove-docker
 - make test-runtime-image
+- make doc
 after_success:
 - if [ "${TRAVIS_BRANCH}" = "v2" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
   docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}" quay.io;

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,8 @@ dependencies:
 clean: ## Remove all running docker containers
 	$(DOCKER_COMPOSE) down --volumes --remove-orphans
 
+doc: dependencies ## Generate documentation
+	ldoc -c doc/config.ld .
 # Check http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help: ## Print this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/apicast/src/configuration/service.lua
+++ b/apicast/src/configuration/service.lua
@@ -1,3 +1,7 @@
+-----------------
+--- Service configuration object.
+-- @classmod Service
+
 local setmetatable = setmetatable
 local tostring = tostring
 local rawget = rawget
@@ -12,13 +16,9 @@ local type = type
 
 local http_authorization = require 'resty.http_authorization'
 
-local _M = {
 
-}
-
-local mt = {
-  __index = _M
-}
+local _M = { }
+local mt = { __index = _M  }
 
 function _M.new(attributes)
   return setmetatable(attributes or {}, mt)
@@ -86,7 +86,11 @@ function backend_version_credentials.version_1(config)
   else
     return nil, 'invalid credentials location'
   end
-
+  ------
+  -- user_key credentials.
+  -- @field 1 User Key
+  -- @field user_key User Key
+  -- @table credentials_v1
   return { user_key = user_key }
 end
 
@@ -119,6 +123,13 @@ function backend_version_credentials.version_2(config)
     return nil, 'invalid credentials location'
   end
 
+  ------
+  -- app\_id/app\_key credentials.
+  -- @field 1 app id or app key
+  -- @field[opt] 2
+  -- @field app_id App ID
+  -- @field app_key App Key
+  -- @table credentials_v2
   return { app_id = app_id, app_key = app_key }
 end
 
@@ -144,6 +155,11 @@ function backend_version_credentials.version_oauth(config)
   -- Resource servers MUST support this method. [Bearer]
   access_token = access_token or authorization.token
 
+  ------
+  -- oauth credentials.
+  -- @field 1 Access Token
+  -- @field access_token Access Token
+  -- @table credentials_oauth
   return { access_token = access_token }
 end
 
@@ -164,7 +180,10 @@ local function to_hybrid_array_table(table)
   return setmetatable(hybrid, credentials_mt)
 end
 
-function _M.extract_credentials(self)
+--- extracts credentials from the current request
+-- @return @{credentials_v1}, @{credentials_v2}, or @{credentials_oauth}
+-- @return[opt] error message why credentials could not be extracted
+function _M:extract_credentials()
   local backend_version = tostring(self.backend_version)
   local credentials = rawget(self, 'credentials')
 

--- a/apicast/src/configuration/service.lua
+++ b/apicast/src/configuration/service.lua
@@ -1,0 +1,167 @@
+local setmetatable = setmetatable
+local tostring = tostring
+local rawget = rawget
+local next = next
+local lower = string.lower
+local gsub = string.gsub
+local select = select
+local type = type
+
+local http_authorization = require 'resty.http_authorization'
+
+local _M = {
+
+}
+
+local mt = {
+  __index = _M
+}
+
+function _M.new(attributes)
+  return setmetatable(attributes or {}, mt)
+end
+
+local http_methods_with_body = {
+  POST = true,
+  PUT = true,
+  PATCH = true
+}
+
+local function read_body_args(...)
+  local method = ngx.req.get_method()
+
+  if not http_methods_with_body[method] then
+    return {}, 'not supported'
+  end
+
+  ngx.req.read_body()
+
+  local args = ngx.req.get_post_args()
+  local results = {}
+
+  for n=1, select('#', ...) do
+    results[n] = args[select(n, ...)]
+  end
+
+  return results
+end
+
+local function read_http_header(name)
+  local normalized = gsub(lower(name), '-', '_')
+  return ngx.var['http_' .. normalized]
+end
+
+local credentials_mt = {
+  -- nipairs = only non integer pairs
+  __pairs = function (t)
+    return function(_, k)
+      local v
+      repeat
+        k, v = next(t, k)
+      until k == nil or type(k) ~= 'number'
+      return k, v
+    end, t, nil
+  end
+}
+
+local backend_version_credentials = {
+  ['1'] = function(credentials)
+    local name = (credentials.user_key or 'user_key')
+    local user_key
+
+    if credentials.location == 'query' then
+      user_key = ngx.var['arg_' .. name] or read_body_args(name)[1]
+
+    elseif credentials.location == 'headers' then
+      user_key = read_http_header(name)
+
+    elseif credentials.location == 'authorization' then
+      local auth = http_authorization.new(ngx.var.http_authorization)
+
+      user_key = auth.userid or auth.password or auth.token
+    else
+      return nil, 'invalid credentials location'
+    end
+
+    return { user_key, user_key = user_key }
+  end,
+
+  ['2'] = function(credentials)
+    local app_id_name = (credentials.app_id or 'app_id')
+    local app_key_name = (credentials.app_key or 'app_key')
+
+    local app_id, app_key
+
+    if credentials.location == 'query' then
+      app_id = ngx.var['arg_' .. app_id_name]
+      app_key = ngx.var['arg_' .. app_key_name]
+
+      if not app_id or not app_key then
+        local body = read_body_args(app_id_name, app_key_name)
+
+        app_id = app_id or body[1]
+        app_key = app_key or body[2]
+      end
+    elseif credentials.location == 'headers' then
+      app_id = read_http_header(app_id_name)
+      app_key = read_http_header(app_key_name)
+
+    elseif credentials.location == 'authorization' then
+      local auth = http_authorization.new(ngx.var.http_authorization)
+
+      app_id = auth.userid or auth.token
+      app_key = auth.password
+    else
+      return nil, 'invalid credentials location'
+    end
+
+    return { app_id, app_key, app_id = app_id, app_key = app_key }
+  end,
+
+  ['oauth'] = function(credentials)
+    local name = (credentials.access_token or 'access_token')
+    local authorization = http_authorization.new(ngx.var.http_authorization)
+    local access_token
+
+    if credentials.location == 'query' then
+      access_token = ngx.var['arg_' .. name] or read_body_args(name)[1]
+
+    elseif credentials.location == 'headers' then
+      access_token = read_http_header(name)
+
+    elseif credentials.location == 'authorization' then
+      access_token = authorization.token
+
+    else
+      return nil, 'invalid credentials location'
+    end
+
+    -- https://tools.ietf.org/html/rfc6750#section-2.1 says:
+    -- Resource servers MUST support this method. [Bearer]
+    access_token = access_token or authorization.token
+
+    return { access_token, access_token = access_token }
+  end
+}
+
+function _M.extract_credentials(self)
+  local backend_version = tostring(self.backend_version)
+  local credentials = rawget(self, 'credentials')
+
+  if not credentials then
+    return nil, 'missing credentials'
+  end
+
+  local extractor = backend_version_credentials[backend_version]
+
+  if not extractor then
+   return nil, 'invalid backend version: ' .. tostring(backend_version)
+  end
+
+  local result = extractor(credentials)
+
+
+  return setmetatable(result, credentials_mt)
+end
+
+return _M

--- a/doc/config.ld
+++ b/doc/config.ld
@@ -1,0 +1,8 @@
+file = {
+
+}
+dir = '../doc/api'
+project = 'APIcast'
+title = 'NGINX based API gateway used to integrate your internal and external API services with 3scale’s API Management Platform'
+merge = true
+format = 'markdown'

--- a/doc/config.ld
+++ b/doc/config.ld
@@ -1,5 +1,5 @@
 file = {
-
+  '../apicast/src/configuration/service.lua'
 }
 dir = '../doc/api'
 project = 'APIcast'

--- a/rockspec
+++ b/rockspec
@@ -4,7 +4,8 @@ version = '0.0-0'
 dependencies = {
   'luacheck >= 0',
   'busted  >= 0',
-  'lua-cjson >= 0'
+  'lua-cjson >= 0',
+  'ldoc >= 0'
 }
 build = {
   type = "builtin",

--- a/spec/configuration/service_spec.lua
+++ b/spec/configuration/service_spec.lua
@@ -1,0 +1,162 @@
+local Service = require 'configuration.service'
+
+describe('Service object', function()
+  describe(':credentials', function()
+
+    describe('backend_version=1', function()
+      it('returns only GET parameters', function()
+        local service = Service.new({
+          backend_version = 1,
+          credentials = { location = 'query' }
+        })
+
+        ngx.var = { arg_user_key = 'foobar' }
+
+        assert.same({ 'foobar', user_key = 'foobar' }, assert(service:extract_credentials()))
+      end)
+
+      it('returns POST ', function()
+        local service = Service.new({
+          backend_version = 1,
+          credentials = { location = 'query' }
+        })
+
+        ngx.var = {}
+        stub(ngx.req, 'get_method', function() return 'POST' end)
+        stub(ngx.req, 'read_body')
+        stub(ngx.req, 'get_post_args', function() return { user_key = 'post' } end)
+
+        assert.same({ 'post', user_key = 'post' }, assert(service:extract_credentials()))
+      end)
+
+      it('uses http authorization header', function()
+        local service = Service.new({
+          backend_version = 1,
+          credentials = { location = 'authorization' }
+        })
+
+        ngx.var = { http_authorization = 'Bearer token' }
+
+        assert.same({ 'token', user_key = 'token' }, assert(service:extract_credentials()))
+      end)
+
+
+      it('returns Headers ', function()
+        local service = Service.new({
+          backend_version = 1,
+          credentials = { location = 'headers', user_key = 'some-user-key' }
+        })
+
+        ngx.var = { http_some_user_key = 'val'  }
+
+        assert.same({ 'val', user_key = 'val' }, assert(service:extract_credentials()))
+      end)
+    end)
+
+    describe('backend_version=2', function()
+      it('returns only GET parameters', function()
+        local service = Service.new({
+          backend_version = 2,
+          credentials = { location = 'query' }
+        })
+
+        stub(ngx.req, 'get_method', function() return 'GET' end)
+        ngx.var = { arg_app_id = 'foobar' }
+
+        assert.same({ 'foobar', app_id = 'foobar' }, assert(service:extract_credentials()))
+      end)
+
+      it('returns POST ', function()
+        local service = Service.new({
+          backend_version = 2,
+          credentials = { location = 'query' }
+        })
+
+        ngx.var = {}
+        stub(ngx.req, 'get_method', function() return 'POST' end)
+        stub(ngx.req, 'read_body')
+        stub(ngx.req, 'get_post_args', function() return { app_id = 'post' } end)
+
+        assert.same({ 'post', app_id = 'post' }, assert(service:extract_credentials()))
+      end)
+
+      it('uses http authorization header', function()
+        local service = Service.new({
+          backend_version = 2,
+          credentials = { location = 'authorization' }
+        })
+
+        ngx.var = { http_authorization = 'Bearer token' }
+
+        assert.same({ 'token', app_id = 'token' }, assert(service:extract_credentials()))
+      end)
+
+      it('returns Headers ', function()
+        local service = Service.new({
+          backend_version = 2,
+          credentials = {
+            location = 'headers',
+            app_id = 'some-app-id',
+            app_key = 'some-app-key'
+          }
+        })
+
+        ngx.var = { http_some_app_id = 'id', http_some_app_key = 'key'  }
+
+        assert.same({ 'id', 'key', app_id = 'id', app_key = 'key' },
+          assert(service:extract_credentials()))
+      end)
+    end)
+  
+    describe('backend_version=oauth', function()
+      it('returns only GET parameters', function()
+        local service = Service.new({
+          backend_version = 'oauth',
+          credentials = { location = 'query' }
+        })
+
+        ngx.var = { arg_access_token = 'foobar' }
+
+        assert.same({ 'foobar', access_token = 'foobar' }, assert(service:extract_credentials()))
+      end)
+
+      it('returns POST ', function()
+        local service = Service.new({
+          backend_version = 'oauth',
+          credentials = { location = 'query' }
+        })
+
+        ngx.var = {}
+        stub(ngx.req, 'get_method', function() return 'POST' end)
+        stub(ngx.req, 'read_body')
+        stub(ngx.req, 'get_post_args', function() return { access_token = 'post' } end)
+
+        assert.same({ 'post', access_token = 'post' }, assert(service:extract_credentials()))
+      end)
+
+      it('uses http authorization header', function()
+        local service = Service.new({
+          backend_version = 'oauth',
+          credentials = { location = 'authorization' }
+        })
+
+        ngx.var = { http_authorization = 'Bearer token' }
+
+        assert.same({ 'token', access_token = 'token' }, assert(service:extract_credentials()))
+      end)
+
+
+      it('returns Headers ', function()
+        local service = Service.new({
+          backend_version = 'oauth',
+          credentials = { location = 'headers', access_token = 'some-access-token' }
+        })
+
+        ngx.var = { http_some_access_token = 'val'  }
+
+        assert.same({ 'val', access_token = 'val' }, assert(service:extract_credentials()))
+      end)
+    end)
+
+  end)
+end)

--- a/t/003-apicast.t
+++ b/t/003-apicast.t
@@ -140,10 +140,12 @@ It asks backend and then forwards the request to the api.
 
   location /transactions/authrep.xml {
     content_by_lua_block {
-      expected = "service_token=token-value&service_id=42&usage[hits]=2&user_key=value"
-      if ngx.var.args == expected then
+      local expected = "service_token=token-value&service_id=42&usage[hits]=2&user_key=value"
+      local args = ngx.var.args
+      if args == expected then
         ngx.exit(200)
       else
+        ngx.log(ngx.ERR, expected, ' did not match: ', args)
         ngx.exit(403)
       end
     }
@@ -159,6 +161,8 @@ yay, api backend: 127.0.0.1
 --- error_code: 200
 --- error_log
 apicast cache miss key: 42:value:usage[hits]=2
+--- no_error_log
+[error]
 
 === TEST 5: call to backend is cached
 First call is done synchronously and the second out of band.


### PR DESCRIPTION
* into new object: Service
* in the future can be extracted further in to Credentials
* uses new resty-http_authorization library
* now is a metamethod on new Service object
* remove old get_credentials
* overall unify credentials retrieval and handling

extracted from #162

This is a breaking change as it totally removes `:get_credentials` and changes `:extract_credentials` method. Imo it should be easier for modules to work with this, but would be good to get some feedback from @davidor.

the next steps would be to unify parameter extraction to fix https://github.com/3scale/apicast/issues/163
it should be prepared to parse json too and be lazy, as the payloads can be huge