### PR TITLE
fix handling missing configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,9 @@ test-runtime-image: export IMAGE_NAME = apicast-release-test
 test-runtime-image: runtime-image clean ## Smoke test the runtime image. Pass any docker image in IMAGE_NAME parameter.
 	$(DOCKER_COMPOSE) run --rm --user 100001 gateway apicast -d
 	@echo -e $(SEPARATOR)
+	$(DOCKER_COMPOSE) run --rm --user 100002 -e APICAST_MISSING_CONFIGURATION=exit -e THREESCALE_PORTAL_ENDPOINT=https://echo-api.3scale.net gateway bin/apicast -d
+	@echo -e $(SEPARATOR)
 	$(DOCKER_COMPOSE) run --rm test sh -c 'sleep 5 && curl --fail http://gateway:8090/status/live'
-
 
 dependencies:
 	luarocks make apicast/*.rockspec

--- a/apicast/src/configuration_store.lua
+++ b/apicast/src/configuration_store.lua
@@ -55,6 +55,8 @@ function _M.store(self, config)
   for _,service in ipairs(config.services) do
     _M.add(self, service)
   end
+
+  return config
 end
 
 function _M.reset(self)


### PR DESCRIPTION
the missing configuration handler would be executed even when configuration 
was loaded successfuly

fixes https://github.com/3scale/apicast/issues/203