### PR TITLE
[configuration] read config with absolute path

### DIFF
--- a/apicast/src/configuration_loader/file.lua
+++ b/apicast/src/configuration_loader/file.lua
@@ -3,18 +3,33 @@ local len = string.len
 local tostring = tostring
 local open = io.open
 local assert = assert
+local sub = string.sub
+local util = require 'util'
 
 local _M = {
   _VERSION = '0.1'
 }
+
+local pwd
 
 local function read(path)
   if not path or len(tostring(path)) == 0 then
     return nil, 'missing path'
   end
 
-  ngx.log(ngx.INFO, 'configuration loading file ' .. path)
-  return assert(open(path)):read('*a')
+  local relative_path = sub(path, 1, 1) ~= '/'
+  local absolute_path
+
+  if relative_path then
+    pwd = pwd or util.system('pwd')
+    absolute_path =  sub(pwd, 1, len(pwd) - 1) .. '/' .. path
+  else
+    absolute_path = path
+  end
+
+  ngx.log(ngx.INFO, 'configuration loading file ' .. absolute_path)
+
+  return assert(open(absolute_path)):read('*a'), absolute_path
 end
 
 function _M.call(path)

--- a/spec/configuration_loader/file_spec.lua
+++ b/spec/configuration_loader/file_spec.lua
@@ -10,5 +10,12 @@ describe('Configuration File loader', function()
     it('reads a file', function()
       assert.truthy(loader.call('fixtures/config.json'))
     end)
+
+    it('reads absolute path', function()
+      local pl_path = require('pl.path')
+      local _, path = loader.call('fixtures/config.json')
+
+      assert.match(pl_path.currentdir(), path)
+    end)
   end)
 end)


### PR DESCRIPTION
uses current working directory to create absolute path

I'm not sure if this is going to fix the inconsisecies. 
Definitely needs more testing.

@mayorova would be great if you could try if it fits your expectations. With some increased debug level it should always print the full path being loaded.