### PR TITLE
[doc] integrate tool to check broken links in the documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ luacov.*.out
 local/
 t/servroot/
 doc/api/
+node_modules

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,13 @@ clean: ## Remove all running docker containers
 
 doc: dependencies ## Generate documentation
 	ldoc -c doc/config.ld .
+
+node_modules/.bin/markdown-link-check:
+	npm install markdown-link-check
+
+test-doc: node_modules/.bin/markdown-link-check
+	@find . \( -name node_modules -o -name .git \) -prune -o -name "*.md" -print0 | xargs -0 -n1  -I % sh -c 'echo; echo ====================; echo Checking: %; node_modules/.bin/markdown-link-check  %' \;
+
 # Check http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help: ## Print this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The 3scale gateway image requires one of two environment variables. The first op
 * **THREESCALE_PORTAL_ENDPOINT**
 
 URI that includes your password and portal endpoint in following format: `schema://access-token@domain`. The password can be either the [provider key](https://support.3scale.net/docs/terminology#apikey) or an [access token](https://support.3scale.net/docs/terminology#tokens) for the 3scale Account Management API. Note: these should not be confused with [service tokens](https://support.3scale.net/docs/terminology#tokens)
-Example: https://ACCESS-TOKEN@ACCOUNT-admin.3scale.net (where the host name is the same as the domain for the URL when you are logged into the admin portal from a browser.
+Example: `https://ACCESS-TOKEN@ACCOUNT-admin.3scale.net` (where the host name is the same as the domain for the URL when you are logged into the admin portal from a browser.
 
 When `THREESCALE_PORTAL_ENDPOINT` environment variable is provided, the gateway will download the configuration from the 3scale on initializing. The configuration includes all the settings provided on the Integration page of the API(s).
 
@@ -45,7 +45,7 @@ docker run --name apicast --rm -p 8080:8080 -e THREESCALE_PORTAL_ENDPOINT=https:
 
 * **THREESCALE_CONFIG_FILE**
 
-Path to saved JSON file with configuration for the gateway. The configuration can be downloaded from the 3scale admin portal using the URL https://ACCOUNT-admin.3scale.net/admin/api/nginx/spec.json (replace `ACCOUNT` with your 3scale account name). The file has to be injected to the docker image as read only volume, and the path should indicate where the volume is mounted, i.e. path local to the docker container.
+Path to saved JSON file with configuration for the gateway. The configuration can be downloaded from the 3scale admin portal using the URL `https://ACCOUNT-admin.3scale.net/admin/api/nginx/spec.json` (replace `ACCOUNT` with your 3scale account name). The file has to be injected to the docker image as read only volume, and the path should indicate where the volume is mounted, i.e. path local to the docker container.
 
 ```shell
 docker run --name apicast --rm -p 8080:8080 -v $(pwd)/config.json:/opt/app/config.json:ro -e THREESCALE_CONFIG_FILE=/opt/app/config.json quay.io/3scale/apicast:v2


### PR DESCRIPTION
depends on https://github.com/tcort/link-check/pull/3 plus other fixes before it can be totally usable

here is current output (with some local monkeypatch to pass the base url):

```
====================
Checking: ./.github/CONTRIBUTING.md
[✖] ../t
[✖] ../schema.json
[✖] ../examples/configuration
[✖] ../examples/configuration/multiservice.json
[✓] https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md

ERROR: dead links found!

====================
Checking: ./.github/ISSUE_TEMPLATE.md

====================
Checking: ./doc/build.md
[✓] https://openresty.org/en/
[✓] https://docs.docker.com/engine/tutorials/dockerimages/
[✓] https://github.com/3scale/apicast/blob/50daf279b3cf2da80b20ad473ec820d7a364b688/apicast-0.1-0.rockspec
[✓] https://github.com/openshift/source-to-image
[✓] https://github.com/3scale/s2i-openresty
[✓] https://github.com/3scale/apicast/blob/bc8631fcf91fcab25cae84152e16536ce01d22be/Makefile#L31-L32
[✓] https://github.com/3scale/apicast/blob/bc8631fcf91fcab25cae84152e16536ce01d22be/Makefile#L34-L35
[✓] https://quay.io/repository/3scale/s2i-openresty-centos7?tag=latest
[✓] https://github.com/3scale/apicast/blob/bc8631fcf91fcab25cae84152e16536ce01d22be/.travis.yml#L51-L56
[✓] https://quay.io/repository/3scale/apicast?tab=tags&amp;tag=v2

====================
Checking: ./doc/centos-installation.md
[✓] https://openresty.org/en/linux-packages.html
[✓] https://openresty.org/en/rpm-packages.html
[✓] https://fedoraproject.org/wiki/EPEL
[✓] https://github.com/3scale/apicast
[✓] https://github.com/3scale/apicast/releases

====================
Checking: ./doc/configuration.md

====================
Checking: ./doc/management-api.md
[✖] ../examples/configuration/example-config.json
[✖] https://ACCOUNT-admin.3scale.net/admin/api/nginx/spec.json

ERROR: dead links found!

====================
Checking: ./doc/oauth-guide.md
[✓] https://tools.ietf.org/html/rfc6749#section-1.1
[✓] https://redis.io
[✓] https://tools.ietf.org/html/rfc6749#section-4.1.1
[✓] https://tools.ietf.org/html/rfc6749#section-4.1.2

====================
Checking: ./doc/openshift-guide.md
[✓] https://docs.openshift.com/container-platform/3.3/install_config/install/quick_install.html
[✓] https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md
[✓] https://www.openshift.org/vm
[✓] https://docs.docker.com/engine/installation/linux/
[✓] https://docs.docker.com/docker-for-mac/
[✓] https://docs.docker.com/docker-for-windows/
[✓] https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#macos-with-docker-for-mac
[✓] https://github.com/openshift/origin/blob/master/docs/cluster_up_down.md#windows-with-docker-for-windows
[✓] https://docs.docker.com/registry/insecure/
[✓] https://github.com/openshift/origin/releases
[✖] https://ec2-54-321-67-89.compute-1.amazonaws.com:8443
[✖] https://OPENSHIFT-SERVER-IP:8443/console/
[✓] https://docs.openshift.com/container-platform/3.3/dev_guide/deployments/deployment_strategies.html
[✖] #setup-openshift
[✓] https://docs.openshift.com/container-platform/3.3/welcome/index.html

ERROR: dead links found!

====================
Checking: ./doc/overview.md
[✓] https://github.com/3scale/apicast#tools-and-dependencies
[✓] https://github.com/3scale/apicast#docker
[✓] https://www.3scale.net/

====================
Checking: ./doc/why.md
[✓] http://search.cpan.org/~agent/Test-Nginx-0.25/lib/Test/Nginx/Socket.pm
[✓] https://olivinelabs.com/busted/

====================
Checking: ./examples/add-ssl/README.md
[✓] http://nginx.org/en/docs/http/ngx_http_core_module.html#server

====================
Checking: ./examples/custom-config/README.md

====================
Checking: ./examples/custom-module/README.md
[✖] https://github.com/3scale/apicast/blob/v2/apicast/src/apicast.lua
[✖] http://127.0.0.1:8081/?user_key=foo

ERROR: dead links found!

====================
Checking: ./examples/oauth2/README.md

====================
Checking: ./examples/s2i/README.md

====================
Checking: ./README.md
[✓] https://github.com/3scale/apicast/tree/master
[✓] doc/overview.md
[✓] http://www.3scale.net
[✓] https://support.3scale.net/docs/terminology#apikey
[✓] https://support.3scale.net/docs/terminology#tokens
[✓] schema.json
[✓] examples/configuration/example-config.json
[✓] examples/configuration/multiservice.json
[✓] doc/management-api.md
[✓] https://docs.docker.com/engine/reference/commandline/
[✓] http://openresty.org/en/
[✓] http://openresty.org/en/installation.html
[✓] https://luarocks.org/
[✓] https://github.com/keplerproject/luarocks/wiki/Download#installing
[✓] http://brew.sh/
[✓] http://olivinelabs.com/busted/
[✓] http://search.cpan.org/~agent/Test-Nginx-0.25/lib/Test/Nginx/Socket.pm
[✓] http://redis.io/
[✓] https://github.com/openshift/source-to-image
[✓] https://github.com/openshift/source-to-image/releases
[✓] .github/CONTRIBUTING.md
make: *** [test-doc] Error 1
```