### PR TITLE
fix X-3scale-Debug header by using Service Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Require openresty 1.11.2 [PR #194](https://github.com/3scale/apicast/pull/194)
 - moved development from `v2` branch to `master` [PR #209](https://github.com/3scale/apicast/pull/209)
+- `X-3scale-Debug` HTTP header now uses Service Token [PR #217](https://github.com/3scale/apicast/pull/217)
 
 ### Fixed
 

--- a/apicast/src/configuration.lua
+++ b/apicast/src/configuration.lua
@@ -270,8 +270,7 @@ function _M.new(configuration)
 
   return setmetatable({
     version = configuration.timestamp,
-    services = _M.filter_services(map(_M.parse_service, services)),
-    debug_header = configuration.provider_key -- TODO: change this to something secure
+    services = _M.filter_services(map(_M.parse_service, services))
   }, mt)
 end
 

--- a/apicast/src/provider.lua
+++ b/apicast/src/provider.lua
@@ -112,8 +112,8 @@ end
 local build_querystring = build_querystring_formatter("usage[%s]=%s")
 local build_query = build_querystring_formatter("%s=%s")
 
-local function get_debug_value()
-  return ngx.var.http_x_3scale_debug == _M.configuration.debug_header
+local function get_debug_value(service)
+  return ngx.var.http_x_3scale_debug == service.backend_authentication.value
 end
 
 local function find_service_strict(host)
@@ -362,7 +362,7 @@ function _M.access(service)
     return error_no_match(service)
   end
 
-  if get_debug_value() then
+  if get_debug_value(service) then
     ngx.header["X-3scale-matched-rules"] = matched_patterns
     ngx.header["X-3scale-credentials"]   = ngx.var.credentials
     ngx.header["X-3scale-usage"]         = ngx.var.usage

--- a/t/003-apicast.t
+++ b/t/003-apicast.t
@@ -231,26 +231,26 @@ Two services can exist together and are split by their hostname.
     require('configuration_loader').save({
       services = {
         {
-          id = 42,
+          id = 1,
           backend_version = 1,
+          backend_authentication_type = 'service_token',
+          backend_authentication_value = 'service-one',
           proxy = {
             api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/one/",
             hosts = { 'one' },
-            backend_authentication_type = 'service_token',
-            backend_authentication_value = 'service-one',
             proxy_rules = {
               { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1 }
             }
           }
         },
         {
-          id = 21,
+          id = 2,
           backend_version = 2,
+          backend_authentication_type = 'service_token',
+          backend_authentication_value = 'service-two',
           proxy = {
             api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/two/",
             hosts = { 'two' },
-            backend_authentication_type = 'service_token',
-            backend_authentication_value = 'service-two',
             proxy_rules = {
               { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
             }
@@ -266,7 +266,19 @@ Two services can exist together and are split by their hostname.
   set $backend_endpoint 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT';
 
   location /transactions/authrep.xml {
-    content_by_lua_block { ngx.exit(200) }
+    content_by_lua_block {
+      if ngx.var.arg_service_id == '1' then
+        if ngx.var.arg_service_token == 'service-one' then
+         return ngx.exit(200)
+       end
+     elseif ngx.var.arg_service_id == '2' then
+       if ngx.var.arg_service_token == 'service-two' then
+         return ngx.exit(200)
+       end
+     end
+
+     ngx.exit(403)
+    }
   }
 
   location ~ /api-backend(/.+) {
@@ -288,12 +300,14 @@ GET /t
 yay, api backend: /one/
 yay, api backend: /two/
 --- error_code: 200
+--- no_error_log
+[error]
 --- grep_error_log eval: qr/apicast cache (?:hit|miss|write) key: [^,\s]+/
 --- grep_error_log_out
-apicast cache miss key: 42:one-key:usage[hits]=1
-apicast cache write key: 42:one-key:usage[hits]=1
-apicast cache miss key: 21:two-id:two-key:usage[hits]=2
-apicast cache write key: 21:two-id:two-key:usage[hits]=2
+apicast cache miss key: 1:one-key:usage[hits]=1
+apicast cache write key: 1:one-key:usage[hits]=1
+apicast cache miss key: 2:two-id:two-key:usage[hits]=2
+apicast cache write key: 2:two-id:two-key:usage[hits]=2
 
 === TEST 7: mapping rule with fixed value is mandatory
 When mapping rule has a parameter with fixed value it has to be matched.


### PR DESCRIPTION
* fixes #180
* fixes #216

The Service Token is unique per service, so there is no global configuration needed.

@3scale/documentation @3scale/support I guess this might need some documentation update?