### PR TITLE
[configuration] fix duplicate host warning

### DIFF
--- a/apicast/src/configuration_store.lua
+++ b/apicast/src/configuration_store.lua
@@ -92,7 +92,7 @@ function _M.add(self, service)
     all[id] = service
     hosts[host] = index
 
-    if exists then
+    if exists and exists ~= id then
       ngx.log(ngx.WARN, 'host ', host, ' for service ', id, ' already defined by service ', exists)
     end
   end

--- a/t/003-apicast.t
+++ b/t/003-apicast.t
@@ -517,6 +517,7 @@ location /t {
       services = {
         { id = 1, proxy = { hosts = { 'foo', 'bar' } } },
         { id = 2, proxy = { hosts = { 'foo', 'daz' } } },
+        { id = 1, proxy = { hosts = { 'foo', 'fee' } } },
       }
     })
     ngx.say('all ok')
@@ -528,7 +529,8 @@ GET /t
 all ok
 --- log_level: warn
 --- error_code: 200
---- error_log
+--- grep_error_log eval: qr/host .+? for service .? already defined by service [^,\s]+/
+--- grep_error_log_out
 host foo for service 2 already defined by service 1
 
 === TEST 12: print message that service was added to the configuration


### PR DESCRIPTION
do not warn if the same service id defines the same host

this happens when configuration is being reloaded for example

> host api-2-3scale-staging.os.3sca.net for service 2 already defined by service 2