### PR TITLE
[echo] echo api prints requests to the debug log

### DIFF
--- a/apicast/conf.d/echo.conf
+++ b/apicast/conf.d/echo.conf
@@ -1,8 +1,13 @@
 set_by_lua_block $delay { return ngx.var.arg_delay or 0 }
+
 location / {
-      echo_duplicate 1 $echo_client_request_headers;
-      echo "\r";
-      echo_sleep $delay;
-      echo_read_request_body;
-      echo $request_body;
+    log_by_lua_block {
+      ngx.log(ngx.DEBUG, "[echo]:\n", ngx.req.raw_header())
+    }
+
+    echo_duplicate 1 $echo_client_request_headers;
+    echo "\r";
+    echo_sleep $delay;
+    echo_read_request_body;
+    echo $request_body;
 }

--- a/apicast/src/provider.lua
+++ b/apicast/src/provider.lua
@@ -341,9 +341,12 @@ function _M.access(service)
 
   ngx.var.secret_token = service.secret_token
 
-  local credentials = service:extract_credentials()
+  local credentials, err = service:extract_credentials()
 
-  if #credentials == 0 then
+  if not credentials or #credentials == 0 then
+    if err then
+      ngx.log(ngx.WARN, "cannot get credentials: ", err)
+    end
     return error_no_credentials(service)
   end
 

--- a/examples/configuration/echo.json
+++ b/examples/configuration/echo.json
@@ -1,0 +1,28 @@
+{
+  "services": [
+    {
+      "id": 1234,
+      "backend_version": 1,
+      "proxy": {
+        "api_backend": "http://127.0.0.1:8081",
+        "hostname_rewrite": "echo",
+        "hosts": [
+          "localhost",
+          "127.0.0.1"
+        ],
+        "backend": {
+          "endpoint": "http://127.0.0.1:8081",
+          "host": "echo"
+        },
+        "proxy_rules": [
+          {
+            "http_method": "GET",
+            "pattern": "/",
+            "metric_system_name": "hits",
+            "delta": 1
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
* on debug level, just look for `[echo]` in the log
* `echo.json` example, that sends backend to echo api too
* provider can handle invalid configuration (missing backend_version for example)


```shell
 bin/apicast -c examples/configuration/echo.json -v -v -v 2>&1 | grep '\[echo\]' -A 5
```

```shell
curl "http://localhost:8080/video?user_key=foobar"
```


```
2017/01/18 15:54:27 [debug] 38689#0: *9 [lua] log_by_lua(echo.conf:6):2: [echo]:
GET /transactions/authrep.xml?=&service_id=1234&usage[hits]=1&user_key=foobar HTTP/1.1
Host: echo
User-Agent: APIcast/3.0.0-pre (OSX; x64; env:unknown) APIcast/3.0.0-pre
X-3scale-User-Agent: APIcast/3.0.0-pre+unknown

```