### PR TITLE
[resty-env] introduce global environment object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 ### Changed
+- Cache all calls to `os.getenv` via custom module [PR #231](https://github.com/3scale/apicast/pull/231)
+
 ### Fixed
 ### Removed
 

--- a/apicast/src/apicast.lua
+++ b/apicast/src/apicast.lua
@@ -1,12 +1,11 @@
 local provider = require('provider')
 local balancer = require('balancer')
 local configuration_loader = require('configuration_loader')
-local util = require('util')
 local pcall = pcall
 local tonumber = tonumber
 local math = math
-local getenv = os.getenv
-local reload_config = util.env_enabled('APICAST_RELOAD_CONFIG')
+local env = require('resty.env')
+local reload_config = env.enabled('APICAST_RELOAD_CONFIG')
 local user_agent = require('user_agent')
 
 local _M = {
@@ -14,8 +13,8 @@ local _M = {
   _NAME = 'APIcast'
 }
 
-local missing_configuration = getenv('APICAST_MISSING_CONFIGURATION') or 'log'
-local request_logs = util.env_enabled('APICAST_REQUEST_LOGS')
+local missing_configuration = env.get('APICAST_MISSING_CONFIGURATION') or 'log'
+local request_logs = env.enabled('APICAST_REQUEST_LOGS')
 
 local function handle_missing_configuration(err)
   if missing_configuration == 'log' then
@@ -55,7 +54,7 @@ local function refresh_config()
 end
 
 function _M.init_worker()
-  local interval = tonumber(getenv('AUTO_UPDATE_INTERVAL'), 10) or 0
+  local interval = tonumber(env.get('AUTO_UPDATE_INTERVAL'), 10) or 0
 
   local function schedule(...)
     local ok, err = ngx.timer.at(...)

--- a/apicast/src/configuration.lua
+++ b/apicast/src/configuration.lua
@@ -21,6 +21,7 @@ local setmetatable = setmetatable
 local inspect = require 'inspect'
 local cjson = require 'cjson'
 local re = require 'ngx.re'
+local env = require 'resty.env'
 
 local mt = { __index = _M }
 
@@ -241,7 +242,7 @@ end
 
 function _M.services_limit()
   local services = {}
-  local subset = os.getenv('APICAST_SERVICES')
+  local subset = env.get('APICAST_SERVICES')
   if not subset or subset == '' then return services end
 
   local ids = re.split(subset, ',', 'oj')

--- a/apicast/src/configuration_loader/file.lua
+++ b/apicast/src/configuration_loader/file.lua
@@ -1,10 +1,10 @@
-local getenv = os.getenv
 local len = string.len
 local tostring = tostring
 local open = io.open
 local assert = assert
 local sub = string.sub
 local util = require 'util'
+local env = require 'resty.env'
 
 local _M = {
   _VERSION = '0.1'
@@ -33,7 +33,7 @@ local function read(path)
 end
 
 function _M.call(path)
-  local file = path or getenv('THREESCALE_CONFIG_FILE')
+  local file = path or env.get('THREESCALE_CONFIG_FILE')
 
   return read(file)
 end

--- a/apicast/src/configuration_loader/remote_v1.lua
+++ b/apicast/src/configuration_loader/remote_v1.lua
@@ -1,4 +1,3 @@
-local getenv = os.getenv
 local unpack = unpack
 local concat = table.concat
 local tostring = tostring
@@ -9,6 +8,7 @@ local http = require "resty.http"
 local configuration = require 'configuration'
 local util = require 'util'
 local user_agent = require 'user_agent'
+local env = require 'resty.env'
 
 local _M = {
   version = '0.1'
@@ -16,7 +16,7 @@ local _M = {
 
 
 function _M.call(host)
-  local endpoint = getenv('THREESCALE_PORTAL_ENDPOINT')
+  local endpoint = env.get('THREESCALE_PORTAL_ENDPOINT')
 
   return _M.wait(endpoint, 3) or _M.download(endpoint, host) or _M.curl(endpoint, host)
 end
@@ -136,7 +136,7 @@ function _M.curl(endpoint)
     return nil, err
   end
 
-  local timeout = getenv('CURL_TIMEOUT') or 3
+  local timeout = env.get('CURL_TIMEOUT') or 3
   local scheme, user, pass, host, port, path = unpack(url)
 
   if port then host = concat({host, port}, ':') end

--- a/apicast/src/configuration_loader/remote_v2.lua
+++ b/apicast/src/configuration_loader/remote_v2.lua
@@ -1,4 +1,3 @@
-local getenv = os.getenv
 local setmetatable = setmetatable
 local format = string.format
 local ipairs = ipairs
@@ -8,6 +7,7 @@ local resty_url = require 'resty.url'
 local http_ng = require "resty.http_ng"
 local user_agent = require 'user_agent'
 local cjson = require 'cjson'
+local resty_env = require 'resty.env'
 
 local _M = {
   _VERSION = '0.1'
@@ -17,7 +17,7 @@ local mt = {
 }
 
 function _M.new(url, options)
-  local endpoint = url or getenv('THREESCALE_PORTAL_ENDPOINT')
+  local endpoint = url or resty_env.get('THREESCALE_PORTAL_ENDPOINT')
   local opts = options or {}
 
   local http_client = http_ng.new{
@@ -46,7 +46,7 @@ function _M:call(environment)
     return nil, 'not initialized'
   end
 
-  local env = environment or getenv('THREESCALE_DEPLOYMENT_ENV')
+  local env = environment or resty_env.get('THREESCALE_DEPLOYMENT_ENV')
   if not env then
     return nil, 'missing environment'
   end

--- a/apicast/src/configuration_store.lua
+++ b/apicast/src/configuration_store.lua
@@ -6,11 +6,11 @@ local insert = table.insert
 local concat = table.concat
 local next = next
 
-local util = require 'util'
+local env = require 'resty.env'
 
 local _M = {
   _VERSION = '0.1',
-  path_routing = util.env_enabled('APICAST_PATH_ROUTING_ENABLED')
+  path_routing = env.enabled('APICAST_PATH_ROUTING_ENABLED')
 }
 
 local mt = { __index = _M }

--- a/apicast/src/module.lua
+++ b/apicast/src/module.lua
@@ -5,6 +5,8 @@ local dofile = dofile
 local pairs = pairs
 local type = type
 
+local env = require 'resty.env'
+
 local _M = {
   _VERSION = '0.1'
 }
@@ -12,7 +14,7 @@ local _M = {
 local mt = { __index = _M }
 
 function _M.new(name)
-  name = name or os.getenv('APICAST_MODULE') or 'apicast'
+  name = name or env.get('APICAST_MODULE') or 'apicast'
 
   ngx.log(ngx.DEBUG, 'init plugin ', name)
   return setmetatable({

--- a/apicast/src/provider.lua
+++ b/apicast/src/provider.lua
@@ -1,11 +1,11 @@
 local cjson = require 'cjson'
-local custom_config = os.getenv('APICAST_CUSTOM_CONFIG')
+local env = require 'resty.env'
+local custom_config = env.get('APICAST_CUSTOM_CONFIG')
 local configuration = require 'configuration'
 local configuration_store = require 'configuration_store'
 
 local inspect = require 'inspect'
 local oauth = require 'oauth'
-local util = require 'util'
 local resty_url = require 'resty.url'
 
 local type = type
@@ -24,8 +24,8 @@ local tonumber = tonumber
 local resty_resolver = require 'resty.resolver'
 local dns_resolver = require 'resty.resolver.dns'
 
-local response_codes = util.env_enabled('APICAST_RESPONSE_CODES')
-local request_logs = util.env_enabled('APICAST_REQUEST_LOGS')
+local response_codes = env.enabled('APICAST_RESPONSE_CODES')
+local request_logs = env.enabled('APICAST_REQUEST_LOGS')
 
 local _M = {
   -- FIXME: this is really bad idea, this file is shared across all requests,

--- a/apicast/src/resty/env.lua
+++ b/apicast/src/resty/env.lua
@@ -1,0 +1,39 @@
+local _M = {
+  _VERSION = '0.1',
+  env = {}
+}
+
+local getenv = os.getenv
+
+local function fetch(name)
+  local value = getenv(name)
+
+  _M.env[name] = value
+
+  return value
+end
+
+function _M.get(name)
+  return _M.env[name] or fetch(name)
+end
+
+local env_mapping = {
+  ['true'] = true,
+  ['false'] = false,
+  ['1'] = true,
+  ['0'] = false,
+  [''] = false
+}
+
+function _M.enabled(name)
+  return env_mapping[_M.get(name)]
+end
+
+function _M.set(name, value)
+  local env = _M.env
+  local previous = env[name]
+  env[name] = value
+  return previous
+end
+
+return _M

--- a/apicast/src/resty/env.lua
+++ b/apicast/src/resty/env.lua
@@ -1,6 +1,5 @@
 local _M = {
-  _VERSION = '0.1',
-  env = {}
+  _VERSION = '0.1'
 }
 
 local getenv = os.getenv
@@ -36,4 +35,9 @@ function _M.set(name, value)
   return previous
 end
 
-return _M
+function _M.reset()
+  _M.env = {}
+  return _M
+end
+
+return _M.reset()

--- a/apicast/src/threescale_utils.lua
+++ b/apicast/src/threescale_utils.lua
@@ -1,5 +1,6 @@
 
 local redis = require 'resty.redis'
+local env = require 'resty.env'
 
 local _M = {} -- public interface
 
@@ -88,8 +89,8 @@ function _M.required_params_present(f_req, actual)
 end
 
 function _M.connect_redis(host, port)
-  local h = host or os.getenv('REDIS_HOST') or "127.0.0.1"
-  local p = port or os.getenv('REDIS_PORT') or 6379
+  local h = host or env.get('REDIS_HOST') or "127.0.0.1"
+  local p = port or env.get('REDIS_PORT') or 6379
   local red = redis:new()
   local ok, err = red:connect(h, p)
   if not ok then

--- a/apicast/src/user_agent.lua
+++ b/apicast/src/user_agent.lua
@@ -1,5 +1,6 @@
 local ffi = require 'ffi'
 local module = require 'module'
+local env = require 'resty.env'
 
 local setmetatable = setmetatable
 
@@ -49,13 +50,13 @@ local mt = {
 }
 
 function _M.reset()
-  local env = {
-    threescale_deployment_env = os.getenv('THREESCALE_DEPLOYMENT_ENV')
+  local cache = {
+    threescale_deployment_env = env.get('THREESCALE_DEPLOYMENT_ENV')
   }
 
-  mt.__index = env
+  mt.__index = cache
 
-  _M.env = env
+  _M.env = cache
 
   mt.__call = _M.call
   mt.__tostring = _M.call

--- a/apicast/src/util.lua
+++ b/apicast/src/util.lua
@@ -9,7 +9,6 @@ local len = string.len
 local open = io.open
 local execute = os.execute
 local tmpname = os.tmpname
-local getenv = os.getenv
 local unpack = unpack
 
 function _M.timer(name, fun, ...)
@@ -19,20 +18,6 @@ function _M.timer(name, fun, ...)
   local time = ngx_now() - start
   ngx.log(ngx.INFO, 'benchmark ' .. name .. ' took ' .. time)
   return unpack(ret)
-end
-
-
-function _M.env_enabled(name)
-  local val = getenv(name)
-  local mapping = {
-    ['true'] = true,
-    ['false'] = false,
-    ['1'] = true,
-    ['0'] = false,
-    [''] = false
-  }
-
-  return mapping[val]
 end
 
 local function read(file)

--- a/spec/configuration_spec.lua
+++ b/spec/configuration_spec.lua
@@ -1,5 +1,6 @@
 local configuration = require 'configuration'
 local cjson = require 'cjson'
+local env = require 'resty.env'
 
 describe('Configuration object', function()
   describe('.parse', function()
@@ -77,7 +78,7 @@ describe('Configuration object', function()
     local services_limit = configuration.services_limit
 
     it('reads from environment', function()
-      stub(os, 'getenv').on_call_with('APICAST_SERVICES').returns('42,21')
+      env.set('APICAST_SERVICES', '42,21')
 
       local services = services_limit()
 
@@ -85,7 +86,7 @@ describe('Configuration object', function()
     end)
 
     it('reads from environment', function()
-      stub(os, 'getenv').on_call_with('APICAST_SERVICES').returns('')
+      env.set('APICAST_SERVICES', '')
 
       local services = services_limit()
 

--- a/spec/resty/env_spec.lua
+++ b/spec/resty/env_spec.lua
@@ -33,4 +33,14 @@ describe('env', function()
       assert.equal('val', _M.env.SOME_MISSING_KEY)
     end)
   end)
+
+  describe('.reset', function()
+    it('cleans the cache', function()
+      _M.env.SOMETHING_EMPTY = 'foo'
+
+      _M.reset()
+
+      assert.same(nil, _M.env.SOMETHING_EMPTY)
+    end)
+  end)
 end)

--- a/spec/resty/env_spec.lua
+++ b/spec/resty/env_spec.lua
@@ -1,0 +1,36 @@
+local _M = require 'resty.env'
+
+describe('env', function()
+  local env
+  before_each(function() env = _M.env end)
+  after_each(function() _M.env = env end)
+
+  describe('.get', function()
+
+    local path = os.getenv("PATH")
+
+    it('returns contents of the ENV variable', function()
+      assert.equal(path, _M.get('PATH'))
+    end)
+
+    it('caches the result', function()
+      _M.get('PATH')
+
+      assert.equal(path, _M.env.PATH)
+    end)
+
+    it('reads from the cache first', function()
+      _M.env = { ['SOME_MISSING_ENV_VAR'] = 'somevalue' }
+
+      assert.equal('somevalue', _M.get("SOME_MISSING_ENV_VAR"))
+    end)
+  end)
+
+  describe('.set', function()
+    it('saves value to the cache', function()
+      _M.set('SOME_MISSING_KEY', 'val')
+
+      assert.equal('val', _M.env.SOME_MISSING_KEY)
+    end)
+  end)
+end)

--- a/spec/spec_helper.lua
+++ b/spec/spec_helper.lua
@@ -3,3 +3,9 @@ require 'resty.lrucache'
 
 require 'ngx_helper'
 require 'luassert_helper'
+
+local busted = require('busted')
+local env = require('resty.env')
+
+busted.before_each(env.reset)
+busted.after_each(env.reset)

--- a/spec/user_agent_spec.lua
+++ b/spec/user_agent_spec.lua
@@ -1,12 +1,13 @@
 local user_agent = require 'user_agent'
 local ffi = require("ffi")
+local env = require 'resty.env'
 
 describe('3scale', function()
   before_each(function() user_agent.reset() end)
 
   describe('.deployment', function()
     it('reads from environment', function()
-      stub(os, 'getenv').on_call_with('THREESCALE_DEPLOYMENT_ENV').returns('foobar')
+      env.set('THREESCALE_DEPLOYMENT_ENV', 'foobar')
 
       user_agent.reset()
 


### PR DESCRIPTION
wraps current environment and caches calls to os.getenv

it is useful in tests to stub env and reset it on every test