### PR TITLE
use resty-resolver everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [OAuth] Return correct state value back to client
 
 ### Removed
+- Nginx resolver directive auto detection. Rely on internal DNS resolver [PR #237](https://github.com/3scale/apicast/pull/237)
 
 ## [3.0.0-alpha1] - 2017-01-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Cache all calls to `os.getenv` via custom module [PR #231](https://github.com/3scale/apicast/pull/231)
 - Bump s2i-openresty to 1.11.2.2-1 [PR #239](https://github.com/3scale/apicast/pull/239)
 - Use resty-resolver over nginx resolver for HTTP [PR #237](https://github.com/3scale/apicast/pull/237)
+- Use resty-resolver over nginx resolver for Redis [PR #237](https://github.com/3scale/apicast/pull/237)
 
 ### Fixed
 - [OAuth] Return correct state value back to client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Cache all calls to `os.getenv` via custom module [PR #231](https://github.com/3scale/apicast/pull/231)
 - Bump s2i-openresty to 1.11.2.2-1 [PR #239](https://github.com/3scale/apicast/pull/239)
+- Use resty-resolver over nginx resolver for HTTP [PR #237](https://github.com/3scale/apicast/pull/237)
 
 ### Fixed
 - [OAuth] Return correct state value back to client

--- a/apicast/.s2i/bin/assemble
+++ b/apicast/.s2i/bin/assemble
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-/usr/libexec/s2i/assemble
-
-chmod g+w /opt/app/http.d/resolver.conf

--- a/apicast/bin/entrypoint
+++ b/apicast/bin/entrypoint
@@ -17,34 +17,6 @@ if [ "${AUTO_UPDATE_INTERVAL}" != 0 ] && [ "${AUTO_UPDATE_INTERVAL}" -lt 60 ]; t
   exit 1
 fi
 
-pick_dns_server() {
-  DNS=$(grep nameserver /etc/resolv.conf | awk {'print $2'})
-
-  if [ -z "$DNS" ]; then
-    echo "127.0.0.1"
-  else
-    for server in $DNS; do
-      if (nslookup -timeout=1 -retry=3 redhat.com "$server" &> /dev/null); then
-        echo "$server"
-	 exit 0
-      fi
-    done
-
-    (>&2 echo "error: no working DNS server found")
-    exit 1
-  fi
-}
-
-
-export NAMESERVER
-
-NAMESERVER=$(pick_dns_server)
-
-export RESOLVER=${RESOLVER:-${NAMESERVER}}
-
-mkdir -pv "$(pwd)/http.d"
-echo "resolver ${RESOLVER};" > "$(pwd)/http.d/resolver.conf"
-
 THREESCALE_PORTAL_ENDPOINT="${THREESCALE_PORTAL_ENDPOINT:-}"
 THREESCALE_CONFIG_FILE="${THREESCALE_CONFIG_FILE:-}"
 

--- a/apicast/http.d/resolver.conf
+++ b/apicast/http.d/resolver.conf
@@ -1,1 +1,0 @@
-resolver 127.0.0.1 ipv6=off;

--- a/apicast/src/configuration_loader/remote_v1.lua
+++ b/apicast/src/configuration_loader/remote_v1.lua
@@ -4,7 +4,7 @@ local tostring = tostring
 local len = string.len
 
 local resty_url = require 'resty.url'
-local http = require "resty.http"
+local http = require "resty.resolver.http"
 local configuration_parser = require 'configuration_parser'
 local util = require 'util'
 local user_agent = require 'user_agent'

--- a/apicast/src/resty/http_ng/backend/async_resty.lua
+++ b/apicast/src/resty/http_ng/backend/async_resty.lua
@@ -13,7 +13,7 @@ local spawn = ngx.thread.spawn
 local _M = {}
 
 local response = require 'resty.http_ng.response'
-local http = require 'resty.http'
+local http = require 'resty.resolver.http'
 
 _M.async = function(req)
   local httpc = http.new()

--- a/apicast/src/resty/http_ng/backend/resty.lua
+++ b/apicast/src/resty/http_ng/backend/resty.lua
@@ -1,6 +1,6 @@
 local backend = {}
 local response = require 'resty.http_ng.response'
-local http = require 'resty.http'
+local http = require 'resty.resolver.http'
 
 backend.send = function(request)
   local httpc = http.new()

--- a/apicast/src/resty/resolver/http.lua
+++ b/apicast/src/resty/resolver/http.lua
@@ -1,0 +1,48 @@
+local resty_http = require 'resty.http'
+local dns_resolver = require 'resty.resolver.dns'
+local resty_resolver = require 'resty.resolver'
+local round_robin = require 'resty.balancer.round_robin'
+
+local setmetatable = setmetatable
+local unpack = unpack
+
+local _M = setmetatable({}, { __index = resty_http })
+
+local mt = { __index = _M }
+
+function _M.new()
+  local http = resty_http:new()
+  local dns = dns_resolver:new{ nameservers = resty_resolver.nameservers() }
+
+  http.resolver = resty_resolver.new(dns)
+  http.balancer = round_robin.new()
+
+  return setmetatable(http, mt)
+end
+
+function _M.connect(self, host, port)
+  local resolver = self.resolver
+  local balancer = self.balancer
+
+  if not resolver or not balancer then
+    return nil, 'not initialized'
+  end
+
+  local servers = resolver:get_servers(host, { port = port })
+  local peers = balancer:peers(servers)
+  local peer = balancer:select_peer(peers)
+
+  local ip = host
+
+  if peer then
+    ip, port = unpack(peer)
+  end
+
+  local ok, err = resty_http.connect(self, ip, port)
+
+  self.host = host
+
+  return ok, err
+end
+
+return _M

--- a/spec/resty/resolver/http_spec.lua
+++ b/spec/resty/resolver/http_spec.lua
@@ -1,0 +1,23 @@
+local _M = require 'resty.resolver.http'
+
+describe('resty.resolver.http', function()
+
+  describe('.new', function()
+    it('initializes client', function()
+      local client = _M.new()
+
+      assert.truthy(client)
+    end)
+  end)
+
+  describe(':connect', function()
+    it('resolves localhost', function()
+      local client = _M.new()
+      client.resolver.cache:save({ { address = '127.0.0.1', name = 'unknown', ttl = 1800 } })
+      assert(client:connect('unknown', 1984))
+      assert.equal('unknown', client.host)
+      assert.equal(1984, client.port)
+    end)
+  end)
+
+end)


### PR DESCRIPTION
closes #236
depends on https://github.com/3scale/s2i-openresty/pull/16

- [x] resty-http
- [x] resty-redis

This totally removes nginx `resolver` directive and fully relies on our internal DNS resolver.
Setting `RESOLVER`  env variable still works. Default servers are auto detected from `/etc/resolv.conf` on boot. Works everywhere (native/docker/openshift).


/cc @mayorova @mpguerra 


/cc @davidor this might be something XC will need on OpenShift to properly resolve redis via a Service. 