### PR TITLE
[make] wait for gateway to start when testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,7 @@ test-builder-image: builder-image clean ## Smoke test the builder image. Pass an
 	@echo -e $(SEPARATOR)
 	$(DOCKER_COMPOSE) run --rm --user 100001 gateway bin/entrypoint -d
 	@echo -e $(SEPARATOR)
-	$(DOCKER_COMPOSE) run --rm test bash -c '(bin/entrypoint -d 2>&1 || :) | grep "error: no working DNS server found"'
-	@echo -e $(SEPARATOR)
-	$(DOCKER_COMPOSE) run --rm test curl --fail http://gateway:8090/status/live
+	$(DOCKER_COMPOSE) run --rm test bash -c 'for i in {1..5}; do curl --fail http://gateway:8090/status/live && break || sleep 1; done'
 	@echo -e $(SEPARATOR)
 	$(DOCKER_COMPOSE) run --rm test curl --fail -X PUT http://gateway:8090/config --data '{"services":[{"id":42}]}'
 	@echo -e $(SEPARATOR)


### PR DESCRIPTION
sometimes it would return `connection refused`
because the gateway haven't started yet