### PR TITLE
Fix path routing and refactoring

### DIFF
--- a/apicast/src/apicast.lua
+++ b/apicast/src/apicast.lua
@@ -118,7 +118,7 @@ end
 
 function _M:access()
   local p = self.proxy
-  local fun = p:call()
+  local fun = p:call() -- proxy:access() or oauth handler
   return fun()
 end
 

--- a/apicast/src/configuration_store.lua
+++ b/apicast/src/configuration_store.lua
@@ -36,7 +36,28 @@ function _M.all(self)
   return services
 end
 
-function _M.find(self, host)
+function _M.find_by_id(self, service_id)
+  local all = self.services
+
+  if not all then
+    return nil, 'not initialized'
+  end
+
+  if service_id then
+    return all[service_id]
+  end
+  return nil
+end
+
+function _M.find_by_host(self, host)
+  local hosts = self.hosts
+  if not hosts then
+    return nil, 'not initialized'
+  end
+  return hosts[host] or { }
+end
+
+function _M.find(self, host_or_id)
   local hosts = self.hosts
   local all = self.services
 
@@ -44,13 +65,12 @@ function _M.find(self, host)
     return nil, 'not initialized'
   end
 
-  local exact_match = all[host]
-
+  local exact_match = all[host_or_id]
   if exact_match then
     return { exact_match }
   end
 
-  return hosts[host] or { }
+  return hosts[host_or_id] or { }
 end
 
 function _M.store(self, config)

--- a/apicast/src/proxy.lua
+++ b/apicast/src/proxy.lua
@@ -438,7 +438,7 @@ function _M:post_action()
   if cached_key and cached_key ~= "null" then
     ngx.log(ngx.INFO, '[async] reporting to backend asynchronously, cached_key: ', cached_key)
 
-    local service_id = tonumber(ngx.var.service_id, 10)
+    local service_id = ngx.var.service_id
     local service = ngx.ctx.service or self.configuration:find_by_id(service_id)
     self:set_backend_upstream(service)
 

--- a/apicast/src/proxy.lua
+++ b/apicast/src/proxy.lua
@@ -166,7 +166,7 @@ local function find_service_cascade(self, host)
     end
   end
 
-  return find_service_strict(host)
+  return find_service_strict(self, host)
 end
 
 if configuration_store.path_routing then

--- a/apicast/src/proxy.lua
+++ b/apicast/src/proxy.lua
@@ -267,7 +267,6 @@ function _M.set_service(host)
 
   ngx.ctx.service = service
   ngx.var.service_id = service.id
-
   return service
 end
 
@@ -321,15 +320,6 @@ function _M:set_backend_upstream(service)
 
   ngx.var.backend_endpoint = scheme .. '://backend_upstream' .. path
 
-  if service.backend_version == 'oauth' then
-    local f, params = oauth.call()
-
-    if f then
-      ngx.log(ngx.DEBUG, 'apicast oauth flow')
-      return function() return f(params) end
-    end
-  end
-
 end
 
 function _M:call(host)
@@ -351,11 +341,9 @@ function _M:call(host)
     -- call access phase
     return self:access(service)
   end
-
 end
 
 function _M:access(service)
-
   local backend_version = service.backend_version
   local usage
   local matched_patterns

--- a/apicast/src/proxy.lua
+++ b/apicast/src/proxy.lua
@@ -266,7 +266,7 @@ function _M.set_service(host)
   end
 
   ngx.ctx.service = service
-  ngx.var.service_id = tostring(service.id)
+  ngx.var.service_id = service.id
 
   return service
 end

--- a/apicast/src/proxy.lua
+++ b/apicast/src/proxy.lua
@@ -136,10 +136,6 @@ end
 
 local function find_service_strict(self, host)
   for _,service in pairs(self.configuration:find_by_host(host)) do
-    if service.id == host then
-      return service
-    end
-
     for _,_host in ipairs(service.hosts or {}) do
       if _host == host then
         return service

--- a/spec/configuration_store_spec.lua
+++ b/spec/configuration_store_spec.lua
@@ -33,6 +33,47 @@ describe('Configuration Store', function()
     end)
   end)
 
+  describe('.find_by_id', function()
+    it('finds service by id', function()
+      local store = configuration.new()
+      local service = { 'service' }
+
+      store.services['42'] = service
+
+      assert.same({ service }, store:find('42'))
+    end)
+    it('it does not seach by host', function()
+      local store = configuration.new()
+      local service =  { 'service' }
+
+      store.services['42'] = service
+      store.hosts['example.com'] = { ['42'] = service }
+
+      assert.is_nil(store:find_by_id('example.com'))
+    end)
+  end)
+
+  describe('.find_by_host', function()
+    it('returns stored services by host', function()
+      local store = configuration.new()
+      local service =  { 'service' }
+
+      store.hosts['example.com'] = { ['42'] = service }
+
+      assert.same({ ['42'] = service }, store:find('example.com'))
+    end)
+
+    it('does not search by id', function()
+      local store = configuration.new()
+      local service = { 'service' }
+
+      store.hosts['example.com'] = { ['42'] = service }
+      store.services['42'] = service
+
+      assert.same({}, store:find_by_host('42'))
+    end)
+  end)
+
   describe('.reset', function()
     local store
 

--- a/t/003-apicast.t
+++ b/t/003-apicast.t
@@ -50,6 +50,7 @@ The message is configurable and status also.
     require('configuration_loader').save({
       services = {
         {
+          id = 42,
           backend_version = 1,
           proxy = {
             error_no_match = 'no mapping rules!',


### PR DESCRIPTION
Refactoring and fixes:

- fixes #254 
- extract `set_backend_upstream` to a separate function
- distinguish `find_by_id` and `find_by_host` functions in configuration store and `find_service_strict` (treating both under the name 'host' is quite confusing)
- skip searching for the service in the post_action, and get it directly from the configuration by id (in APICAST_PATH_ROUTING_ENABLED mode iterating over all rules in `find_service_cascade` was useless)
- pass service as parameters to reduce getting value from `ngx.ctx`

Based on `performance-optimizations` branch to avoid future conflicts.