### PR TITLE
[remote_v2] return configuration for all available services

### DIFF
--- a/apicast/src/configuration_loader/remote_v2.lua
+++ b/apicast/src/configuration_loader/remote_v2.lua
@@ -65,7 +65,7 @@ function _M:call(environment)
     if config then
       insert(configs, config)
     else
-      return nil, err
+      ngx.log(ngx.INFO, 'could not get configuration for service ', object.service.id, ': ', err)
     end
   end
 

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -113,7 +113,7 @@ describe('Configuration Rmote Loader V2', function()
       assert.equal('invalid status', err)
     end)
 
-    it('does not crash on error when getting config', function()
+    it('returns configuration even when some services are missing', function()
       test_backend.expect{ url = 'http://example.com/admin/api/services.json' }.
         respond_with{ status = 200, body = cjson.encode({ services = {
             { service = { id = 1 }},
@@ -133,10 +133,12 @@ describe('Configuration Rmote Loader V2', function()
       test_backend.expect{ url = 'http://example.com/admin/api/services/2/proxy/configs/staging/latest.json' }.
         respond_with{ status = 404 }
 
-      local config, err = loader:call('staging')
+      local config = assert(loader:call('staging'))
 
-      assert.falsy(config)
-      assert.equal('invalid status', err)
+      assert.truthy(config)
+      assert.equals('string', type(config))
+
+      assert.equals(1, #(cjson.decode(config).services))
     end)
   end)
 


### PR DESCRIPTION
don't return error status when some services fail, because
they don't have to have working configuration

fixes https://issues.jboss.org/browse/THREESCALE-63