### PR TITLE
performance tuning

### DIFF
--- a/.env
+++ b/.env
@@ -31,3 +31,6 @@ REDIS_HOST=redis
 
 # Override backend endpoint in the config globally.
 # BACKEND_ENDPOINT_OVERRIDE=https://backend.example.com
+
+# Set number of worker processes.
+# APICAST_WORKERS=2

--- a/apicast/bin/apicast
+++ b/apicast/bin/apicast
@@ -46,6 +46,7 @@ log_level="${!log}"
 mkdir -p "${apicast_dir}/logs"
 
 daemon=off
+worker_processes=${APICAST_WORKERS:-1}
 
 usage () {
 	cat <<-USAGE
@@ -87,7 +88,7 @@ while getopts ":dc:hvqi:rw:m:s:p:" opt; do
       export AUTO_UPDATE_INTERVAL="${OPTARG}"
     ;;
     w)
-      main+=("worker_processes ${OPTARG};")
+      worker_processes=${OPTARG}
     ;;
     m)
       main+=("master_process ${OPTARG};")
@@ -112,6 +113,7 @@ while getopts ":dc:hvqi:rw:m:s:p:" opt; do
 done
 
 main+=("daemon ${daemon};")
+main+=("worker_processes ${worker_processes};")
 
 function join_by { local IFS="$1"; shift; echo "$*"; }
 args=$(join_by '' "${args[@]}")

--- a/apicast/conf/nginx.conf
+++ b/apicast/conf/nginx.conf
@@ -19,11 +19,9 @@ env BACKEND_ENDPOINT_OVERRIDE;
 error_log /dev/null emerg;
 
 events {
-  worker_connections  8096;
+  worker_connections  16192;
   multi_accept        on;
 }
-
-worker_rlimit_nofile 40000;
 
 http {
   sendfile           on;

--- a/apicast/http.d/upstream.conf
+++ b/apicast/http.d/upstream.conf
@@ -4,7 +4,7 @@ upstream upstream {
 
   balancer_by_lua_block { require('module'):balancer() }
 
-  keepalive 32;
+  keepalive 1024;
 }
 
 upstream backend_upstream {
@@ -12,5 +12,5 @@ upstream backend_upstream {
 
   balancer_by_lua_block { require('module'):balancer() }
 
-  keepalive 32;
+  keepalive 1024;
 }


### PR DESCRIPTION
* keep more connections opened
* allow configuring workers via env variable

we were able to pus through up to 5k requests per second