### PR TITLE
[config] use LRU cache for configuration store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,10 @@ script:
 - make busted
 - make prove
 - make builder-image
-- make test-builder-image
-- make prove-docker
+- make test-builder-image gateway-logs --keep-going
+- make prove-docker 
 - make runtime-image
-- make test-runtime-image
+- make test-runtime-image gateway-logs --keep-going
 - make doc
 - make test-doc
 - make danger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Always use DNS search scopes [PR #271](https://github.com/3scale/apicast/pull/271)
 - Reduce use of global objects [PR #273](https://github.com/3scale/apicast/pull/273)
 - Load V2 configuration for all services in parallel [PR #272](https://github.com/3scale/apicast/pull/272)
+- Configuration is using LRU cache [PR #274](https://github.com/3scale/apicast/pull/274)
 
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,10 @@ test-builder-image: builder-image clean-containers ## Smoke test the builder ima
 	$(DOCKER_COMPOSE) run --rm test curl --fail -X POST http://gateway:8090/boot
 	@echo -e $(SEPARATOR)
 	$(DOCKER_COMPOSE) run --rm -e THREESCALE_PORTAL_ENDPOINT=https://echo-api.3scale.net gateway /opt/app/libexec/boot | grep 'APIcast/'
-	@echo -e $(SEPARATOR)
+
+gateway-logs: export IMAGE_NAME = does-not-matter
+gateway-logs:
+	$(DOCKER_COMPOSE) logs gateway
 
 test-runtime-image: export IMAGE_NAME = apicast-runtime-test
 test-runtime-image: clean-containers ## Smoke test the runtime image. Pass any docker image in IMAGE_NAME parameter.

--- a/apicast/conf/nginx.conf
+++ b/apicast/conf/nginx.conf
@@ -52,7 +52,14 @@ http {
     require("resty.core")
     require('resty.resolver').init()
 
-    require('module'):init()
+    local module, err = require('module')
+
+    if not module then
+      ngx.log(ngx.EMERG, 'fatal error when loading the root module')
+      os.exit(1)
+    end
+
+    module:init()
 
     collectgarbage("collect")
   }

--- a/apicast/src/configuration_store.lua
+++ b/apicast/src/configuration_store.lua
@@ -5,27 +5,29 @@ local concat = table.concat
 local rawset = rawset
 
 local env = require 'resty.env'
+local lrucache = require 'resty.lrucache'
 
 local _M = {
   _VERSION = '0.1',
-  path_routing = env.enabled('APICAST_PATH_ROUTING_ENABLED')
+  path_routing = env.enabled('APICAST_PATH_ROUTING_ENABLED'),
+  cache_size = 1000
 }
 
 local mt = { __index = _M }
 
-function _M.new()
+function _M.new(cache_size)
   return setmetatable({
     -- services hashed by id, example: {
     --   ["16"] = service1
     -- }
-    services = {},
+    services = lrucache.new(cache_size or _M.cache_size),
 
     -- hash of hosts pointing to services, example: {
     --  ["host.example.com"] = {
     --    { service1 },
     --    { service2 }
     --  }
-    cache = {}
+    cache = lrucache.new(cache_size or _M.cache_size)
 
   }, mt)
 end
@@ -38,8 +40,8 @@ function _M.all(self)
     return nil, 'not initialized'
   end
 
-  for _,service in pairs(all) do
-    insert(services, service.serializable or service)
+  for _,v in pairs(all.hasht) do
+    insert(services, v.serializable or v)
   end
 
   return services
@@ -52,7 +54,7 @@ function _M.find_by_id(self, service_id)
     return nil, 'not initialized'
   end
 
-  return all[service_id]
+  return all:get(service_id)
 end
 
 function _M.find_by_host(self, host)
@@ -61,7 +63,7 @@ function _M.find_by_host(self, host)
     return nil, 'not initialized'
   end
 
-  return cache[host] or { }
+  return cache:get(host) or { }
 end
 
 local hashed_array = {
@@ -72,47 +74,54 @@ local hashed_array = {
   end
 }
 
-function _M.store(self, config)
+function _M.store(self, config, ttl)
   self.configured = true
 
   local services = config.services
   local by_host = setmetatable({}, hashed_array)
 
+  local ids = {}
+
   for i=1, #services do
     local hosts = services[i].hosts or {}
     local id = services[i].id
 
-    ngx.log(ngx.INFO, 'added service ', id, ' configuration with hosts: ', concat(hosts, ', '))
+    if not ids[id] then
+      ngx.log(ngx.INFO, 'added service ', id, ' configuration with hosts: ', concat(hosts, ', '))
 
-    for j=1, #hosts do
-      local h = by_host[hosts[j]]
+      for j=1, #hosts do
+        local h = by_host[hosts[j]]
 
-      if #(h) == 0 or _M.path_routing then
-        insert(h, services[i])
-      else
-        ngx.log(ngx.WARN, 'skipping host ', hosts[j], ' for service ', id, ' already defined by service ', h[1].id)
+        if #(h) == 0 or _M.path_routing then
+          insert(h, services[i])
+        else
+          ngx.log(ngx.WARN, 'skipping host ', hosts[j], ' for service ', id, ' already defined by service ', h[1].id)
+        end
       end
-    end
 
-    self.services[id] = services[i]
+      self.services:set(id, services[i]) -- FIXME: no ttl here, is that correct assumption?
+      ids[id] = services[i]
+    else
+      ngx.log(ngx.WARN, 'skipping service ', id, ' becasue it is a duplicate')
+    end
   end
 
   local cache = self.cache
 
-  for host, services in pairs(by_host) do
-    cache[host] = services
+  for host, services_for_host in pairs(by_host) do
+    cache:set(host, services_for_host, config.ttl or ttl or _M.ttl)
   end
 
   return config
 end
 
-function _M.reset(self)
+function _M.reset(self, cache_size)
   if not self then
     return nil, 'not initialized'
   end
 
-  self.services = {}
-  self.cache = {}
+  self.services = lrucache.new(cache_size or _M.cache_size)
+  self.cache = lrucache.new(cache_size or _M.cache_size)
   self.configured = false
 end
 

--- a/apicast/src/proxy.lua
+++ b/apicast/src/proxy.lua
@@ -64,7 +64,7 @@ function _M:configured(host)
 
   local hosts = configuration:find_by_host(host)
 
-  return next(hosts) and true
+  return #(hosts) > 0
 end
 
 -- Error Codes

--- a/spec/configuration_store_spec.lua
+++ b/spec/configuration_store_spec.lua
@@ -16,17 +16,17 @@ describe('Configuration Store', function()
   describe('.find_by_id', function()
     it('finds service by id', function()
       local store = configuration.new()
-      local service = { 'service' }
+      local service = { id = '42' }
 
-      store.services['42'] = service
+      store:add(service)
 
       assert.same(service, store:find_by_id('42'))
     end)
     it('it does not seach by host', function()
       local store = configuration.new()
-      local service =  { 'service' }
+      local service = { id = '42', hosts = { 'example.com' } }
 
-      store.services['42'] = service
+      store:add(service)
 
       assert.is_nil(store:find_by_id('example.com'))
     end)
@@ -104,9 +104,10 @@ describe('Configuration Store', function()
     it('returns all services', function()
       local store = configuration.new()
 
-      store.services['42'] = { 'service' }
+      local service = { id = '42' }
+      store:add(service)
 
-      assert.same({{'service'}}, store:all())
+      assert.same({ service }, store:all())
     end)
   end)
 end)

--- a/spec/configuration_store_spec.lua
+++ b/spec/configuration_store_spec.lua
@@ -9,21 +9,7 @@ describe('Configuration Store', function()
 
       store:store({services = { service }})
 
-      assert.truthy(store.hosts['example.com']['42'])
-    end)
-  end)
-
-  describe('.add', function()
-    it('stores cached touples of services', function()
-      local store = configuration.new()
-      local service1 =  { id = '1', hosts = { 'localhost' } }
-      local service2 = { id = '2', hosts = { 'localhost' } }
-
-      store:add(service1)
-      store:add(service2)
-
-
-      assert.same({ service1, service2 }, store.cache.localhost)
+      assert.equal(service, store:find_by_id('42'))
     end)
   end)
 
@@ -41,7 +27,6 @@ describe('Configuration Store', function()
       local service =  { 'service' }
 
       store.services['42'] = service
-      store.hosts['example.com'] = { ['42'] = service }
 
       assert.is_nil(store:find_by_id('example.com'))
     end)
@@ -91,11 +76,11 @@ describe('Configuration Store', function()
     end)
 
     it('deletes stored hosts', function()
-      store.hosts['example.com'] = { ['42'] = { } }
+      store.cache['example.com'] = { { '42'} }
 
       store:reset()
 
-      assert.equal(0, #store.hosts)
+      assert.equal(0, #store.cache)
     end)
 
     it('deletes all services', function()

--- a/spec/module_spec.lua
+++ b/spec/module_spec.lua
@@ -27,8 +27,10 @@ describe('module', function()
 
     it('defaults to apicast', function()
       local apicast = require('apicast')
+      local module = require('module')
 
-      assert.same(apicast.new(), require('module'))
+      assert.truthy(module._NAME)
+      assert.same(apicast._NAME, module._NAME)
     end)
   end)
 end)


### PR DESCRIPTION
* prevent memory leaks with long running instances
* offers TTL

The important change here is when new configuration is loaded it overrides all existing configuration for those hosts. 

When path routing is not enabled nothing really happens as there can be just one service for each host.
But when path routing is enabled and first you load two services for host 'a' and next time just one service for host 'a' it removes the first service. Which is more correct.