### PR TITLE
[doc] management api is for debugging only

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -8,7 +8,7 @@ warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"
 # Warn when there is a big PR
 warn("Big PR") if git.lines_of_code > 500
 
-has_app_changes = git.modified_files.grep(%{apicast/})
+has_app_changes = git.modified_files.grep(%{apicast/}).any?
 markdown_files = git.modified_files.grep(/\.md$/)
 
 if !git.modified_files.include?("CHANGELOG.md") && has_app_changes
@@ -20,5 +20,8 @@ ENV['LANG'] = 'en_US.utf8'
 prose.lint_files markdown_files - %w(CHANGELOG.md)
 
 # Look for spelling issues
-prose.ignored_words = %w(s2i openresty APIcast nameservers resty-resolver nginx Redis OAuth ENV backend 3scale OpenShift Default Lua)
+prose.ignored_words = %w(
+  s2i openresty APIcast nameservers resty-resolver nginx Redis OAuth ENV backend 3scale OpenShift Default Lua
+  hostname LRU cosocket TODO lua-resty-lrucache
+)
 prose.check_spelling markdown_files - %w(CHANGELOG.md)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -2,7 +2,7 @@
 
 Gateway needs configuation in order to work. It needs it to determine service configuration, hostname, etc.
 
-Gateway can load the configuration from file, API or write it through management API.
+Gateway can load the configuration from file, API or write it through management API (for debugging purposes).
 
 ## Configuration loading
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,6 +1,6 @@
 # Configuration and its persistence
 
-Gateway needs configuation in order to work. It needs it to determine service configuration, hostname, etc.
+Gateway needs configuration in order to work. It needs it to determine service configuration, hostname, etc.
 
 Gateway can load the configuration from file, API or write it through management API (for debugging purposes).
 

--- a/doc/management-api.md
+++ b/doc/management-api.md
@@ -2,6 +2,8 @@
 
 Management API is a simple API that allows updating or retrieving the configuration currently used by the gateway. The API is available on port `8090`.
 
+This is mean to be used for **debugging purposes only**. Offers no authentication or synchronization between several instances.
+
 Available endpoints:
 
 - `GET /config`


### PR DESCRIPTION
Management API is for debugging only and should be marked as such.

https://issues.jboss.org/browse/THREESCALE-71