### PR TITLE
Revert "[config] parallelize access to the v2 api"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Echo API on port 8081 listens accepts any Host [PR #268](https://github.com/3scale/apicast/pull/268)
 - Always use DNS search scopes [PR #271](https://github.com/3scale/apicast/pull/271)
 - Reduce use of global objects [PR #273](https://github.com/3scale/apicast/pull/273)
-- Load V2 configuration for all services in parallel [PR #272](https://github.com/3scale/apicast/pull/272)
 - Configuration is using LRU cache [PR #274](https://github.com/3scale/apicast/pull/274)
 - Management API not opened by default [PR #276](https://github.com/3scale/apicast/pull/276)
 - Management API returns ready status with no services [PR #]()

--- a/apicast/src/configuration_loader/remote_v2.lua
+++ b/apicast/src/configuration_loader/remote_v2.lua
@@ -58,19 +58,19 @@ function _M:call(environment)
     return nil, err
   end
 
+  local config
   for _, object in ipairs(res) do
-    insert(configs, ngx.thread.spawn(self.config, self, object.service, env, 'latest'))
+    config, err = self:config(object.service, env, 'latest')
+
+    if config then
+      insert(configs, config)
+    else
+      ngx.log(ngx.INFO, 'could not get configuration for service ', object.service.id, ': ', err)
+    end
   end
 
   for i, c in ipairs(configs) do
-    local ok, ret = ngx.thread.wait(c)
-
-    if ok then
-      configs[i] = ret and ret.content or nil
-    else
-      configs[i] = nil
-      ngx.log(ngx.WARN, 'failed to download configuration: ', ret)
-    end
+    configs[i] = c.content
   end
 
   return cjson.encode({ services = configs })
@@ -113,12 +113,9 @@ function _M:config(service, environment, version)
 
   local url = resty_url.join(self.endpoint, '/admin/api/services/', id , '/proxy/configs/', environment, '/', format('%s.json', version))
 
-  ngx.log(ngx.INFO, 'downloading configuration from: ', url)
-
   local res, err = http_client.get(url)
 
   if not res and err then
-    ngx.log(ngx.WARN, 'could not get configuration for service ', id, ': ', err)
     return nil, err
   end
 
@@ -127,7 +124,6 @@ function _M:config(service, environment, version)
 
     return json.proxy_config
   else
-    ngx.log(ngx.WARN, 'could not get configuration for service ', id, ': status ', res.status, ' != 200')
     return nil, 'invalid status'
   end
 end


### PR DESCRIPTION
This reverts commit 7281c82f48079d1a1759ba0295c2de9c609220a6.

Because our http client is not thread safe yet.
So accessing it from several threads will result in undefined behaviour.
This is limitation of underlying lua-resty-http.