### PR TITLE
fix not reloading configuration

### DIFF
--- a/apicast/src/configuration_store.lua
+++ b/apicast/src/configuration_store.lua
@@ -57,15 +57,19 @@ function _M.find_by_id(self, service_id)
   return all:get(service_id)
 end
 
-function _M.find_by_host(self, host)
+function _M.find_by_host(self, host, stale)
   local cache = self.cache
   if not cache then
     return nil, 'not initialized'
   end
 
-  local services, stale = cache:get(host)
+  if stale == nil then
+    stale = true
+  end
 
-  return services or stale or { }
+  local services, expired = cache:get(host)
+
+  return services or (stale and expired) or { }
 end
 
 local hashed_array = {

--- a/apicast/src/proxy.lua
+++ b/apicast/src/proxy.lua
@@ -63,7 +63,7 @@ function _M:configured(host)
   local configuration = self.configuration
   if not configuration or not configuration.find_by_host then return nil, 'not initialized' end
 
-  local hosts = configuration:find_by_host(host)
+  local hosts = configuration:find_by_host(host, false)
 
   return #(hosts) > 0
 end

--- a/spec/configuration_store_spec.lua
+++ b/spec/configuration_store_spec.lua
@@ -67,13 +67,23 @@ describe('Configuration Store', function()
       assert.same({ }, store:find_by_host('unknown'))
     end)
 
-    it('returns stale records', function()
+    it('returns stale records by default', function()
       local store = configuration.new()
       local service =  { id = '21', hosts = { 'example.com', 'localhost' } }
 
       store:add(service, -1)
 
       assert.same({ service }, store:find_by_host('example.com'))
+    end)
+
+
+    it('not returns stale records when disabled', function()
+      local store = configuration.new()
+      local service =  { id = '21', hosts = { 'example.com', 'localhost' } }
+
+      store:add(service, -1)
+
+      assert.same({ }, store:find_by_host('example.com', false))
     end)
   end)
 

--- a/spec/proxy_spec.lua
+++ b/spec/proxy_spec.lua
@@ -55,6 +55,14 @@ describe('Proxy', function()
 
       assert.truthy(p:configured('example.com'))
     end)
+
+    it('returns false when configuration is stale', function()
+      local config = configuration_store.new()
+      config:add({ id = 42, hosts = { 'example.com' } }, -1)
+      local p = assert(proxy.new(config))
+
+      assert.falsy(p:configured('example.com'))
+    end)
   end)
 
 end)


### PR DESCRIPTION
when cache was set to 0 the configuration 
would be cached forever, because stale records were used

so don't consider stale config as being configured and reload

fixes https://issues.jboss.org/browse/THREESCALE-76