### PR TITLE
[configuration] allow locking service configuration version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Backend HTTP client that uses cosockets [PR #295](https://github.com/3scale/apicast/pull/295)
 - Ability to customize main section of nginx configuration (and expose more env variables) [PR #292](https://github.com/3scale/apicast/pull/292)
+- Ability to lock service to specific configuration version [PR #293](https://github.com/3scale/apicast/pull/292)
 
 ### Removed
 

--- a/apicast/src/configuration_loader/remote_v2.lua
+++ b/apicast/src/configuration_loader/remote_v2.lua
@@ -111,7 +111,13 @@ function _M:config(service, environment, version)
   if not environment then return nil, 'missing environment' end
   if not version then return nil, 'missing version' end
 
-  local url = resty_url.join(self.endpoint, '/admin/api/services/', id , '/proxy/configs/', environment, '/', format('%s.json', version))
+  local version_override = resty_env.get(format('APICAST_SERVICE_%s_CONFIGURATION_VERSION', id))
+
+  local url = resty_url.join(
+    self.endpoint,
+    '/admin/api/services/', id , '/proxy/configs/', environment, '/',
+    format('%s.json', version_override or version)
+  )
 
   local res, err = http_client.get(url)
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -126,3 +126,9 @@ URI that overrides backend endpoint from the configuration. Useful when deployin
 
 The [Management API](./management-api.md) is powerful and can control the APIcast configuration.
 You should enable the debug level only for debugging.
+
+### `APICAST_SERVICE_${ID}_CONFIGURATION_VERSION`
+
+Replace `${ID}` with the actual Service ID. The value should be the configuration version you can see in the configuration history on the Admin Portal.
+
+Setting it to particual version will make it not auto-update and always use that version.


### PR DESCRIPTION
by setting `APICAST_SERVICE_${ID}_CONFIGURATION_VERSION` environment
variable to some version it is going to be used to lock to that version

depends on https://github.com/3scale/apicast/pull/292

no ideas how to document this, ideas ? @vramosp @3scale/support @jcechace ?