### PR TITLE
[backend] introduce backend client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Backend HTTP client that uses cosockets [PR #295](https://github.com/3scale/apicast/pull/295)
+
 ### Removed
 
 ## [3.0.0-beta2] - 2017-03-08

--- a/apicast/src/backend_client.lua
+++ b/apicast/src/backend_client.lua
@@ -1,0 +1,85 @@
+local setmetatable = setmetatable
+local concat = table.concat
+
+local http_ng = require('resty.http_ng')
+local user_agent = require('user_agent')
+local resty_url = require('resty.url')
+
+local _M = {
+
+}
+
+local mt = { __index = _M }
+
+function _M.new(service, http_client)
+  local endpoint = service.backend.endpoint or ngx.var.backend_endpoint
+  local service_id = service.id
+
+  if not endpoint then
+    ngx.log(ngx.WARN, 'service ', service_id, ' does not have backend endpoint configured')
+  end
+
+  local authentication = { service_id = service_id }
+
+  if service.backend_authentication.type then
+    authentication[service.backend_authentication.type] = service.backend_authentication.value
+  end
+
+  local backend, err = resty_url.split(endpoint)
+
+  if not backend and err then
+    return nil, err
+  end
+
+  local client = http_ng.new{
+    backend = http_client,
+    options = {
+      headers = {
+        user_agent = user_agent(),
+        host = service.backend.host or backend[4]
+      },
+      ssl = { verify = false }
+    }
+  }
+
+  return setmetatable({
+    version = service.backend_version,
+    endpoint = endpoint,
+    service_id = service_id,
+    authentication = authentication,
+    http_client = client
+  }, mt)
+end
+
+function _M:authrep(...)
+  local version = self.version
+  local http_client = self.http_client
+
+  if not version or not http_client then
+    return nil, 'not initialized'
+  end
+
+  local endpoint = self.endpoint
+
+  if not endpoint then
+    return nil, 'missing endpoint'
+  end
+
+  local auth_uri = version == 'oauth' and 'oauth_authrep.xml' or 'authrep.xml'
+
+  local args = { self.authentication, ... }
+
+  for i=1, #args do
+    args[i] = ngx.encode_args(args[i])
+  end
+
+  local url = resty_url.join(endpoint, '/transactions/', auth_uri, '?', concat(args, '&'))
+
+  local res = http_client.get(url)
+
+  ngx.log(ngx.INFO, 'backend client uri: ', url, ' ok: ', res.ok, ' status: ', res.status, ' body: ', res.body)
+
+  return res
+end
+
+return _M

--- a/apicast/src/backend_client.lua
+++ b/apicast/src/backend_client.lua
@@ -1,3 +1,14 @@
+------------
+-- Backend Client
+-- HTTP client using @{http_ng.HTTP} to call 3scale backend.
+--
+-- @module backend_client
+-- @author mikz
+-- @license Apache License Version 2.0
+
+--- Backend Client
+-- @type backend_client
+
 local setmetatable = setmetatable
 local concat = table.concat
 
@@ -11,7 +22,11 @@ local _M = {
 
 local mt = { __index = _M }
 
-function _M.new(service, http_client)
+--- Return new instance of backend client
+-- @tparam Service service object with service definition
+-- @tparam http_ng.backend http_client async/test/custom http backend
+-- @treturn backend_client
+function _M.new(_, service, http_client)
   local endpoint = service.backend.endpoint or ngx.var.backend_endpoint
   local service_id = service.id
 
@@ -81,6 +96,9 @@ local function call_backend_transaction(self, path, ...)
   return res
 end
 
+--- Call authrep (oauth_authrep) on backend.
+-- @tparam ?{table,...} query list of query parameters
+-- @treturn http_ng.response http response
 function _M:authrep(...)
   if not self then
     return nil, 'not initialized'
@@ -90,6 +108,9 @@ function _M:authrep(...)
   return call_backend_transaction(self, auth_uri, ...)
 end
 
+--- Call authorize (oauth_authorize) on backend.
+-- @tparam ?{table,...} query list of query parameters
+-- @treturn http_ng.response http response
 function _M:authorize(...)
   if not self then
     return nil, 'not initialized'

--- a/apicast/src/proxy.lua
+++ b/apicast/src/proxy.lua
@@ -328,6 +328,10 @@ function _M:access(service)
     credentials[i] = nil
   end
 
+  -- save those tables in context so they can be used in the backend client
+  ngx.ctx.usage = params
+  ngx.ctx.credentials = credentials
+
   credentials = encode_args(credentials)
 
   ngx.var.credentials = credentials

--- a/apicast/src/resty/http_ng.lua
+++ b/apicast/src/resty/http_ng.lua
@@ -1,3 +1,11 @@
+------------
+--- HTTP NG module
+-- Implements HTTP client.
+-- @module http_ng
+
+--- HTTP Client
+-- @type HTTP
+
 local type = type
 local unpack = unpack
 local assert = assert
@@ -11,13 +19,6 @@ local next = next
 local pairs = pairs
 local concat = table.concat
 
-------------
---- HTTP
--- HTTP client
--- @module middleware
-
---- HTTP
--- @type HTTP
 
 local resty_backend = require 'resty.http_ng.backend.resty'
 local json = require 'cjson'

--- a/apicast/src/resty/http_ng/backend/resty.lua
+++ b/apicast/src/resty/http_ng/backend/resty.lua
@@ -1,7 +1,15 @@
+------------
+--- HTTP
+-- HTTP client
+-- @module http_ng.backend
+
 local backend = {}
 local response = require 'resty.http_ng.response'
 local http = require 'resty.resolver.http'
 
+--- Send request and return the response
+-- @tparam http_ng.request request
+-- @treturn http_ng.response
 backend.send = function(request)
   local httpc = http.new()
   local ssl_verify = request.options and request.options.ssl and request.options.ssl.verify

--- a/doc/config.ld
+++ b/doc/config.ld
@@ -1,6 +1,9 @@
 file = {
   '../apicast/src/configuration/service.lua',
   '../apicast/src/resty/env.lua',
+  '../apicast/src/resty/http_ng.lua',
+  '../apicast/src/resty/http_ng/backend/resty.lua',
+  '../apicast/src/backend_client.lua',
   '../apicast/src/resty/synchronization.lua',
 }
 dir = '../doc/api'
@@ -8,3 +11,6 @@ project = 'APIcast'
 title = 'NGINX based API gateway used to integrate your internal and external API services with 3scale’s API Management Platform'
 merge = true
 format = 'markdown'
+
+new_type("http","HTTP")
+new_type("http_ng.backend","http_ng.backend")

--- a/spec/backend_client_spec.lua
+++ b/spec/backend_client_spec.lua
@@ -1,0 +1,84 @@
+local _M = require('backend_client')
+local configuration = require('configuration')
+local test_backend_client = require 'resty.http_ng.backend.test'
+
+describe('backend client', function()
+
+  local test_backend
+
+  before_each(function() test_backend = test_backend_client.new() end)
+
+  describe('authrep', function()
+    it('works without params', function()
+      local service = configuration.parse_service({
+        id = '42', backend_version = '1',
+        proxy = {
+          backend = { endpoint = 'http://example.com' },
+        },
+        backend_authentication_type = 'auth', backend_authentication_value = 'val'
+      })
+      test_backend.expect{
+        url = 'http://example.com/transactions/authrep.xml?service_id=42&auth=val',
+        headers = { host = 'example.com' }
+      }.respond_with{ status = 200 }
+      local backend_client = assert(_M.new(service, test_backend))
+
+      local res = backend_client:authrep()
+
+      assert.equal(200, res.status)
+    end)
+
+    it('passes params along', function()
+      local service = configuration.parse_service({
+        id = '42', backend_version = '1',
+        proxy = {
+          backend = { endpoint = 'http://example.com' },
+        },
+        backend_authentication_type = 'auth', backend_authentication_value = 'val'
+      })
+      test_backend.expect{
+        url = 'http://example.com/transactions/authrep.xml?service_id=42&auth=val&usage%5Bhits%5D=1&user_key=foobar'
+      }.respond_with{ status = 200 }
+      local backend_client = assert(_M.new(service, test_backend))
+
+      local res = backend_client:authrep({ ['usage[hits]'] = 1 }, { user_key = 'foobar' })
+
+      assert.equal(200, res.status)
+    end)
+
+    it('can override backend host header', function()
+      local service = configuration.parse_service({
+        id = '42', backend_version = '1',
+        proxy = {
+          backend = { endpoint = 'http://example.com', host = 'foo.example.com' },
+        }
+      })
+      test_backend.expect{
+        url = 'http://example.com/transactions/authrep.xml?service_id=42',
+        headers = { host = 'foo.example.com' }
+      }.respond_with{ status = 200 }
+      local backend_client = assert(_M.new(service, test_backend))
+
+      local res = backend_client:authrep()
+
+      assert.equal(200, res.status)
+    end)
+
+    it('detects oauth', function()
+      local service = configuration.parse_service({
+        id = '42', backend_version = 'oauth',
+        proxy = {
+          backend = { endpoint = 'http://example.com' },
+        }
+      })
+      test_backend.expect{
+        url = 'http://example.com/transactions/oauth_authrep.xml?service_id=42'
+      }.respond_with{ status = 200 }
+      local backend_client = assert(_M.new(service, test_backend))
+
+      local res = backend_client:authrep()
+
+      assert.equal(200, res.status)
+    end)
+  end)
+end)

--- a/spec/backend_client_spec.lua
+++ b/spec/backend_client_spec.lua
@@ -81,4 +81,78 @@ describe('backend client', function()
       assert.equal(200, res.status)
     end)
   end)
+
+  describe('authorize', function()
+    it('works without params', function()
+      local service = configuration.parse_service({
+        id = '42', backend_version = '1',
+        proxy = {
+          backend = { endpoint = 'http://example.com' },
+        },
+        backend_authentication_type = 'auth', backend_authentication_value = 'val'
+      })
+      test_backend.expect{
+        url = 'http://example.com/transactions/authorize.xml?service_id=42&auth=val',
+        headers = { host = 'example.com' }
+      }.respond_with{ status = 200 }
+      local backend_client = assert(_M.new(service, test_backend))
+
+      local res = backend_client:authorize()
+
+      assert.equal(200, res.status)
+    end)
+
+    it('passes params along', function()
+      local service = configuration.parse_service({
+        id = '42', backend_version = '1',
+        proxy = {
+          backend = { endpoint = 'http://example.com' },
+        },
+        backend_authentication_type = 'auth', backend_authentication_value = 'val'
+      })
+      test_backend.expect{
+        url = 'http://example.com/transactions/authorize.xml?service_id=42&auth=val&usage%5Bhits%5D=1&user_key=foobar'
+      }.respond_with{ status = 200 }
+      local backend_client = assert(_M.new(service, test_backend))
+
+      local res = backend_client:authorize({ ['usage[hits]'] = 1 }, { user_key = 'foobar' })
+
+      assert.equal(200, res.status)
+    end)
+
+    it('can override backend host header', function()
+      local service = configuration.parse_service({
+        id = '42', backend_version = '1',
+        proxy = {
+          backend = { endpoint = 'http://example.com', host = 'foo.example.com' },
+        }
+      })
+      test_backend.expect{
+        url = 'http://example.com/transactions/authorize.xml?service_id=42',
+        headers = { host = 'foo.example.com' }
+      }.respond_with{ status = 200 }
+      local backend_client = assert(_M.new(service, test_backend))
+
+      local res = backend_client:authorize()
+
+      assert.equal(200, res.status)
+    end)
+
+    it('detects oauth', function()
+      local service = configuration.parse_service({
+        id = '42', backend_version = 'oauth',
+        proxy = {
+          backend = { endpoint = 'http://example.com' },
+        }
+      })
+      test_backend.expect{
+        url = 'http://example.com/transactions/oauth_authorize.xml?service_id=42'
+      }.respond_with{ status = 200 }
+      local backend_client = assert(_M.new(service, test_backend))
+
+      local res = backend_client:authorize()
+
+      assert.equal(200, res.status)
+    end)
+  end)
 end)

--- a/spec/backend_client_spec.lua
+++ b/spec/backend_client_spec.lua
@@ -21,7 +21,7 @@ describe('backend client', function()
         url = 'http://example.com/transactions/authrep.xml?service_id=42&auth=val',
         headers = { host = 'example.com' }
       }.respond_with{ status = 200 }
-      local backend_client = assert(_M.new(service, test_backend))
+      local backend_client = assert(_M:new(service, test_backend))
 
       local res = backend_client:authrep()
 
@@ -39,7 +39,7 @@ describe('backend client', function()
       test_backend.expect{
         url = 'http://example.com/transactions/authrep.xml?service_id=42&auth=val&usage%5Bhits%5D=1&user_key=foobar'
       }.respond_with{ status = 200 }
-      local backend_client = assert(_M.new(service, test_backend))
+      local backend_client = assert(_M:new(service, test_backend))
 
       local res = backend_client:authrep({ ['usage[hits]'] = 1 }, { user_key = 'foobar' })
 
@@ -57,7 +57,7 @@ describe('backend client', function()
         url = 'http://example.com/transactions/authrep.xml?service_id=42',
         headers = { host = 'foo.example.com' }
       }.respond_with{ status = 200 }
-      local backend_client = assert(_M.new(service, test_backend))
+      local backend_client = assert(_M:new(service, test_backend))
 
       local res = backend_client:authrep()
 
@@ -74,7 +74,7 @@ describe('backend client', function()
       test_backend.expect{
         url = 'http://example.com/transactions/oauth_authrep.xml?service_id=42'
       }.respond_with{ status = 200 }
-      local backend_client = assert(_M.new(service, test_backend))
+      local backend_client = assert(_M:new(service, test_backend))
 
       local res = backend_client:authrep()
 
@@ -95,7 +95,7 @@ describe('backend client', function()
         url = 'http://example.com/transactions/authorize.xml?service_id=42&auth=val',
         headers = { host = 'example.com' }
       }.respond_with{ status = 200 }
-      local backend_client = assert(_M.new(service, test_backend))
+      local backend_client = assert(_M:new(service, test_backend))
 
       local res = backend_client:authorize()
 
@@ -113,7 +113,7 @@ describe('backend client', function()
       test_backend.expect{
         url = 'http://example.com/transactions/authorize.xml?service_id=42&auth=val&usage%5Bhits%5D=1&user_key=foobar'
       }.respond_with{ status = 200 }
-      local backend_client = assert(_M.new(service, test_backend))
+      local backend_client = assert(_M:new(service, test_backend))
 
       local res = backend_client:authorize({ ['usage[hits]'] = 1 }, { user_key = 'foobar' })
 
@@ -131,7 +131,7 @@ describe('backend client', function()
         url = 'http://example.com/transactions/authorize.xml?service_id=42',
         headers = { host = 'foo.example.com' }
       }.respond_with{ status = 200 }
-      local backend_client = assert(_M.new(service, test_backend))
+      local backend_client = assert(_M:new(service, test_backend))
 
       local res = backend_client:authorize()
 
@@ -148,7 +148,7 @@ describe('backend client', function()
       test_backend.expect{
         url = 'http://example.com/transactions/oauth_authorize.xml?service_id=42'
       }.respond_with{ status = 200 }
-      local backend_client = assert(_M.new(service, test_backend))
+      local backend_client = assert(_M:new(service, test_backend))
 
       local res = backend_client:authorize()
 


### PR DESCRIPTION
* using http_ng
* unit tested
* authrep + oauth authrep
* extracted from 414d313
* needed for https://github.com/3scale/apicast/pull/283 and https://github.com/3scale/apicast/pull/290

# Example

```lua
local backend_client = require('backend_client')

...

local service = ...

local backend = backend_client:new(service)

local res = backend:authrep({ user_key = 'foo' }, { ['usage[hits]'] = 1 })
```