### PR TITLE
[git] allow merge=union on the changelog file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
so changelogs are easier rebased

https://github.com/olivierlacan/keep-a-changelog/issues/56
https://github.com/isaacs/github/issues/487

Not supported by GitHub merge interface but at least locally