### PR TITLE
Fix OAuth client example

### DIFF
--- a/examples/oauth2/README.md
+++ b/examples/oauth2/README.md
@@ -51,10 +51,10 @@ A very simple Sinatra app acting as a Client, running on `http://localhost:3001`
 
 The app will display a page where you can enter a `client_id`, `redirect_uri` and `scope` to request an authorization code. 
 
-The Authorization URL targeted will be the `/authorize` endpoint on your API Gateway instance, e.g `localhost:8080/authorize` 
-The Access Token URL targeted will be the `/oauth/token` endpoint on your API Gateway instance. e.g `localhost:8080/oauth/token`
+The Authorization URL targeted will be the `/authorize` endpoint on your API Gateway instance, e.g `http://localhost:8080/authorize` 
+The Access Token URL targeted will be the `/oauth/token` endpoint on your API Gateway instance. e.g `http://localhost:8080/oauth/token`
 
-Both these values are built in to the client, however, the Gateway host can be overwritten by adding a `.env` file under the `client` directory and specifying the gateway host in the `GATEWAY` environment variable (in format `<host>:<port>`), otherwise this will default to `localhost:8080`
+Both these values are built in to the client, however, the Gateway URI can be overwritten by adding a `.env` file under the `client` directory and specifying the gateway URI in the `GATEWAY` environment variable (in format `<scheme>://<host>:<port>`), otherwise this will default to `http://localhost:8080`
 
 Once an authorization code is returned back to the app, you can exchange that for an access token by additionally providing a client secret.
 
@@ -78,4 +78,4 @@ The authorization server will callback APIcast (running on `http://localhost:808
 
 Once the Authorization Code is sent to the redirect URL (client callback endpoint in this case) we exchange this for an access token as per the instructions above under "Exchanging authorization code for an access token."
 
-The `auth-server.rb` code for running this example using `docker-compose` locally assumes that the Gateway host is running on `localhost:8080`. You can always override this by adding a `.env` file in the `auth-server` directory and referencing this within your `docker-compose.yml` file, same as for `client.rb`.
+The `auth-server.rb` code for running this example using `docker-compose` locally assumes that the Gateway host is running on `http://localhost:8080`. You can always override this by adding a `.env` file in the `auth-server` directory and referencing this within your `docker-compose.yml` file, same as for `client.rb`.

--- a/examples/oauth2/auth-server/auth-server.rb
+++ b/examples/oauth2/auth-server/auth-server.rb
@@ -2,8 +2,8 @@ require 'sinatra'
 
 set :bind, '0.0.0.0'
 
-GATEWAY = ENV['GATEWAY'] || "localhost:8080"
-nginx_redirect_uri =  "http://#{GATEWAY}/callback?"  #nginx callback
+GATEWAY = ENV['GATEWAY'] || "http://localhost:8080"
+nginx_redirect_uri =  "#{GATEWAY}/callback?"  #nginx callback
 enable :sessions
 set :session_secret, '*&(^B234'
 

--- a/examples/oauth2/client/client.rb
+++ b/examples/oauth2/client/client.rb
@@ -4,12 +4,12 @@ require 'securerandom'
 enable :sessions
 set :session_secret, '*&(^B234'
 
-GATEWAY = ENV['GATEWAY'] || "localhost:8080"
+GATEWAY = ENV['GATEWAY'] || "http://localhost:8080"
 CLIENT_ID = ENV['CLIENT_ID']
 CLIENT_SECRET = ENV['CLIENT_SECRET']
 REDIRECT_URI = ENV['REDIRECT_URI'] || "http://localhost:3001/callback"
-AUTHORIZE_ENDPOINT = "http://#{GATEWAY}/authorize"
-TOKEN_ENDPOINT = "http://#{GATEWAY}/oauth/token"
+AUTHORIZE_ENDPOINT = "#{GATEWAY}/authorize"
+TOKEN_ENDPOINT = "#{GATEWAY}/oauth/token"
 
 get("/") do
   @state = SecureRandom.uuid

--- a/examples/oauth2/client/client.rb
+++ b/examples/oauth2/client/client.rb
@@ -12,11 +12,12 @@ AUTHORIZE_ENDPOINT = "http://#{GATEWAY}/authorize"
 TOKEN_ENDPOINT = "http://#{GATEWAY}/oauth/token"
 
 get("/") do
+  @state = SecureRandom.uuid
+  session[:state] = @state
 	erb :root
 end
 
 get("/callback") do
-	@code = session[:code] = params[:state] == session[:state] ? params[:code] : "error: state does not match"
-
+	@code = params[:state] == session[:state] ? params[:code] : "error: state does not match"
 	erb :root
 end

--- a/examples/oauth2/client/views/root.erb
+++ b/examples/oauth2/client/views/root.erb
@@ -6,7 +6,7 @@
 
 <form method="get" action="<%= AUTHORIZE_ENDPOINT %>">
   <div class="form-group">
-    <input type="hidden" name="state" value="<%= SecureRandom.uuid %>" />
+    <input type="hidden" name="state" value="<%= @state %>" />
     <input type="hidden" name="response_type" value="code" />
   </div>
   <div class="form-group">  


### PR DESCRIPTION
Fixes the `error: state does not match` error reported by @kevprice83 here: https://github.com/3scale/apicast/issues/282#issuecomment-286250869

To be honest, I am not sure how it was working before...

Also, allows to specify the full URI of the APIcast gateway.