### PR TITLE
Avoid throwing an error when there is no cached proxy object

### DIFF
--- a/apicast/src/apicast.lua
+++ b/apicast/src/apicast.lua
@@ -67,7 +67,7 @@ function _M.post_action()
   local request_id = ngx.var.original_request_id
   local p = post_action_proxy[request_id]
   post_action_proxy[request_id] = nil
-  p:post_action()
+  if p then p:post_action() end
 end
 
 function _M.access()


### PR DESCRIPTION
In case the API call doesn't pass thought the `access` phase (typical case would be if it is an `/authorize` or `/oauth/token`, or if the service is not found, so the exit is done in the `rewrite` phase), an error will be thrown in `post_action`:

```
2017/03/15 05:09:43 [error] 31748#0: *2 lua entry thread aborted: runtime error: .../apicast.lua:70: attempt to index local 'p' (a nil value)
```

Not sure if we also need to print some warning in the log in this case.