### PR TITLE
Fix OAuth auth caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Reloading of configuration with every request when cache is disabled [PR #287](https://github.com/3scale/apicast/pull/287)
+- Auth caching is not used when OAuth method is used [PR #304](https://github.com/3scale/apicast/pull/304)
 
 ## [3.0.0-beta1] - 2017-03-03
 

--- a/apicast/src/proxy.lua
+++ b/apicast/src/proxy.lua
@@ -150,14 +150,9 @@ local http = {
   end
 }
 
-function _M.authorize(backend_version, service)
-  local internal_location
-  if backend_version == 'oauth' then
-    internal_location = '/threescale_oauth_authrep'
-  else
-    internal_location = '/threescale_authrep'
-  end
-
+function _M.authorize(service)
+  local internal_location = (service.backend_version == 'oauth' and '/threescale_oauth_authrep')
+                                                         or '/threescale_authrep'
   -- NYI: return to lower frame
   local cached_key = ngx.var.cached_key .. ":" .. ngx.var.usage
   local api_keys = ngx.shared.api_keys
@@ -269,7 +264,6 @@ function _M:call(host)
 end
 
 function _M:access(service)
-  local backend_version = service.backend_version
 
   if ngx.status == 403  then
     ngx.say("Throttling due to too many requests")
@@ -324,7 +318,7 @@ function _M:access(service)
     ngx.header["X-3scale-hostname"]      = ngx.var.hostname
   end
 
-  self.authorize(backend_version, service)
+  self.authorize(service)
 end
 
 

--- a/apicast/src/proxy.lua
+++ b/apicast/src/proxy.lua
@@ -159,6 +159,7 @@ local function oauth_authrep(service)
     ngx.log(ngx.DEBUG, 'apicast cache hit key: ', cached_key)
     ngx.var.cached_key = cached_key
   else
+    ngx.log(ngx.INFO, 'apicast cache miss key: ', cached_key)
     local res = http.get("/threescale_oauth_authrep")
 
     if res.status ~= 200   then
@@ -167,6 +168,7 @@ local function oauth_authrep(service)
       ngx.header.content_type = "application/json"
       error_authorization_failed(service)
     else
+      ngx.log(ngx.INFO, 'apicast cache write key: ', cached_key)
       access_tokens:set(ngx.var.cached_key,200)
     end
 

--- a/apicast/src/proxy.lua
+++ b/apicast/src/proxy.lua
@@ -169,7 +169,7 @@ local function oauth_authrep(service)
       error_authorization_failed(service)
     else
       ngx.log(ngx.INFO, 'apicast cache write key: ', cached_key)
-      access_tokens:set(ngx.var.cached_key,200)
+      access_tokens:set(cached_key,200)
     end
 
     ngx.var.cached_key = nil

--- a/t/009-apicast-caching.t
+++ b/t/009-apicast-caching.t
@@ -160,3 +160,62 @@ apicast cache miss key: 1:one-key:usage%5Bhits%5D=1
 apicast cache write key: 1:one-key:usage%5Bhits%5D=1
 apicast cache miss key: 2:two-id:two-key:usage%5Bhits%5D=2
 apicast cache write key: 2:two-id:two-key:usage%5Bhits%5D=2
+
+=== TEST 7: call to backend is cached
+First call is done synchronously and the second out of band.
+--- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+  init_by_lua_block {
+    require('configuration_loader').mock({
+      services = {
+        {
+          id = 42,
+          backend_version = 'oauth',
+          proxy = {
+            credentials_location = "query",
+            api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
+            proxy_rules = {
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
+            }
+          }
+        }
+      }
+    })
+  }
+  lua_shared_dict api_keys 10m;
+--- config
+  include $TEST_NGINX_APICAST_CONFIG;
+
+  set $backend_endpoint 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT';
+  set $backend_authentication_type 'service_token';
+  set $backend_authentication_value 'token-value';
+
+  location /transactions/oauth_authrep.xml {
+    content_by_lua_block { ngx.exit(200) }
+  }
+
+  location /api-backend/ {
+     echo 'yay, api backend';
+  }
+
+  location ~ /test/(.+) {
+    proxy_pass $scheme://127.0.0.1:$server_port/$1$is_args$args;
+    proxy_set_header Host localhost;
+  }
+
+  location = /t {
+    echo_subrequest GET /test/one -q access_token=value;
+    echo_subrequest GET /test/two -q access_token=value;
+  }
+--- request
+GET /t
+--- response_body
+yay, api backend
+yay, api backend
+--- error_code: 200
+--- grep_error_log eval: qr/apicast cache (?:hit|miss|write) key: [^,\s]+/
+--- grep_error_log_out
+apicast cache miss key: 42:value:usage%5Bhits%5D=2
+apicast cache write key: 42:value:usage%5Bhits%5D=2
+apicast cache hit key: 42:value:usage%5Bhits%5D=2


### PR DESCRIPTION
I realized that in OAuth mode the auth caching was not working (not sure if it never worked, the bug or was introduced at some point.

Also, I've decided to remove the duplication in `authrep` and `oauth_authrep`, as only the internal location should be different for them. This can probably be improved further, by using the co-socket http library instead of internal locations. 