### PR TITLE
[configuration] print better error messages on loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Use per request configuration when cache is disabled [PR #289](https://github.com/3scale/apicast/pull/289)
 - Automatically expose all environment variables starting with `APICAST_` or `THREESCALE_` to nginx [PR #292](https://github.com/3scale/apicast/pull/292)
+- Error log to show why downloading configuration failed [PR #306](https://github.com/3scale/apicast/pull/306)
 
 ### Added
 

--- a/apicast/src/configuration_loader.lua
+++ b/apicast/src/configuration_loader.lua
@@ -8,7 +8,6 @@ local util = require 'util'
 local env = require('resty.env')
 local synchronization = require('resty.synchronization').new(1)
 
-local tostring = tostring
 local error = error
 local len = string.len
 local assert = assert
@@ -77,10 +76,10 @@ function _M.init(cwd)
     return config
   elseif err then
     if code then
-      ngx.log(ngx.ERR, 'boot could not get configuration, ' .. tostring(err) .. ': '.. tostring(code))
+      ngx.log(ngx.ERR, 'boot could not get configuration (exit ', code, ')\n',  err)
       return nil, err
     else
-      ngx.log(ngx.ERR, 'boot failed read: '.. tostring(err))
+      ngx.log(ngx.ERR, 'boot failed read: ', err)
       return nil, err
     end
   end
@@ -92,13 +91,13 @@ local boot = {
 }
 
 function boot.init(configuration)
-  local config, err = _M.init()
-  local init, conferr = _M.configure(configuration, config)
+  local config = _M.init()
+  local init = _M.configure(configuration, config)
 
   if config and init then
     ngx.log(ngx.DEBUG, 'downloaded configuration: ', config)
   else
-    ngx.log(ngx.EMERG, 'failed to load configuration, exiting: ', err or conferr)
+    ngx.log(ngx.EMERG, 'failed to load configuration, exiting')
     os.exit(1)
   end
 

--- a/apicast/src/configuration_loader/remote_v2.lua
+++ b/apicast/src/configuration_loader/remote_v2.lua
@@ -55,6 +55,7 @@ function _M:call(environment)
   local res, err = self:services()
 
   if not res and err then
+    ngx.log(ngx.WARN, 'failed to get list of services: ', err)
     return nil, err
   end
 
@@ -88,8 +89,11 @@ function _M:services()
   local res, err = http_client.get(url)
 
   if not res and err then
+    ngx.log(ngx.DEBUG, 'services get error: ', err, ' url: ', url)
     return nil, err
   end
+
+  ngx.log(ngx.DEBUG, 'services get status: ', res.status, ' url: ', url)
 
   if res.status == 200 then
     local json = cjson.decode(res.body)
@@ -122,8 +126,11 @@ function _M:config(service, environment, version)
   local res, err = http_client.get(url)
 
   if not res and err then
+    ngx.log(ngx.DEBUG, 'services get error: ', err, ' url: ', url)
     return nil, err
   end
+
+  ngx.log(ngx.DEBUG, 'services get status: ', res.status, ' url: ', url)
 
   if res.status == 200 then
     local json = cjson.decode(res.body)

--- a/t/012-configuration-loading-boot-with-config.t
+++ b/t/012-configuration-loading-boot-with-config.t
@@ -16,7 +16,7 @@ env_to_nginx(
     'THREESCALE_CONFIG_FILE'
 );
 
-log_level('error');
+log_level('warn');
 repeat_each(2);
 no_root_location();
 run_tests();
@@ -47,7 +47,7 @@ should exit when the file has invalid json
 --- request
 GET
 --- error_log
-failed to load configuration, exiting: Expected value but found invalid token at character 1
+Expected value but found invalid token at character 1
 --- user_files
 >>> config.json
 not valid json


### PR DESCRIPTION
fixes https://issues.jboss.org/browse/THREESCALE-80

* print reason why configuration could not be downloaded
* print more debugging information

example log:
```
2017/03/16 08:08:15 [error] 30795#0: [lua] configuration_loader.lua:80: init(): boot could not get configuration (exit 1)
2017/03/16 08:08:16 [warn] 30816#0: *2 [lua] remote_v2.lua:58: call(): failed to get list of services: invalid status, context: ngx.timer
./src/configuration_loader.lua:25: missing configuration

2017/03/16 08:08:15 [emerg] 30795#0: [lua] configuration_loader.lua:101: init(): failed to load configuration, exiting
```