### PR TITLE
Fix the custom module example

### DIFF
--- a/examples/custom-module/verbose.lua
+++ b/examples/custom-module/verbose.lua
@@ -3,10 +3,14 @@ local apicast = require('apicast')
 local _M = { _VERSION = '0.0' }
 local mt = { __index = apicast }
 
+function _M.new()
+  return setmetatable(_M, { __index = apicast.new() })
+end
+
 function _M.log()
   ngx.log(ngx.WARN,
     'upstream response time: ', ngx.var.upstream_response_time, ' ',
     'upstream connect time: ', ngx.var.upstream_connect_time)
 end
 
-return setmetatable(_M, mt)
+return _M


### PR DESCRIPTION
I was  trying to extend the default apicast module by using [this example](https://github.com/3scale/apicast/blob/master/examples/custom-module/verbose.lua), but we ran into some issues. I think this merge request should fix the example, but I'am not much of an lua expert.

The `module.lua` file loads the `apicast` or the overriden module, but calls the `new()` method when it is available. When the new method is not overridden it just returns the `apicast` module and not the module override.

The new code works for us.
