### PR TITLE
[resolver] remove parallel dns query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 - Removed support for sending Request logs [PR #296](https://github.com/3scale/apicast/pull/296)
+- Support for parallel DNS query [PR #311](https://github.com/3scale/apicast/pull/311)
 
 ### Known Issues
 


### PR DESCRIPTION
lets delegate this work to a dns resolver like dnsmasq

it was broken and sometimes would return a string "killed" instead of
table with answers that would count as valid answer