### PR TITLE
[configuration] fix locking of configuration loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - `http_ng` client supports auth passsed in the url, and default client options if the request options are missing for methods with body (POST, PUT, etc.) [PR #310](https://github.com/3scale/apicast/pull/310)
+- Fixed lazy configuration loader to recover from failures [PR #313](https://github.com/3scale/apicast/pull/313)
 
 ### Removed
 

--- a/spec/configuration_loader_spec.lua
+++ b/spec/configuration_loader_spec.lua
@@ -94,4 +94,15 @@ insulate('Configuration object', function()
     end)
   end)
 
+  describe('lazy loader', function()
+    local _M = require('configuration_loader')
+    local loader
+
+    before_each(function() loader = _M.new('lazy') end)
+
+    it('does not crash on rewrite', function()
+      local configuration = {}
+      assert.same(configuration, loader.rewrite(configuration, 'example.com'))
+    end)
+  end)
 end)

--- a/t/013-configuration-loading-lazy.t
+++ b/t/013-configuration-loading-lazy.t
@@ -59,10 +59,7 @@ env THREESCALE_PORTAL_ENDPOINT=http://127.0.0.1:$TEST_NGINX_SERVER_PORT;
   }
 --- request
 GET /t
---- error_code: 500
---- error_log
-missing configuration
-
+--- error_code: 404
 
 === TEST 2: load valid configuration
 should correctly route the request


### PR DESCRIPTION
when configuration failed to download exception
prevented the clock to be released and next request
would fail loading the configuration