### PR TITLE
[dns] do not cache non existent records in dnsmasq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `http_ng` client supports auth passsed in the url, and default client options if the request options are missing for methods with body (POST, PUT, etc.) [PR #310](https://github.com/3scale/apicast/pull/310)
 - Fixed lazy configuration loader to recover from failures [PR #313](https://github.com/3scale/apicast/pull/313)
 - Fixed undefined variable `p` in post\_action [PR #316](https://github.com/3scale/apicast/pull/316)
+- Fixed caching of negative ttl by dnsmasq [PR #318](https://github.com/3scale/apicast/pull/318)
 
 ### Removed
 

--- a/apicast/bin/entrypoint
+++ b/apicast/bin/entrypoint
@@ -34,7 +34,7 @@ else
   apicast=apicast
 fi
 
-dnsmasq --listen-address=127.0.0.1 --all-servers --no-host --no-hosts --log-facility=- --cache-size=1000 --port=5353 --server="${RESOLVER:-}"
+dnsmasq --listen-address=127.0.0.1 --all-servers --no-host --no-hosts --log-facility=- --cache-size=1000 --port=5353 --no-negcache --server="${RESOLVER:-}"
 export RESOLVER=127.0.0.1:5353
 
 exec "${apicast}" "$@"


### PR DESCRIPTION
because openshift when reloading services reloads the dns
which will take more time to respond and dnsmasq using the other dns
server
which is public and returns invalid SOA for local domains
caching it for 30 seconds