### PR TITLE
[remote_v2] ability to load configuration from custom path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Support for loading configration from custom URL [PR #323](https://github.com/3scale/apicast/pull/323)
+
 ## [3.0.0-beta3] - 2017-03-20
 
 ### Changed

--- a/apicast/src/configuration_loader.lua
+++ b/apicast/src/configuration_loader.lua
@@ -23,7 +23,7 @@ local _M = {
 }
 
 function _M.load(host)
-  return mock_loader.call() or file_loader.call() or remote_loader_v2.call() or remote_loader_v1.call(host)
+  return mock_loader.call() or file_loader.call() or remote_loader_v2:call(host) or remote_loader_v1.call(host)
 end
 
 function _M.boot(host)

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -165,6 +165,34 @@ describe('Configuration Rmote Loader V2', function()
     end)
   end)
 
+
+  describe(':index', function()
+    before_each(function()
+      loader = _M.new('http://example.com/something/with/path', { client = test_backend })
+    end)
+
+    it('returns configuration for all services', function()
+      env.set('THREESCALE_DEPLOYMENT_ENV', 'production')
+      test_backend.expect{ url = 'http://example.com/something/with/path/production.json?host=foobar.example.com' }.
+        respond_with{ status = 200, body = cjson.encode({ proxy_configs = {
+          {
+            proxy_config = {
+              version = 42,
+              environment = 'staging',
+              content = { id = 2, backend_version = 2 }
+            }
+          }
+        }})}
+
+      local config = assert(loader:index('foobar.example.com'))
+
+      assert.truthy(config)
+      assert.equals('string', type(config))
+
+      assert.equals(1, #(cjson.decode(config).services))
+    end)
+  end)
+
   describe('.call', function()
     it('gets environment from ENV', function()
       local _, err = loader.call()


### PR DESCRIPTION
so custom web service can be used to deliver the configuration

closes https://github.com/3scale/apicast/issues/228

if you set `THREESCALE_PORTAL_ENDPOINT` for example to `http://example.com/some/path` it is going to try to load configuration from `http://example.com/some/path/${THREESCALE_DEPLOYMENT_ENV}.json?host=${request_host}`.

If nothing is found it is going to try continue as usual.