### PR TITLE
[luacheck] lock luacheck version

### DIFF
--- a/rockspec
+++ b/rockspec
@@ -2,7 +2,7 @@ package = "apicast-test"
 source = { url = '.' }
 version = '0.0-0'
 dependencies = {
-  'luacheck >= 0',
+  'luacheck == 0.18.0',
   'busted  >= 0',
   'lua-cjson >= 0',
   'ldoc >= 0',


### PR DESCRIPTION
to prevent silently upgrading it in tests and failing on new checks