### PR TITLE
[configuration] don't return stale configuration when new one is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Use `RESOLVER` before falling back to `resolv.conf` [PR #324](https://github.com/3scale/apicast/pull/324)
 
+### Fixed
+
+- Do not return stale service configuration when new one is available [PR #333](https://github.com/3scale/apicast/pull/333)
+
 ## [3.0.0-beta3] - 2017-03-20
 
 ### Changed

--- a/apicast/src/configuration_store.lua
+++ b/apicast/src/configuration_store.lua
@@ -71,6 +71,10 @@ function _M.find_by_host(self, host, stale)
 
   local services, expired = cache:get(host)
 
+  if expired and stale then
+    ngx.log(ngx.INFO, 'using stale configuration for host ', host)
+  end
+
   return services or (stale and expired) or { }
 end
 

--- a/apicast/src/proxy.lua
+++ b/apicast/src/proxy.lua
@@ -83,7 +83,7 @@ local function find_service_strict(self, host)
     local hosts = service.hosts or {}
 
     for h=1, #hosts do
-      if hosts[h] == host then
+      if hosts[h] == host and service == self.configuration:find_by_id(service.id) then
         found = service
         break
       end

--- a/spec/configuration_store_spec.lua
+++ b/spec/configuration_store_spec.lua
@@ -30,6 +30,18 @@ describe('Configuration Store', function()
 
       assert.is_nil(store:find_by_id('example.com'))
     end)
+
+    it('overrides previous values', function()
+      local store = configuration.new()
+      local first = { id = '42', hosts = { 'first.example.com' } }
+      local second = { id = '42', hosts = { 'second.example.com' } }
+
+      store:add(first)
+      assert.equal(first, store:find_by_id('42'))
+
+      store:add(second)
+      assert.equal(second, store:find_by_id('42'))
+    end)
   end)
 
   describe('.find_by_host', function()

--- a/spec/proxy_spec.lua
+++ b/spec/proxy_spec.lua
@@ -37,6 +37,18 @@ describe('Proxy', function()
     assert.falsy(proxy:find_service('unknown'))
   end)
 
+  it('does not return old configuration when new one is available', function()
+    local foo = { id = '42', hosts = { 'foo.example.com'} }
+    local bar = { id = '42', hosts = { 'bar.example.com'} }
+
+    configuration:add(foo, -1) -- expired record
+    assert.equal(foo, proxy:find_service('foo.example.com'))
+
+    configuration:add(bar, -1) -- expired record
+    assert.equal(bar, proxy:find_service('bar.example.com'))
+    assert.falsy(proxy:find_service('foo.example.com'))
+  end)
+
   describe('.get_upstream', function()
     local get_upstream = proxy.get_upstream
 


### PR DESCRIPTION
this solves case when service changes a host
the old host would still be available with old configuration
even when new service configuration does not have it at all