### PR TITLE
Store JWT in Auth cache with ttl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Improve error logging when failing to download configuration [PR #335](https://github.com/3scale/apicast/pull/325)
 - Service hostnames are normalized to lower case [PR #336](https://github.com/3scale/apicast/pull/326)
 - Don't attempt to perform post\_action when request was handled without authentication [PR #343](https://github.com/3scale/apicast/pull/343)
+- Store authorization responses with a ttl, if sent [PR #341](https://github.com/3scale/apicast/pull/341)
 
 ### Fixed
 
 - Do not return stale service configuration when new one is available [PR #333](https://github.com/3scale/apicast/pull/333)
 - Memory leak in every request [PR #339](https://github.com/3scale/apicast/pull/339)
 - Remove unnecessary code and comments [PR #344](https://github.com/3scale/apicast/pull/344)
+- JWT expiry not taken into account in authorization response cache [PR #283](https://github.com/3scale/apicast/pull/283) / [Issue #309](https://github.com/3scale/apicast/issues/309) / Fixed by [PR #341](https://github.com/3scale/apicast/pull/341)
 
 ## [3.0.0-beta3] - 2017-03-20
 

--- a/apicast/src/proxy.lua
+++ b/apicast/src/proxy.lua
@@ -199,7 +199,7 @@ function _M:authorize(service, usage, credentials, ttl)
     if res.status == 200 then
       if api_keys then
         ngx.log(ngx.INFO, 'apicast cache write key: ', cached_key, ', ttl: ', ttl )
-        api_keys:set(cached_key, 200, ttl)
+        api_keys:set(cached_key, 200, ttl or 0)
       end
     else -- TODO: proper error handling
       if api_keys then api_keys:delete(cached_key) end

--- a/apicast/src/proxy.lua
+++ b/apicast/src/proxy.lua
@@ -170,7 +170,7 @@ local function output_debug_headers(service, usage, credentials)
   end
 end
 
-function _M:authorize(service, usage, credentials)
+function _M:authorize(service, usage, credentials, ttl)
   if usage == '' then
     return error_no_match(service)
   end
@@ -198,8 +198,8 @@ function _M:authorize(service, usage, credentials)
 
     if res.status == 200 then
       if api_keys then
-        ngx.log(ngx.INFO, 'apicast cache write key: ', cached_key)
-        api_keys:set(cached_key, 200)
+        ngx.log(ngx.INFO, 'apicast cache write key: ', cached_key, ', ttl: ', ttl )
+        api_keys:set(cached_key, 200, ttl)
       end
     else -- TODO: proper error handling
       if api_keys then api_keys:delete(cached_key) end
@@ -333,8 +333,10 @@ function _M:access(service)
   ctx.credentials = credentials
   ctx.matched_patterns = matched_patterns
 
+  local ttl
+
   if self.oauth then
-    credentials, err = self.oauth:transform_credentials(credentials)
+    credentials, ttl, err = self.oauth:transform_credentials(credentials)
 
     if err then
       return error_authorization_failed(service)
@@ -344,7 +346,7 @@ function _M:access(service)
   credentials = encode_args(credentials)
   local usage = encode_args(usage_params)
 
-  return self:authorize(service, usage, credentials)
+  return self:authorize(service, usage, credentials, ttl)
 end
 
 

--- a/spec/ngx_helper.lua
+++ b/spec/ngx_helper.lua
@@ -2,10 +2,12 @@ local busted = require('busted')
 
 local ngx_var = ngx.var
 local ngx_ctx = ngx.ctx
+local ngx_shared = ngx.shared
 
 local function cleanup()
   ngx.var = ngx_var
   ngx.ctx = ngx_ctx
+  ngx.shared = ngx_shared
 end
 
 busted.after_each(cleanup)

--- a/spec/proxy_spec.lua
+++ b/spec/proxy_spec.lua
@@ -80,4 +80,36 @@ describe('Proxy', function()
       assert.same(8080, get_upstream({ api_backend = 'http://example.com:8080' }).port)
     end)
   end)
+
+  describe('.authorize', function()
+    local authorize = proxy.authorize
+    local service = { backend_authentication = { value = 'not_baz' } }
+    local usage = 'foo'
+    local credentials = 'client_id=blah'
+
+    it('takes ttl value if sent', function()
+      local ttl = 80
+      ngx.var = { cached_key = credentials, usage=usage, credentials=credentials, http_x_3scale_debug='baz', real_url='blah' }
+      ngx.ctx = { backend_upstream = ''}
+      ngx.shared = { api_keys = { cached_key = 'client_id=blah:foo', get = function () return {} end } }
+
+      stub(ngx.shared.api_keys, 'set')
+      stub(ngx.location, 'capture', function() return { status = 200 } end)
+
+      authorize(proxy, service, usage, credentials, ttl)
+      assert.spy(ngx.shared.api_keys.set).was.called_with(ngx.shared.api_keys, 'client_id=blah:foo', 200, 80)
+    end)
+
+    it('works with no ttl', function()
+      ngx.var = { cached_key = "client_id=blah", usage=usage, credentials=credentials, http_x_3scale_debug='baz', real_url='blah' }
+      ngx.ctx = { backend_upstream = ''}
+      ngx.shared = { api_keys = { cached_key = 'client_id=blah:foo', get = function () return {} end } }
+
+      stub(ngx.shared.api_keys, 'set')
+      stub(ngx.location, 'capture', function() return { status = 200 } end)
+
+      authorize(proxy, service, usage, credentials)
+      assert.spy(ngx.shared.api_keys.set).was.called_with(ngx.shared.api_keys, 'client_id=blah:foo', 200, 0)
+    end)
+  end)
 end)


### PR DESCRIPTION
In theory the expiry is checked already when validating the token and the call should be rejected before it even gets to the point where we are checking the auth response cache.

However for sake of correctness, JWT cached_key should be stored with ttl

To do: 

- [x] Store jwt in cache with ttl
- [x] Tests
- [x] Fix nginx tests
- [x] CHANGELOG

Closes #309 