### PR TITLE
[configuration] normalize service hosts to lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Use `RESOLVER` before falling back to `resolv.conf` [PR #324](https://github.com/3scale/apicast/pull/324)
 - Improve error logging when failing to download configuration [PR #335](https://github.com/3scale/apicast/pull/325)
+- Service hostnames are normalized to lower case [PR #336](https://github.com/3scale/apicast/pull/326)
 
 ### Fixed
 

--- a/apicast/src/configuration_store.lua
+++ b/apicast/src/configuration_store.lua
@@ -3,6 +3,7 @@ local pairs = pairs
 local insert = table.insert
 local concat = table.concat
 local rawset = rawset
+local lower = string.lower
 
 local env = require 'resty.env'
 local lrucache = require 'resty.lrucache'
@@ -102,12 +103,13 @@ function _M.store(self, config, ttl)
       ngx.log(ngx.INFO, 'added service ', id, ' configuration with hosts: ', concat(hosts, ', '), ' ttl: ', ttl)
 
       for j=1, #hosts do
-        local h = by_host[hosts[j]]
+        local host = lower(hosts[j])
+        local h = by_host[host]
 
         if #(h) == 0 or _M.path_routing then
           insert(h, services[i])
         else
-          ngx.log(ngx.WARN, 'skipping host ', hosts[j], ' for service ', id, ' already defined by service ', h[1].id)
+          ngx.log(ngx.WARN, 'skipping host ', host, ' for service ', id, ' already defined by service ', h[1].id)
         end
       end
 

--- a/spec/configuration_store_spec.lua
+++ b/spec/configuration_store_spec.lua
@@ -97,6 +97,15 @@ describe('Configuration Store', function()
 
       assert.same({ }, store:find_by_host('example.com', false))
     end)
+
+    it('normalizes hosts to lowercase', function()
+      local store = configuration.new()
+      local service =  { id = '21', hosts = { 'EXAMPLE.com' } }
+
+      store:add(service)
+
+      assert.same({ service }, store:find_by_host('example.com'))
+    end)
   end)
 
   describe('.reset', function()


### PR DESCRIPTION
because nginx does it too and `ngx.var.host` is lowercase

fixes https://issues.jboss.org/browse/THREESCALE-82