### PR TITLE
Add examples folder to luacheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ RUNTIME_IMAGE ?= $(BUILDER_IMAGE)-runtime
 
 lua_files = $(shell find apicast/src -type f -name '*.lua')
 spec_files = $(shell find spec -type f -name '*.lua')
+example_files = $(shell find examples -type f -name '*.lua')
 
 test: ## Run all tests
 	$(MAKE) --keep-going busted prove builder-image test-builder-image prove-docker runtime-image test-runtime-image
@@ -29,7 +30,7 @@ busted: dependencies ## Test Lua.
 	@- luacov
 
 check: dependencies ## Run luacheck to lint lua files
-	luacheck $(lua_files) $(spec_files)
+	luacheck $(lua_files) $(spec_files) $(example_files)
 
 nginx:
 	@ ($(NGINX) -V 2>&1 | grep -e '--with-ipv6' > /dev/null) || (>&2 echo "$(NGINX) `$(NGINX) -v 2>&1` does not have ipv6 support" && exit 1)

--- a/examples/custom-module/verbose.lua
+++ b/examples/custom-module/verbose.lua
@@ -1,7 +1,6 @@
 local apicast = require('apicast')
 
 local _M = { _VERSION = '0.0' }
-local mt = { __index = apicast }
 
 function _M.new()
   return setmetatable(_M, { __index = apicast.new() })


### PR DESCRIPTION
This PR adds the examples directory to luacheck.

Merging this will probably break build though as there is a warning in custom-module/verbose.lua

```
Checking examples/custom-module/verbose.lua       1 warning

    examples/custom-module/verbose.lua:4:7: unused variable mt
```