### PR TITLE
Show more info on module load errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Turn on SSL/TLS validation by `OPENSSL_VERIFY` environment variable [PR #332](https://github.com/3scale/apicast/pull/332)
 - Load trusted CA chain certificates [PR #332](https://github.com/3scale/apicast/pull/332)
 - Support HTTP Basic authentication for client credentials when authorizing with RH-SSO [PR #336](https://github.com/3scale/apicast/pull/336)
+- Show more information about the error when the module load fails [PR #348](https://github.com/3scale/apicast/pull/348)
 
 ### Changed
 

--- a/apicast/http.d/init.conf
+++ b/apicast/http.d/init.conf
@@ -8,7 +8,7 @@ init_by_lua_block {
     require("resty.core")
     require('resty.resolver').init()
 
-    local module, err = require('module')
+    local module = require('module')
 
     if not module then
       ngx.log(ngx.EMERG, 'fatal error when loading the root module')

--- a/apicast/src/module.lua
+++ b/apicast/src/module.lua
@@ -9,12 +9,16 @@ local prequire = function(file)
   local ok, ret = pcall(require, file)
 
   if not ok and ret then
-    -- dofile can load absolue paths, require can't
+    -- dofile can load absolute paths, require can't
     ok, ret = pcall(dofile, file)
   end
 
-  if type(ret) == 'userdata' then
-    ngx.log(ngx.WARN, 'cyclic require detected: ', debug.traceback())
+  if not ok and ret then
+    if type(ret) == 'userdata' then
+      ngx.log(ngx.WARN, 'cyclic require detected: ', debug.traceback())
+    elseif type(ret) == 'string' then
+      ngx.log(ngx.WARN, ret, ', ', debug.traceback())
+    end
     return false, ret
   end
 


### PR DESCRIPTION
Closes #347 (only partially)

This helps, but still in some cases the error is confusing and doesn't really point to the module where the problem is. Instead it says something like:
```
[warn] 63285#0: [lua] module.lua:20: prequire(): cannot read apicast: Is a directory, stack traceback:
```

So, if there is a better way, please feel free to close this PR, or change the commit. Otherwise, maybe it's better than nothing.