### PR TITLE
Add HTTP Cache support to http_ng

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Bump OpenResty version to [1.11.2.3](https://github.com/3scale/s2i-openresty/releases/tag/1.11.2.3-1) [PR #359](https://github.com/3scale/apicast/pull/359) 
 
+### Added
+
+- Experimental caching proxy to the http client [PR #357](https://github.com/3scale/apicast/pull/357)
+
 ## [3.0.0-rc1] - 2017-04-04
 
 ### Added

--- a/apicast/src/resty/http_ng.lua
+++ b/apicast/src/resty/http_ng.lua
@@ -90,7 +90,7 @@ http.method = function(method, client)
     local req_params = get_request_params(method, client, url, options)
     local req = http.request.new(req_params)
 
-    return client.backend.send(req)
+    return client.backend:send(req)
   end
 end
 
@@ -111,7 +111,7 @@ http.method_with_body = function(method, client)
     req_params.body = body
     local req = http.request.new(req_params)
 
-    return client.backend.send(req)
+    return client.backend:send(req)
   end
 end
 

--- a/apicast/src/resty/http_ng/backend/async_resty.lua
+++ b/apicast/src/resty/http_ng/backend/async_resty.lua
@@ -106,7 +106,7 @@ local function future(thread, request)
   })
 end
 
-_M.send = function(request)
+_M.send = function(_, request)
   local thread = spawn(_M.async, request)
   return future(thread, request)
 end

--- a/apicast/src/resty/http_ng/backend/cache.lua
+++ b/apicast/src/resty/http_ng/backend/cache.lua
@@ -1,0 +1,43 @@
+local setmetatable = setmetatable
+
+------------
+--- HTTP
+-- HTTP client
+-- @module http_ng.backend
+
+local _M = {}
+
+local mt = { __index = _M }
+
+function _M.new(backend, options)
+  local opts = options or {}
+  return setmetatable({
+    backend = backend, cache_store = opts.cache_store
+  }, mt)
+end
+
+--- Send request and return the response
+-- @tparam http_ng.request request
+-- @treturn http_ng.response
+function _M:send(request)
+  local cache_store = self.cache_store
+  local backend = self.backend
+
+  if cache_store then
+     local res, err = cache_store:get(request)
+
+     if not res then
+
+       res, err = backend:send(request)
+       if res and not err then
+         cache_store:set(res)
+       end
+     end
+
+     return res, err
+  else
+    return backend:send(request)
+  end
+end
+
+return _M

--- a/apicast/src/resty/http_ng/backend/cache.lua
+++ b/apicast/src/resty/http_ng/backend/cache.lua
@@ -23,21 +23,15 @@ function _M:send(request)
   local cache_store = self.cache_store
   local backend = self.backend
 
+  local response, err
+
   if cache_store then
-     local res, err = cache_store:get(request)
-
-     if not res then
-
-       res, err = backend:send(request)
-       if res and not err then
-         cache_store:set(res)
-       end
-     end
-
-     return res, err
+    response, err = cache_store:send(backend, request)
   else
-    return backend:send(request)
+    response, err = backend:send(request)
   end
+
+  return response, err
 end
 
 return _M

--- a/apicast/src/resty/http_ng/backend/ngx.lua
+++ b/apicast/src/resty/http_ng/backend/ngx.lua
@@ -14,7 +14,7 @@ local METHODS = {
 local PROXY_LOCATION = '/___http_call'
 
 backend.capture = ngx.location.capture
-backend.send = function(request)
+backend.send = function(_, request)
   local res = backend.capture(PROXY_LOCATION, {
     method = METHODS[request.method],
     body = request.body,

--- a/apicast/src/resty/http_ng/backend/resty.lua
+++ b/apicast/src/resty/http_ng/backend/resty.lua
@@ -10,7 +10,7 @@ local http = require 'resty.resolver.http'
 --- Send request and return the response
 -- @tparam http_ng.request request
 -- @treturn http_ng.response
-backend.send = function(request)
+backend.send = function(_, request)
   local httpc = http.new()
   local ssl_verify = request.options and request.options.ssl and request.options.ssl.verify
 

--- a/apicast/src/resty/http_ng/backend/test.lua
+++ b/apicast/src/resty/http_ng/backend/test.lua
@@ -2,6 +2,7 @@ local pairs = pairs
 local type = type
 local assert = assert
 local setmetatable = setmetatable
+local getmetatable = getmetatable
 local insert = table.insert
 local remove = table.remove
 local error = error
@@ -13,7 +14,15 @@ local _M = {}
 local function contains(expected, actual)
   if actual == expected then return true end
   local t1,t2 = type(actual), type(expected)
-  if t1 ~= t2 then return false, format("can't compare %q with %q", t1, t2) end
+
+  if t1 ~= t2 then
+    local mt = getmetatable(actual) or {}
+    if t2 == 'string' and mt.__tostring then
+      return mt.__tostring(actual) == expected
+    else
+      return false, format("can't compare %q with %q", t1, t2)
+    end
+  end
 
   if t1 == 'table' then
     for k,v in pairs(expected) do

--- a/apicast/src/resty/http_ng/backend/test.lua
+++ b/apicast/src/resty/http_ng/backend/test.lua
@@ -60,7 +60,7 @@ _M.new = function()
     return expectation
   end
 
-  backend.send = function(request)
+  backend.send = function(_, request)
     local expectation = remove(expectations, 1)
 
     if not expectation then error('no expectation') end

--- a/apicast/src/resty/http_ng/cache_store.lua
+++ b/apicast/src/resty/http_ng/cache_store.lua
@@ -11,7 +11,7 @@ local max = math.max
 local pairs = pairs
 local floor = math.floor
 
-local _M = { default_size = 1000 }
+local _M = { default_size = 100 }
 
 local mt = { __index = _M }
 

--- a/apicast/src/resty/http_ng/cache_store.lua
+++ b/apicast/src/resty/http_ng/cache_store.lua
@@ -6,46 +6,31 @@ local setmetatable = setmetatable
 local gsub = string.gsub
 local lower = string.lower
 local format = string.format
+local insert = table.insert
+local tonumber = tonumber
+local max = math.max
+local ipairs = ipairs
+local floor = math.floor
 
 local _M = { default_size = 1000 }
 
 local mt = { __index = _M }
 
-function _M.new(size)
-  return setmetatable({ cache = lrucache.new(size or _M.default_size) }, mt)
+function _M.new(store)
+  return setmetatable({ cache = store or lrucache.new(_M.default_size) }, mt)
+end
+
+local function TODO(ret)
+  return ret
 end
 
 local function request_cache_key(request)
   -- TODO: verify if this is correct cache key and what are the implications
   -- FIXME: missing headers, ...
+  -- Match Effective Request URI: https://tools.ietf.org/html/rfc7230#section-5.5
+  -- Calculate Secondary Key wtih Vary: https://tools.ietf.org/html/rfc7234#section-4.1
   return format('%s:%s', request.method, request.url)
 end
-
-function _M:get(request)
-  local cache = self.cache
-  if not cache then
-    return nil, 'not initialized'
-  end
-
-  -- TODO: verify it is valid request per the RFC: https://tools.ietf.org/html/rfc7234#section-3
-
-  local cache_key = request_cache_key(request)
-
-  if not cache_key then return end
-
-  local res, stale = cache:get(cache_key)
-
-  -- TODO: handle stale responses per the RFC: https://tools.ietf.org/html/rfc7234#section-4.2.4
-  local serve_stale = false
-
-  if res then
-    return res
-  elseif serve_stale then
-    -- TODO: generate Warning header per the RFC: https://tools.ietf.org/html/rfc7234#section-4.2.4
-    return stale
-  end
-end
-
 
 local function parse_cache_control(value)
   if not value then return end
@@ -74,16 +59,425 @@ local function parse_cache_control(value)
   return cache_control
 end
 
+local empty_t = {}
+
+local function no_cache(http)
+  -- the presented request does not contain the no-cache pragma
+  -- (Section 5.4), nor the no-cache cache directive (Section 5.2.1),
+  -- unless the stored response is successfully validated (Section 4.3)
+  -- TODO: implement the "unless the stored response is successfuly validated"
+
+  local pragma = parse_cache_control(http.headers.pragma) or empty_t
+  local cache_control = parse_cache_control(http.headers.cache_control) or empty_t
+
+  return pragma.no_cache or cache_control.no_cache
+end
+
+local function reuse_stored_response(request)
+  -- https://tools.ietf.org/html/rfc7234#section-4
+  return request.version > 1.0 and not no_cache(request)
+end
+
+function _M:trace(message, object)
+  -- trace events
+end
+
+-- Invalidation https://tools.ietf.org/html/rfc7234#section-4.4
+function _M:delete(response)
+  -- TODO: implement invalidation (Section 4.4)
+end
+
+--- Section 4.2.1. Calculating Freshness Lifetime
+-- https://tools.ietf.org/html/rfc7234#section-4.2.1
+local function freshness_lifetime(response)
+  local cache_control = parse_cache_control(response.headers.cache_control) or empty_t
+  local expires = ngx.parse_http_time(response.headers.expires or '')
+  local date = ngx.parse_http_time(response.headers.date)
+
+  --  A cache can calculate the freshness lifetime (denoted as freshness_lifetime)
+  --  of a response by using the first match of the following:
+  return tonumber(
+    --  If the cache is shared and the s-maxage response directive
+    -- (Section 5.2.2.9) is present, use its value,
+    (_M.shared and cache_control.s_maxage)
+        or
+    --  If the max-age response directive (Section 5.2.2.8) is present, use its value,
+    cache_control.max_age
+      or
+    --  If the Expires response header field (Section 5.3) is present, use
+    --  its value minus the value of the Date response header field,
+    (expires and expires - date)
+      or
+    --  Otherwise, no explicit expiration time is present in the response.
+    --  A heuristic freshness lifetime might be applicable; see Section 4.2.2.
+    0 -- TODO: implement Heuristic Freshness https://tools.ietf.org/html/rfc7234#section-4.2.2
+  )
+end
+
+--- Section 4.2.3. Calculating Age
+-- https://tools.ietf.org/html/rfc7234#section-4.2.3
+local function current_age(response)
+  --  The term "age_value" denotes the value of the Age header field
+  --  (Section 5.1), in a form appropriate for arithmetic operation; or
+  --  0, if not available.
+  local age_value = 0
+
+  --  The term "date_value" denotes the value of the Date header field,
+  --  in a form appropriate for arithmetic operations.  See Section
+  --  7.1.1.2 of [RFC7231](https://tools.ietf.org/html/rfc7231#section-7.1.1.2)
+  --  for the definition of the Date header field,
+  --  and for requirements regarding responses without it.
+  local date_value = ngx.parse_http_time(response.headers.date)
+
+  --  The term "now" means "the current value of the clock at the host
+  --  performing the calculation".  A host ought to use NTP ([RFC5905])
+  --  or some similar protocol to synchronize its clocks to Coordinated
+  --  Universal Time.
+  local now = ngx.now()
+
+  --  The current value of the clock at the host at the time the request
+  --  resulting in the stored response was made.
+  local request_time = response.request_time
+
+  -- The current value of the clock at the host at the time the
+  -- response was received.
+  local response_time = response.response_time
+
+  -- A response's age can be calculated in two entirely independent ways:
+
+  -- 1. the "apparent_age": response_time minus date_value, if the local
+  -- clock is reasonably well synchronized to the origin server's
+  -- clock. If the result is negative, the result is replaced by zero.
+
+  local apparent_age = max(0, response_time - date_value)
+
+  -- 2. the "corrected_age_value", if all of the caches along the
+  -- response path implement HTTP/1.1.  A cache MUST interpret this
+  -- value relative to the time the request was initiated, not the
+  -- time that the response was received.
+  local response_delay = response_time - request_time
+  local corrected_age_value = age_value + response_delay
+
+  local corrected_initial_age = max(apparent_age, corrected_age_value)
+
+  -- The current_age of a stored response can then be calculated by adding
+  -- the amount of time (in seconds) since the stored response was last
+  -- validated by the origin server to the corrected_initial_age.
+
+  local resident_time = now - response_time
+
+  return corrected_initial_age + resident_time
+end
+
+local function fresh_response(response)
+  if not response then return nil, 'no response' end
+
+  local age = current_age(response)
+  local response_is_fresh = (freshness_lifetime(response) > age)
+
+  if response_is_fresh then
+    response.headers.age = floor(age)
+  end
+
+  return response_is_fresh-- TODO: implement freshness https://tools.ietf.org/html/rfc7234#section-4.2
+end
+
+local function stale_response(response)
+  if not response then return nil, 'no response' end
+
+  -- TODO: implement https://tools.ietf.org/html/rfc7234#section-4.2.4
+  local cache_control = parse_cache_control(response.headers.cache_control) or empty_t
+
+  return cache_control.must_revalidate
+end
+
+local function serve_stale_response(response)
+  -- TODO: handle stale responses per the RFC: https://tools.ietf.org/html/rfc7234#section-4.2.4
+
+  --  A cache MUST NOT generate a stale response if it is prohibited by an
+  --  explicit in-protocol directive (e.g., by a "no-store" or "no-cache"
+  --  cache directive, a "must-revalidate" cache-response-directive, or an
+  --  applicable "s-maxage" or "proxy-revalidate" cache-response-directive; see Section 5.2.2).
+end
+
+function _M:get(request)
+  local cache = self.cache
+  if not cache then
+    return nil, 'not initialized'
+  end
+
+  -- TODO: verify it is valid request per the RFC: https://tools.ietf.org/html/rfc7234#section-3
+
+  request.headers = request.headers or http_headers.new()
+  request.headers.via = (request.headers.via or {})
+  request.headers.via['1.1 APIcast'] = true
+
+  if not reuse_stored_response(request) then
+    self:trace('not reusing stored response', request)
+    return nil, 'not reusing stored response'
+  end
+
+  local cache_key = request_cache_key(request)
+
+  if not cache_key then return nil, 'missing cache key' end
+
+  local res = cache:get(cache_key)
+
+  if fresh_response(res) then
+    res.headers.x_cache_status = 'HIT'
+    return res
+  elseif res then
+    res.headers.x_cache_status = 'EXPIRED'
+  end
+
+  if stale_response(res) then
+    res.headers.x_cache_status = 'STALE'
+
+    if serve_stale_response(res) then
+      -- TODO: generate Warning header per the RFC: https://tools.ietf.org/html/rfc7234#section-4.2.4
+      return res
+    end
+  end
+
+  if res then
+    return res, 'must-revalidate'
+  end
+
+  return res
+end
+
 local function response_cache_key(response)
   return request_cache_key(response.request)
 end
 
 local function response_ttl(response)
-  local cache_control = parse_cache_control(response.headers.cache_control)
+  local cache_control = parse_cache_control(response.headers.cache_control) or empty_t
 
   return cache_control.max_age
 end
 
+local allowed_status_codes = {
+  [200] = true
+}
+
+local allowed_methods = {
+  GET = true,
+  HEAD = true
+}
+
+local function cacheable_response(response)
+  -- TODO: verify it is valid response per the RFC: https://tools.ietf.org/html/rfc7234#section-3
+
+  local request = response.request
+
+  local request_cache_control = parse_cache_control(request.headers.cache_control) or empty_t
+  local response_cache_control = parse_cache_control(response.headers.cache_control) or empty_t
+
+  --  A cache MUST NOT store a response to any request, unless:
+  return (
+    --  The request method is understood by the cache and defined as being cacheable
+    allowed_methods[request.method]
+      and
+    --  the response status code is understood by the cache
+    allowed_status_codes[response.status]
+      and
+    --  the "no-store" cache directive (see Section 5.2) does not appear in request or response header fields
+    not (request_cache_control.no_store or response_cache_control.no_store)
+      and
+    --  the "private" response directive (see Section 5.2.2.6) does not appear in the response, if the cache is shared
+    not (_M.shared and response_cache_control.private)
+      and
+    --  the Authorization header field (see Section 4.2 of [RFC7235]) does
+    --  not appear in the request, if the cache is shared, unless the
+    --  response explicitly allows it (see Section 3.2)
+    not (_M.shared and request.headers.authorization)
+      and ( -- the response either:
+      --  contains an Expires header field (see Section 5.3)
+      response.headers.expires
+        or
+      -- contains a max-age response directive (see Section 5.2.2.8)
+      response_cache_control.max_age
+        or
+      -- contains a s-maxage response directive (see Section 5.2.2.9) and the cache is shared
+      (response_cache_control.s_maxage and _M.shared)
+        or
+      --  contains a Cache Control Extension (see Section 5.2.3) allows it to be cached
+      TODO(false) -- TODO: https://tools.ietf.org/html/rfc7234#section-5.2.3
+        or
+      --  has a status code that is defined as cacheable by default (see Section 4.2.2)
+      TODO(false) -- TODO: https://tools.ietf.org/html/rfc7234#section-4.2.2
+        or
+      --  contains a public response directive (see Section 5.2.2.5).
+      TODO(false) -- TODO: https://tools.ietf.org/html/rfc7234#section-5.2.2.5
+    )
+  )
+end
+
+function _M:entry(response)
+  return {
+    body = response.body,
+    headers = http_headers.new(response.headers),
+    status = response.status,
+    response_time = response.time,
+    request_time = response.request.time
+  }
+end
+
+local function send(backend, request)
+  request.time = ngx.now()
+  local res, err = backend:send(request)
+
+  if res then
+    res.time = ngx.now()
+  end
+
+  return res, err
+end
+
+
+function _M:send(backend, request)
+  local response, err = self:get(request)
+
+  if response and err then
+    response, err = self:revalidate(response, backend, request)
+  elseif err then
+    ngx.log(ngx.WARN, 'http cache store: ', err) -- FIXME: for debuging
+  end
+
+  if not response then
+    response, err = send(backend, request)
+
+    if response and not err then
+      response.headers.x_cache_status = 'MISS'
+
+      local ok, err = self:set(response)
+
+      if not ok and err then
+        ngx.log(ngx.WARN, 'http cache store: ', err) -- FIXME: for debugging we need more info
+      end
+    end
+  end
+
+  return response, err
+end
+
+local function freshen_stored_response(stored, response)
+  local response_etag = response.headers.etag
+  local stored_etag = stored.headers.etag
+
+  local update
+
+  --  If the new response contains a strong validator (see Section 2.1
+  --  of [RFC7232]), then that strong validator identifies the selected
+  --  representation for update.  All of the stored responses with the
+  --  same strong validator are selected.  If none of the stored
+  --  responses contain the same strong validator, then the cache MUST
+  --  NOT use the new response to update any stored responses.
+  if response_etag then
+    -- FIXME: yeah, we should first check if the ETag is strong or weak, but
+    -- we don't support weak ETags yet and treat them as strong.
+
+    --  If the new response contains a weak validator and that validator
+    --  corresponds to one of the cache's stored responses, then the most
+    --  recent of those matching stored responses is selected for update.
+    if stored_etag == response_etag then
+      update = stored
+    else
+      return stored
+    end
+  end
+
+  --  If the new response does not include any form of validator (such
+  --  as in the case where a client generates an If-Modified-Since
+  --  request from a source other than the Last-Modified response header
+  --  field), and there is only one stored response, and that stored
+  --  response also lacks a validator, then that stored response is
+  --  selected for update.
+
+  if (not response_etag and not response.headers.last_modified) and
+     (not stored_etag and not stored.headers.last_modified) then
+    update = stored
+  end
+
+  -- If a stored response is selected for update, the cache MUST:
+  if update then
+    --  delete any Warning header fields in the stored response with
+    --  warn-code 1xx (see Section 5.5);
+    -- TODO: implement Warning header
+
+    --  retain any Warning header fields in the stored response with
+    --  warn-code 2xx; and,
+    -- TODO: implement Warning header
+
+    --  use other header fields provided in the 304 (Not Modified)
+    --  response to replace all instances of the corresponding header
+    --  fields in the stored response.
+
+    for name, value in ipairs(response.headers) do
+      puts('updating name ', name , 'to ', value)
+      if update.headers[name] then
+        update.headers[name] = value
+      end
+    end
+    update.headers.x_cache_status = 'REVALIDATED'
+  end
+
+  -- FIXME: set the X-Cache-Status to something other than UPDATING (from the revalidate
+
+  return stored
+end
+
+function _M:revalidate(response, backend, request)
+  local etag = response.headers.etag
+  local last_modified = response.headers.last_modified
+
+  response.headers.x_cache_status = 'UPDATING'
+
+  -- One such validator is the timestamp given in a Last-Modified header
+  -- field (Section 2.2 of [RFC7232]), which can be used in an
+  -- If-Modified-Since header field for response validation, or in an
+  -- If-Unmodified-Since or If-Range header field for representation
+  -- selection (i.e., the client is referring specifically to a previously
+  -- obtained representation with that timestamp).
+  request.headers.if_modified_since = last_modified
+
+  --  Another validator is the entity-tag given in an ETag header field
+  --  (Section 2.3 of [RFC7232]).  One or more entity-tags, indicating one
+  --  or more stored responses, can be used in an If-None-Match header
+  --  field for response validation, or in an If-Match or If-Range header
+  --  field for representation selection (i.e., the client is referring
+  --  specifically to one or more previously obtained representations with
+  --  the listed entity-tags).
+  request.headers.if_none_match = etag
+
+  -- TODO: implement representation selection validation
+
+  local res, err = send(backend, request)
+
+  --  A 304 (Not Modified) response status code indicates that the
+  --  stored response can be updated and reused; see Section 4.3.4.
+  if res and res.status == 304 then
+    return freshen_stored_response(response, res)
+
+  --  However, if a cache receives a 5xx (Server Error) response while
+  --  attempting to validate a response, it can either forward this
+  --  response to the requesting client, or act as if the server failed
+  --  to respond.  In the latter case, the cache MAY send a previously
+  --  stored response (see Section 4.2.4).
+  elseif res.status >= 500 and res.status < 600 then
+    return response -- returns cached response
+
+  --  A full response (i.e., one with a payload body) indicates that
+  --  none of the stored responses nominated in the conditional request
+  --  is suitable.  Instead, the cache MUST use the full response to
+  --  satisfy the request and MAY replace the stored response(s).
+  elseif res then
+    self:set(res)
+    return res
+  end
+
+  return res, err
+end
 
 function _M:set(response)
   local cache = self.cache
@@ -92,23 +486,22 @@ function _M:set(response)
     return nil, 'not initialized'
   end
 
-  -- TODO: verify it is valid response per the RFC: https://tools.ietf.org/html/rfc7234#section-3
-  if not response then return end
+  if not cacheable_response(response) then
+    return nil, 'not cacheable response'
+  end
 
   local cache_key = response_cache_key(response)
 
-  if not cache_key then return end
+  if not cache_key then return nil, 'invalid cache key' end
 
   local ttl = response_ttl(response)
 
   if ttl then
-    local res = {
-      body = response.body,
-      headers = http_headers.new(response.headers),
-      status = response.status
-    }
+    local res = self:entry(response)
 
-    cache:set(cache_key, res, ttl)
+    cache:set(cache_key, res)
+
+    return res
   end
 end
 

--- a/apicast/src/resty/http_ng/cache_store.lua
+++ b/apicast/src/resty/http_ng/cache_store.lua
@@ -1,0 +1,116 @@
+local lrucache = require 'resty.lrucache'
+local ngx_re = require 'ngx.re'
+local http_headers = require 'resty.http_ng.headers'
+
+local setmetatable = setmetatable
+local gsub = string.gsub
+local lower = string.lower
+local format = string.format
+
+local _M = { default_size = 1000 }
+
+local mt = { __index = _M }
+
+function _M.new(size)
+  return setmetatable({ cache = lrucache.new(size or _M.default_size) }, mt)
+end
+
+local function request_cache_key(request)
+  -- TODO: verify if this is correct cache key and what are the implications
+  -- FIXME: missing headers, ...
+  return format('%s:%s', request.method, request.url)
+end
+
+function _M:get(request)
+  local cache = self.cache
+  if not cache then
+    return nil, 'not initialized'
+  end
+
+  -- TODO: verify it is valid request per the RFC: https://tools.ietf.org/html/rfc7234#section-3
+
+  local cache_key = request_cache_key(request)
+
+  if not cache_key then return end
+
+  local res, stale = cache:get(cache_key)
+
+  -- TODO: handle stale responses per the RFC: https://tools.ietf.org/html/rfc7234#section-4.2.4
+  local serve_stale = false
+
+  if res then
+    return res
+  elseif serve_stale then
+    -- TODO: generate Warning header per the RFC: https://tools.ietf.org/html/rfc7234#section-4.2.4
+    return stale
+  end
+end
+
+
+local function parse_cache_control(value)
+  if not value then return end
+
+  local res, err = ngx_re.split(value, '\\s*,\\s*', 'oj')
+
+  local cache_control = {}
+
+  local t = {}
+
+  for i=1, #res do
+    local res, err = ngx_re.split(res[i], '=', 'oj', nil, 2, t)
+
+    if err then
+      ngx.log(ngx.WARN, err)
+    else
+      -- TODO: selectively handle quoted strings per the RFC: https://tools.ietf.org/html/rfc7234#section-5.2
+      cache_control[gsub(lower(res[1]), '-', '_')] = tonumber(res[2]) or res[2] or true
+    end
+  end
+
+  if err then
+    ngx.log(ngx.WARN, err)
+  end
+
+  return cache_control
+end
+
+local function response_cache_key(response)
+  return request_cache_key(response.request)
+end
+
+local function response_ttl(response)
+  local cache_control = parse_cache_control(response.headers.cache_control)
+
+  return cache_control.max_age
+end
+
+
+function _M:set(response)
+  local cache = self.cache
+
+  if not cache then
+    return nil, 'not initialized'
+  end
+
+  -- TODO: verify it is valid response per the RFC: https://tools.ietf.org/html/rfc7234#section-3
+  if not response then return end
+
+  local cache_key = response_cache_key(response)
+
+  if not cache_key then return end
+
+  local ttl = response_ttl(response)
+
+  if ttl then
+    local res = {
+      body = response.body,
+      headers = http_headers.new(response.headers),
+      status = response.status
+    }
+
+    cache:set(cache_key, res, ttl)
+  end
+end
+
+
+return _M

--- a/apicast/src/resty/http_ng/cache_store.lua
+++ b/apicast/src/resty/http_ng/cache_store.lua
@@ -344,8 +344,6 @@ function _M:send(backend, request)
     response, error = send(backend, request)
 
     if response and not error then
-      response.headers.x_cache_status = 'MISS'
-
       local ok, err = self:set(response)
 
       if not ok and err then
@@ -480,6 +478,8 @@ function _M:set(response)
   if not cache then
     return nil, 'not initialized'
   end
+
+  response.headers.x_cache_status = 'MISS'
 
   if not cacheable_response(response) then
     return nil, 'not cacheable response'

--- a/apicast/src/resty/http_ng/headers.lua
+++ b/apicast/src/resty/http_ng/headers.lua
@@ -5,11 +5,18 @@ local pairs = pairs
 local rawset = rawset
 local rawget = rawget
 local setmetatable = setmetatable
+local getmetatable = getmetatable
+local type = type
+local lower = string.lower
+
+local normalize_exceptions = {
+  etag = 'ETag'
+}
 
 local headers = {}
 local headers_mt = {
   __newindex = function(table, key, value)
-    rawset(table, headers.normalize_key(key), value)
+    rawset(table, headers.normalize_key(key), headers.normalize_value(value))
     return value
   end,
   __index = function(table, key)
@@ -23,11 +30,50 @@ local capitalize = function(string)
 end
 
 headers.normalize_key = function(key)
+  local exception = normalize_exceptions[headers.downcase_key(key)]
+
+  if exception then
+    return exception
+  end
+
   local parts = {}
   key:gsub('[^_-]+', function(part)
     insert(parts, capitalize(part))
   end)
+
   return concat(parts, '-')
+end
+
+headers.downcase_key = function(key)
+  local parts = {}
+  key:gsub('[^_-]+', function(part)
+    insert(parts, lower(part))
+  end)
+  return concat(parts, '_')
+end
+
+local header_mt = {
+  __tostring = function(t)
+    local tmp = {}
+
+    for k,v in pairs(t) do
+      if type(k) == 'string' then
+        insert(tmp, k)
+      elseif type(v) == 'string' then
+        insert(tmp, v)
+      end
+    end
+
+    return concat(tmp, ', ')
+  end
+}
+
+headers.normalize_value = function(value)
+  if type(value) == 'table' and getmetatable(value) == nil then
+    return setmetatable(value, header_mt)
+  else
+    return value
+  end
 end
 
 headers.normalize = function(http_headers)
@@ -35,7 +81,7 @@ headers.normalize = function(http_headers)
 
   local normalized = {}
   for k,v in pairs(http_headers) do
-    normalized[headers.normalize_key(k)] = v
+    normalized[headers.normalize_key(k)] = headers.normalize_value(v)
   end
 
   return normalized

--- a/apicast/src/resty/http_ng/request.lua
+++ b/apicast/src/resty/http_ng/request.lua
@@ -37,6 +37,7 @@ function request.new(req)
   assert(req.url)
   assert(req.method)
 
+  req.version = req.version or 1.1
   req.options = req.options or {}
   req.client = req.client or {}
 

--- a/apicast/src/resty/http_ng/response.lua
+++ b/apicast/src/resty/http_ng/response.lua
@@ -22,8 +22,8 @@ response.headers = require 'resty.http_ng.headers'
 
 
 function response.new(request, status, headers, body)
-  assert(status)
-  assert(body)
+  assert(status, 'missing request status')
+  assert(body, 'missing request body')
 
   local mt = {}
   mt['__index'] = function(table, key)
@@ -46,6 +46,13 @@ function response.new(request, status, headers, body)
   elseif type(body) == 'function' then
     mt.body = body
   end
+
+  -- https://tools.ietf.org/html/rfc7231#section-7.1.1.2
+  -- > A recipient with a clock that receives a response message without a
+  --   Date header field MUST record the time it was received and append a
+  --   corresponding Date header field to the message's header section if it
+  --   is cached or forwarded downstream.
+  res.headers.date = res.headers.date or ngx.http_time(ngx.time())
 
   return setmetatable(res, mt)
 end

--- a/spec/fake_backend_helper.lua
+++ b/spec/fake_backend_helper.lua
@@ -3,7 +3,7 @@ local fake_backend = {}
 function fake_backend.new()
   local backend = { requests = {} }
 
-  backend.send = function(request)
+  backend.send = function(_, request)
     backend.requests[#backend.requests + 1] = request
     backend.last_request = request
     return { request = request, status = 200 }

--- a/spec/fake_backend_helper.lua
+++ b/spec/fake_backend_helper.lua
@@ -1,12 +1,19 @@
+local type = type
+
 local fake_backend = {}
 
-function fake_backend.new()
+function fake_backend.new(response)
   local backend = { requests = {} }
 
   backend.send = function(_, request)
     backend.requests[#backend.requests + 1] = request
     backend.last_request = request
-    return { request = request, status = 200 }
+
+    if response then
+      return response(request)
+    else
+      return { request = request, status = 200 }
+    end
   end
 
   return backend

--- a/spec/fake_backend_helper.lua
+++ b/spec/fake_backend_helper.lua
@@ -1,5 +1,3 @@
-local type = type
-
 local fake_backend = {}
 
 function fake_backend.new(response)

--- a/spec/keycloak_spec.lua
+++ b/spec/keycloak_spec.lua
@@ -51,11 +51,11 @@ describe('Keycloak', function()
       stub(ngx.req, 'get_uri_args', function() return { response_type = 'code', client_id = 'foo', redirect_uri = 'bar' } end)
 
       test_backend.expect{ url = 'http://www.example.com:80/auth/realms/test/protocol/openid-connect/auth?client_id=foo' }
-        .respond_with{ status = 200 , body = 'foo', headers = {} }
+        .respond_with{ status = 200 , body = 'foo', headers = { Date = "Thu, 18 Nov 2010 11:27:35 GMT" } }
 
       stub(_M, 'respond_and_exit')
       keycloak:authorize({}, test_backend)
-      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', {})
+      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', { Date = "Thu, 18 Nov 2010 11:27:35 GMT" })
     end)
 
     it('returns error when response_type missing', function()
@@ -98,11 +98,11 @@ describe('Keycloak', function()
       stub(ngx.req, 'get_headers', function() return { } end)
 
       test_backend.expect{ url = 'http://www.example.com:80/auth/realms/test/protocol/openid-connect/token'}
-        .respond_with{ status = 200 , body = 'foo', headers = {} }
+        .respond_with{ status = 200 , body = 'foo', headers = { Date = "Thu, 18 Nov 2010 11:27:35 GMT" } }
 
       keycloak:get_token({}, test_backend)
 
-      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', {})
+      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', { Date = "Thu, 18 Nov 2010 11:27:35 GMT" })
     end)
 
     it('returns "invalid_request" when grant_type missing', function ()
@@ -171,11 +171,11 @@ describe('Keycloak', function()
       stub(ngx.req, 'get_headers', function() return { } end)
 
       test_backend.expect{ url = 'http://www.example.com:80/auth/realms/test/protocol/openid-connect/token'}
-        .respond_with{ status = 200 , body = 'foo', headers = {} }
+        .respond_with{ status = 200 , body = 'foo', headers = { Date = "Thu, 18 Nov 2010 11:27:35 GMT" } }
 
       keycloak:get_token({}, test_backend)
 
-      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', {})
+      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', { Date = "Thu, 18 Nov 2010 11:27:35 GMT" })
     end)
 
     it('accepts client credentials in Authorization header', function()
@@ -194,11 +194,11 @@ describe('Keycloak', function()
       test_backend.expect{
         url = 'http://www.example.com:80/auth/realms/test/protocol/openid-connect/token',
         headers =  { authorization = auth }
-      }.respond_with{ status = 200 , body = 'foo', headers = {} }
+      }.respond_with{ status = 200 , body = 'foo', headers = { Date = "Thu, 18 Nov 2010 11:27:35 GMT" } }
 
       keycloak:get_token({}, test_backend)
 
-      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', {})
+      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', { Date = "Thu, 18 Nov 2010 11:27:35 GMT" })
     end)
 
   end)

--- a/spec/resty/http_ng/backend/async_resty_spec.lua
+++ b/spec/resty/http_ng/backend/async_resty_spec.lua
@@ -6,7 +6,7 @@ describe('resty backend', function()
     local method = 'GET'
 
     it('accesses the url', function()
-      local response = backend.send{method = method, url = 'http://example.com/'}
+      local response = backend:send{method = method, url = 'http://example.com/'}
       assert.truthy(response)
       assert.falsy(response.error)
       assert.truthy(response.ok)
@@ -16,7 +16,7 @@ describe('resty backend', function()
     end)
 
     it('works with ssl', function()
-      local response, err = backend.send{
+      local response, err = backend:send{
         method = method, url = 'https://google.com/',
         -- This is needed because of https://groups.google.com/forum/#!topic/openresty-en/SuqORBK9ys0
         -- So far OpenResty can't use system certificated on demand.
@@ -33,7 +33,7 @@ describe('resty backend', function()
     it('returns proper error on connect timeout', function()
       local req = { method = method, url = 'http://example.com:81/', timeout = { connect = 1 } }
 
-      local response = backend.send(req)
+      local response = backend:send(req)
 
       assert.truthy(response)
       assert.equal('timeout', response.error)
@@ -44,7 +44,7 @@ describe('resty backend', function()
     it('returns proper error on read timeout', function()
       local req = { method = method, url = 'http://example.com/', timeout = { read = 1 } }
 
-      local response = backend.send(req)
+      local response = backend:send(req)
 
       assert.truthy(response)
       assert.equal('timeout', response.error)
@@ -55,7 +55,7 @@ describe('resty backend', function()
     it('returns proper error on invalid ssl', function()
       local req = { method = method, url = 'https://untrusted-root.badssl.com/', options = { ssl = { verify = true } } }
 
-      local response = backend.send(req)
+      local response = backend:send(req)
 
       assert.truthy(response)
       assert.match('unable to get local issuer certificate', response.error)
@@ -66,7 +66,7 @@ describe('resty backend', function()
     it('returns proper error on invalid request', function()
       local req = { method = method }
 
-      local response = backend.send(req)
+      local response = backend:send(req)
 
       assert.truthy(response)
       assert.match('failed to create async request', response.error)
@@ -78,7 +78,7 @@ describe('resty backend', function()
   describe('when there is no error', function()
     local response
     before_each(function()
-      response = backend.send{ method = 'GET', url = 'http://127.0.0.1:1984' }
+      response = backend:send{ method = 'GET', url = 'http://127.0.0.1:1984' }
     end)
 
     it('is ok', function()
@@ -93,7 +93,7 @@ describe('resty backend', function()
   describe('when there is error', function()
     local response
     before_each(function()
-      response = backend.send{ method = 'GET', url = 'http://127.0.0.1:1' }
+      response = backend:send{ method = 'GET', url = 'http://127.0.0.1:1' }
     end)
 
     it('is not ok', function()

--- a/spec/resty/http_ng/backend/cache_spec.lua
+++ b/spec/resty/http_ng/backend/cache_spec.lua
@@ -1,21 +1,23 @@
 local _M = require 'resty.http_ng.backend.cache'
 local fake_backend = require 'fake_backend_helper'
 local spy = require 'luassert.spy'
-local http_response = require 'resty.http_ng.response'
 local cache_store = require 'resty.http_ng.cache_store'
+local http_response = require 'resty.http_ng.response'
+local http_request = require 'resty.http_ng.request'
 
 local inspect = require 'inspect'
+
 describe('cache backend', function()
   describe('GET method', function()
     local function cache(res, options)
       local fake = fake_backend.new(res)
-      return _M.new(fake, options)
+      return _M.new(fake, options or { cache_store = cache_store.new() })
     end
 
     it('accesses the url', function()
       local res = spy.new(function(req) return http_response.new(req, 200, { }, 'ok') end)
-
-      local response, err = cache(res):send{method = 'GET', url = 'http://example.com/' }
+      local request = http_request.new{method = 'GET', url = 'http://example.com/' }
+      local response, err = cache(res):send(request)
 
       assert.falsy(err)
       assert.truthy(response)
@@ -23,30 +25,67 @@ describe('cache backend', function()
       assert.spy(res).was.called(1)
 
       assert.equal('ok', response.body)
+      assert.equal('MISS', response.headers.x_cache_status)
     end)
 
-    it('accesses caches the call', function()
+    it('works with etag and must-revalidate', function()
       local res = spy.new(function(req)
+        local headers = {
+          ETag = 'etag-value', ['Cache-Control'] = 'max-age=0, private, must-revalidate', Vary = 'Accept-Encoding'
+        }
+        assert.equal('1.1 APIcast', tostring(req.headers.via))
+        if req.headers.if_none_match == 'etag-value' then
+          return http_response.new(req, 304, headers, '')
+        else
+          return http_response.new(req, 200, headers, 'ok')
+        end
+      end)
+      local request = http_request.new{method = 'GET', url = 'http://example.com/test' }
+      local backend = cache(res)
+
+      local miss_response = assert(backend:send(request))
+      local hit_response = assert(backend:send(request))
+
+      assert.spy(res).was.called(2)
+
+      assert.equal('MISS', miss_response.headers.x_cache_status)
+      assert.equal('REVALIDATED', hit_response.headers.x_cache_status)
+
+      assert.equal('ok', miss_response.body)
+      assert.equal('ok', hit_response.body)
+    end)
+
+    it('accesses caches the call #TEST', function()
+      local server = spy.new(function(req)
+        assert.match('1.1 APIcast', req.headers.via)
         return http_response.new(req, 200, {
           cache_control = 'private, max-age=10'
         }, 'ok')
       end)
 
-      local backend = cache(res, { cache_store = cache_store.new() })
+      local backend = cache(server)
 
-      local function check()
-        local response, err = backend:send{method = 'GET', url = 'http://example.com/' }
+      local request = http_request.new{method = 'GET', url = 'http://example.com/' }
 
-        assert.spy(res).was.called(1)
+      local function response(req)
+        local res, err = backend:send(req)
 
-        assert.truthy(response)
+        assert.spy(server).was.called(1)
+
+        assert.truthy(res)
         assert.falsy(err)
 
-        assert.equal('ok', response.body)
+        assert.equal('ok', res.body)
+
+        return res
       end
 
-      check()
-      check()
+      local miss = response(request)
+      local hit = response(request)
+
+      assert.equal('MISS', miss.headers.x_cache_status)
+      assert.equal('HIT', hit.headers.x_cache_status)
+      assert.equal(0, hit.headers.age)
     end)
   end)
 end)

--- a/spec/resty/http_ng/backend/cache_spec.lua
+++ b/spec/resty/http_ng/backend/cache_spec.lua
@@ -5,8 +5,6 @@ local cache_store = require 'resty.http_ng.cache_store'
 local http_response = require 'resty.http_ng.response'
 local http_request = require 'resty.http_ng.request'
 
-local inspect = require 'inspect'
-
 describe('cache backend', function()
   describe('GET method', function()
     local function cache(res, options)

--- a/spec/resty/http_ng/backend/cache_spec.lua
+++ b/spec/resty/http_ng/backend/cache_spec.lua
@@ -1,0 +1,52 @@
+local _M = require 'resty.http_ng.backend.cache'
+local fake_backend = require 'fake_backend_helper'
+local spy = require 'luassert.spy'
+local http_response = require 'resty.http_ng.response'
+local cache_store = require 'resty.http_ng.cache_store'
+
+local inspect = require 'inspect'
+describe('cache backend', function()
+  describe('GET method', function()
+    local function cache(res, options)
+      local fake = fake_backend.new(res)
+      return _M.new(fake, options)
+    end
+
+    it('accesses the url', function()
+      local res = spy.new(function(req) return http_response.new(req, 200, { }, 'ok') end)
+
+      local response, err = cache(res):send{method = 'GET', url = 'http://example.com/' }
+
+      assert.falsy(err)
+      assert.truthy(response)
+
+      assert.spy(res).was.called(1)
+
+      assert.equal('ok', response.body)
+    end)
+
+    it('accesses caches the call', function()
+      local res = spy.new(function(req)
+        return http_response.new(req, 200, {
+          cache_control = 'private, max-age=10'
+        }, 'ok')
+      end)
+
+      local backend = cache(res, { cache_store = cache_store.new() })
+
+      local function check()
+        local response, err = backend:send{method = 'GET', url = 'http://example.com/' }
+
+        assert.spy(res).was.called(1)
+
+        assert.truthy(response)
+        assert.falsy(err)
+
+        assert.equal('ok', response.body)
+      end
+
+      check()
+      check()
+    end)
+  end)
+end)

--- a/spec/resty/http_ng/backend/ngx_spec.lua
+++ b/spec/resty/http_ng/backend/ngx_spec.lua
@@ -11,7 +11,7 @@ describe('ngx backend',function()
         assert.are.same({_url = 'http://localhost:8081'}, options.vars)
         return { status = 200, body = '' }
       end
-      local response = backend.send{method = method, url = 'http://localhost:8081' }
+      local response = backend:send{method = method, url = 'http://localhost:8081' }
       assert.truthy(response)
       assert.truthy(response.request)
     end)
@@ -23,7 +23,7 @@ describe('ngx backend',function()
         assert.are.same({Host = 'fake.example.com'}, options.ctx.headers)
         return { status = 200, body = '' }
       end
-      local response = backend.send{method = method, url = 'http://localhost:8081/path', headers = {Host = 'fake.example.com'} }
+      local response = backend:send{method = method, url = 'http://localhost:8081/path', headers = {Host = 'fake.example.com'} }
       assert.truthy(response)
       assert.truthy(response.request)
     end)

--- a/spec/resty/http_ng/backend/resty_spec.lua
+++ b/spec/resty/http_ng/backend/resty_spec.lua
@@ -6,7 +6,7 @@ describe('resty backend', function()
     local method = 'GET'
 
     it('accesses the url', function()
-      local response, err = backend.send{method = method, url = 'http://example.com/'}
+      local response, err = backend:send{method = method, url = 'http://example.com/'}
       assert.falsy(err)
       assert.falsy(response.error)
       assert.truthy(response.ok)
@@ -14,7 +14,7 @@ describe('resty backend', function()
     end)
 
     it('works with ssl', function()
-      local response, err = backend.send{
+      local response, err = backend:send{
         method = method, url = 'https://google.com/',
         -- This is needed because of https://groups.google.com/forum/#!topic/openresty-en/SuqORBK9ys0
         -- So far OpenResty can't use system certificated on demand.
@@ -29,7 +29,7 @@ describe('resty backend', function()
 
     it('returns error', function()
       local req = { method = method, url = 'http://0.0.0.0:0/' }
-      local response, err = backend.send(req)
+      local response, err = backend:send(req)
 
       assert.falsy(err)
       assert.truthy(response.error)

--- a/spec/resty/http_ng/backend/test_spec.lua
+++ b/spec/resty/http_ng/backend/test_spec.lua
@@ -11,7 +11,7 @@ describe('test backend',function()
       backend.expect{method = 'GET'}.respond_with{status = 301 }
 
       local req = request.new{method = 'GET', url = 'http://example.com' }
-      local response = backend.send(req)
+      local response = backend:send(req)
 
       assert.truthy(response)
       assert.truthy(response.request)
@@ -25,13 +25,13 @@ describe('test backend',function()
 
     it('expects a request', function()
       local req = request.new{method = 'GET', url = 'http://example.com' }
-      assert.has.error(function() backend.send(req) end, 'no expectation')
+      assert.has.error(function() backend:send(req) end, 'no expectation')
     end)
 
     it('matches expectation', function()
       backend.expect{method = 'POST'}
       local req = request.new{method = 'GET', url = 'http://example.com' }
-      assert.has.error(function() backend.send(req) end, 'expectation does not match: ["method"] "GET" does not match "POST"')
+      assert.has.error(function() backend:send(req) end, 'expectation does not match: ["method"] "GET" does not match "POST"')
     end)
   end)
 end)

--- a/spec/resty/http_ng/cache_store_spec.lua
+++ b/spec/resty/http_ng/cache_store_spec.lua
@@ -28,7 +28,7 @@ describe('HTTP cache store', function()
         store.set = spy.new(function(self, cache_key, res)
           assert.equal(store, self)
           assert.equal('GET:http://example.com/api/foo.json', cache_key)
-          assert.same(cache:entry(response), res)
+          assert.same(cache.entry(response), res)
         end)
 
         assert(cache:set(response))

--- a/spec/resty/http_ng/cache_store_spec.lua
+++ b/spec/resty/http_ng/cache_store_spec.lua
@@ -1,0 +1,19 @@
+local _M = require 'resty.http_ng.cache_store'
+
+describe('HTTP cache store', function()
+
+  describe('.new', function()
+    local cache_store = _M.new()
+
+    assert.truthy(cache_store.get)
+    assert.truthy(cache_store.set)
+  end)
+
+  describe(':get', function()
+    pending('fetches response from cache')
+  end)
+
+  describe(':set', function()
+    pending('stores response in cache')
+  end)
+end)

--- a/spec/resty/http_ng/cache_store_spec.lua
+++ b/spec/resty/http_ng/cache_store_spec.lua
@@ -1,4 +1,7 @@
 local _M = require 'resty.http_ng.cache_store'
+local http_response = require 'resty.http_ng.response'
+local http_request = require 'resty.http_ng.request'
+local spy = require 'luassert.spy'
 
 describe('HTTP cache store', function()
 
@@ -14,6 +17,49 @@ describe('HTTP cache store', function()
   end)
 
   describe(':set', function()
-    pending('stores response in cache')
+
+    describe('max-age=100', function()
+      it('stores response in cache', function()
+        local store = {}
+        local cache = _M.new(store)
+        local request = http_request.new({ method = 'GET', url = 'http://example.com/api/foo.json' })
+        local response = http_response.new(request, 200, { vary = 'Accept-Encoding', cache_control = 'max-age=100'  }, '<content>')
+
+        store.set = spy.new(function(self, cache_key, res)
+          assert.equal(store, self)
+          assert.equal('GET:http://example.com/api/foo.json', cache_key)
+          assert.same(cache:entry(response), res)
+        end)
+
+        assert(cache:set(response))
+        assert.spy(store.set).was.called(1)
+      end)
+    end)
+
+    describe('max-age=0', function()
+      it('stores response in cache', function()
+        local store = {}
+        local cache = _M.new(store)
+        local request = http_request.new({ method = 'GET', url = 'http://example.com/api/foo.json' })
+        local response = http_response.new(request, 200, { vary = 'Accept-Encoding', cache_control = 'max-age=0'  }, '<content>')
+
+        store.set = spy.new(function() end)
+
+        assert(cache:set(response))
+        assert.spy(store.set).was.called(1)
+      end)
+    end)
+
+    describe('Cache-Control: no-store', function()
+      it('not stores responses in cache', function()
+        local store = { set = spy.new(function() end) }
+        local cache = _M.new(store)
+        local request = http_request.new({ method = 'GET', url = 'http://example.com/api/foo.json' })
+        local response = http_response.new(request, 200, { vary = 'Accept-Encoding', cache_control = 'no-store, max-age=100'  }, '<content>')
+
+        assert.falsy(cache:set(response))
+        assert.spy(store.set).was_not.called()
+      end)
+    end)
   end)
 end)

--- a/spec/resty/http_ng/headers_spec.lua
+++ b/spec/resty/http_ng/headers_spec.lua
@@ -1,0 +1,35 @@
+local _M = require 'resty.http_ng.headers'
+
+describe('headers', function()
+  describe('normalization', function()
+    it('normalizes Cache-Control', function()
+      local headers = _M.new{ ['Cache-Control'] = 'public' }
+      assert.equal('public', headers.cache_control)
+    end)
+
+    it('normalizes ETag', function()
+      local headers = _M.new{ ['ETag'] = 'foo' }
+      assert.equal('foo', headers.etag)
+    end)
+
+    it('works with normal access', function()
+      local headers = _M.new{ ['ETag'] = 'foo' }
+      assert.equal('foo', headers['ETag'])
+    end)
+  end)
+
+  describe('value serialization', function()
+    it('concatenates arrays', function()
+      local headers = _M.new{ ['Cache-Control'] = { 'public', 'max-age=1' } }
+
+
+      assert.equal('public, max-age=1', tostring(headers.cache_control))
+    end)
+
+    it('concatenates hashes', function()
+      local headers = _M.new{ ['Cache-Control'] = { public = true, ['must-revalidate'] = true } }
+
+      assert.equal('must-revalidate, public', tostring(headers.cache_control))
+    end)
+  end)
+end)

--- a/spec/resty/http_ng/request_spec.lua
+++ b/spec/resty/http_ng/request_spec.lua
@@ -28,4 +28,10 @@ describe('request', function()
 
     assert.equal('example.com',req.headers.Host)
   end)
+
+  it('has version', function()
+    local req = request.new{url = 'http://example.com/path', method = 'GET' }
+
+    assert.equal(1.1, req.version)
+  end)
 end)

--- a/spec/resty/http_ng/response_spec.lua
+++ b/spec/resty/http_ng/response_spec.lua
@@ -20,4 +20,12 @@ describe('http_ng response', function()
       assert.equal('error message', error.error)
     end)
   end)
+
+  describe('response without date', function()
+    it('creates default date', function()
+      local res = _M.new(nil, 200, {}, '')
+
+      assert.truthy(ngx.parse_http_time(res.headers.date))
+    end)
+  end)
 end)


### PR DESCRIPTION
Using `Cache-Control: private` the http client 
should be able to cache responses and use the cache
on repeated calls

Good read: https://tools.ietf.org/html/rfc7234

You can use it like:
```lua

local cache_store = require('resty.http_ng.cache_store')
local resty_backend = require('resty.http_ng.backend.resty')
local cache_backend = require('resty.http_ng.backend.cache')

-- cache_backend.new(resty_backend) would use default cache store, but you can customise its size
local backend = cache_backend.new(resty_backend, { cache_store = cache_store.new(100) })
local http_client = http_ng.new({ backend = backend })
```

