### PR TITLE
[luarocks] update lua-resty-http and lua-resty-jwt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Bump OpenResty version to [1.11.2.3](https://github.com/3scale/s2i-openresty/releases/tag/1.11.2.3-1) [PR #359](https://github.com/3scale/apicast/pull/359) 
+- Upgraded lua-resty-http and lua-resty-jwt [PR #361](https://github.com/3scale/apicast/pull/361)
 
 ### Added
 

--- a/apicast/apicast-0.1-0.rockspec
+++ b/apicast/apicast-0.1-0.rockspec
@@ -2,10 +2,10 @@ package = "apicast"
 source = { url = '.' }
 version = '0.1-0'
 dependencies = {
-  'lua-resty-http == 0.09-0',
+  'lua-resty-http == 0.10-0',
   'inspect == 3.1.0-1',
   'router == 2.1-0',
-  'lua-resty-jwt == 0.1.9-0'
+  'lua-resty-jwt == 0.1.10-1'
 }
 build = {
    type = "builtin",


### PR DESCRIPTION
https://github.com/pintsized/lua-resty-http/releases/tag/v0.10
https://github.com/SkyLothar/lua-resty-jwt/releases/tag/v0.1.10

/cc @3scale/productization updating rock dependencies to the latest version before next release