### PR TITLE
redirects to login so that assets load correctly

### DIFF
--- a/apicast/src/oauth/keycloak.lua
+++ b/apicast/src/oauth/keycloak.lua
@@ -237,7 +237,7 @@ function _M:authorize(service, client)
   end
 
   local url = resty_url.join(self.config.authorize_url, ngx.var.is_args, ngx.var.args)
-  local res = http_client.get(url)
+  local res = ngx.redirect(url)
 
   _M.respond_and_exit(res.status, res.body, res.headers)
 end

--- a/apicast/src/oauth/keycloak.lua
+++ b/apicast/src/oauth/keycloak.lua
@@ -237,7 +237,7 @@ function _M:authorize(service, client)
   end
 
   local url = resty_url.join(self.config.authorize_url, ngx.var.is_args, ngx.var.args)
-  ngx.redirect(url)
+  return ngx.redirect(url)
 end
 
 function _M:get_token(service, client)

--- a/apicast/src/oauth/keycloak.lua
+++ b/apicast/src/oauth/keycloak.lua
@@ -237,9 +237,7 @@ function _M:authorize(service, client)
   end
 
   local url = resty_url.join(self.config.authorize_url, ngx.var.is_args, ngx.var.args)
-  local res = ngx.redirect(url)
-
-  _M.respond_and_exit(res.status, res.body, res.headers)
+  ngx.redirect(url)
 end
 
 function _M:get_token(service, client)

--- a/spec/keycloak_spec.lua
+++ b/spec/keycloak_spec.lua
@@ -49,9 +49,7 @@ describe('Keycloak', function()
 
       ngx.var = { is_args = "?", args = "client_id=foo" }
       stub(ngx.req, 'get_uri_args', function() return { response_type = 'code', client_id = 'foo', redirect_uri = 'bar' } end)
-
-      test_backend.expect{ url = 'http://www.example.com:80/auth/realms/test/protocol/openid-connect/auth?client_id=foo' }
-        .respond_with{ status = 200 , body = 'foo', headers = {} }
+      stub(ngx, 'redirect', function() return { status = 200, body = 'foo', headers = {} } end)
 
       stub(_M, 'respond_and_exit')
       keycloak:authorize({}, test_backend)

--- a/spec/keycloak_spec.lua
+++ b/spec/keycloak_spec.lua
@@ -51,9 +51,7 @@ describe('Keycloak', function()
       stub(ngx.req, 'get_uri_args', function() return { response_type = 'code', client_id = 'foo', redirect_uri = 'bar' } end)
       stub(ngx, 'redirect', function() return { status = 200, body = 'foo', headers = {} } end)
 
-      stub(_M, 'respond_and_exit')
       keycloak:authorize({}, test_backend)
-      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', { Date = "Thu, 18 Nov 2010 11:27:35 GMT" })
     end)
 
     it('returns error when response_type missing', function()

--- a/spec/keycloak_spec.lua
+++ b/spec/keycloak_spec.lua
@@ -53,7 +53,7 @@ describe('Keycloak', function()
 
       stub(_M, 'respond_and_exit')
       keycloak:authorize({}, test_backend)
-      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', {})
+      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', { Date = "Thu, 18 Nov 2010 11:27:35 GMT" })
     end)
 
     it('returns error when response_type missing', function()
@@ -96,11 +96,11 @@ describe('Keycloak', function()
       stub(ngx.req, 'get_headers', function() return { } end)
 
       test_backend.expect{ url = 'http://www.example.com:80/auth/realms/test/protocol/openid-connect/token'}
-        .respond_with{ status = 200 , body = 'foo', headers = {} }
+        .respond_with{ status = 200 , body = 'foo', headers = { Date = "Thu, 18 Nov 2010 11:27:35 GMT" } }
 
       keycloak:get_token({}, test_backend)
 
-      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', {})
+      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', { Date = "Thu, 18 Nov 2010 11:27:35 GMT" })
     end)
 
     it('returns "invalid_request" when grant_type missing', function ()
@@ -169,11 +169,11 @@ describe('Keycloak', function()
       stub(ngx.req, 'get_headers', function() return { } end)
 
       test_backend.expect{ url = 'http://www.example.com:80/auth/realms/test/protocol/openid-connect/token'}
-        .respond_with{ status = 200 , body = 'foo', headers = {} }
+        .respond_with{ status = 200 , body = 'foo', headers = { Date = "Thu, 18 Nov 2010 11:27:35 GMT" } }
 
       keycloak:get_token({}, test_backend)
 
-      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', {})
+      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', { Date = "Thu, 18 Nov 2010 11:27:35 GMT" })
     end)
 
     it('accepts client credentials in Authorization header', function()
@@ -192,11 +192,11 @@ describe('Keycloak', function()
       test_backend.expect{
         url = 'http://www.example.com:80/auth/realms/test/protocol/openid-connect/token',
         headers =  { authorization = auth }
-      }.respond_with{ status = 200 , body = 'foo', headers = {} }
+      }.respond_with{ status = 200 , body = 'foo', headers = { Date = "Thu, 18 Nov 2010 11:27:35 GMT" } }
 
       keycloak:get_token({}, test_backend)
 
-      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', {})
+      assert.spy(_M.respond_and_exit).was.called_with(200, 'foo', { Date = "Thu, 18 Nov 2010 11:27:35 GMT" })
     end)
 
   end)


### PR DESCRIPTION
Assets are not loaded when Keycloak (RH SSO) login page is rendered. This is because the request a simple GET and in fact a redirect to the login page would fix this. No specific method is detailed in the [RFC](https://tools.ietf.org/html/rfc6749#section-1.7) and the implementation is at our discretion.

cc @mayorova 