### PR TITLE
[libexec] allow forwarding arguments to libexec/run

### DIFF
--- a/apicast/libexec/run
+++ b/apicast/libexec/run
@@ -5,4 +5,4 @@ ssl=$(mktemp -q)
 echo "lua_ssl_verify_depth 5;" >> "${ssl}"
 echo "lua_ssl_trusted_certificate \"$(pwd)/conf/ca-bundle.crt\";" >> "${ssl}"
 
-exec resty --http-include "${ssl}" "libexec/$(basename "$0").lua"
+exec resty --http-include "${ssl}" "libexec/$(basename "$0").lua" "$@"


### PR DESCRIPTION
so libexec helpers can have arguments