### PR TITLE
[CVE-2017-7512] reject empty client secret

### DIFF
--- a/apicast/src/oauth/apicast_oauth/authorize.lua
+++ b/apicast/src/oauth/apicast_oauth/authorize.lua
@@ -86,7 +86,6 @@ local function check_client_credentials(params)
     {
       args = {
         app_id = params.client_id,
-        app_key = params.client_secret,
         redirect_uri = params.redirect_uri
       },
       copy_all_vars = true,
@@ -95,7 +94,7 @@ local function check_client_credentials(params)
 
   ngx.log(ngx.INFO, "[oauth] Checking client credentials, status: ", res.status, " body: ", res.body)
 
-  if res.status == 200 then
+  if res.status == 200 and ts.match_xml_element(res.body, 'authorized', true) then
     return { ["status"] = res.status, ["body"] = res.body }
   else
     params.error = "invalid_client"

--- a/apicast/src/oauth/apicast_oauth/get_token.lua
+++ b/apicast/src/oauth/apicast_oauth/get_token.lua
@@ -55,7 +55,11 @@ local function check_client_credentials(params)
     { args = { app_id = params.client_id, app_key = params.client_secret, redirect_uri = params.redirect_uri },
       copy_all_vars = true, ctx = ngx.ctx })
 
-  if res.status == 200 then
+  ngx.log(ngx.INFO, "[oauth] Checking client credentials, status: ", res.status, " body: ", res.body)
+
+  if res.status == 200 and
+      ts.match_xml_element(res.body, 'key', params.client_secret) and
+      ts.match_xml_element(res.body, 'authorized', true) then
     return { ["status"] = res.status, ["body"] = res.body }
   else
     ngx.status = 401

--- a/apicast/src/threescale_utils.lua
+++ b/apicast/src/threescale_utils.lua
@@ -179,6 +179,14 @@ function _M.release_redis(red)
   red:set_keepalive(redis_conf.keepalive, redis_conf.poolsize)
 end
 
+local xml_header_len = string.len('<?xml version="1.0" encoding="UTF-8"?>')
+
+function _M.match_xml_element(xml, element, value)
+  if not xml then return nil end
+  local pattern = string.format('<%s>%s</%s>', element, value, element)
+  return string.find(xml, pattern, xml_header_len, xml_header_len, true)
+end
+
 -- error and exist
 function _M.error(...)
   if ngx.get_phase() == 'timer' then

--- a/t/005-apicast-oauth.t
+++ b/t/005-apicast-oauth.t
@@ -80,6 +80,7 @@ called oauth_authorize.xml
     content_by_lua_block {
       expected = "provider_key=fookey&service_id=42&redirect_uri=otheruri&app_id=id"
       if ngx.var.args == expected and ngx.var.host == ngx.var.backend_host then
+        ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized></status>')
         ngx.exit(200)
       else
         ngx.exit(403)
@@ -120,6 +121,7 @@ Location: http://example.com/redirect\?scope=whatever&response_type=code&state=[
   location = /backend/transactions/oauth_authorize.xml {
     content_by_lua_block {
       if ngx.var.args == "provider_key=fookey&service_id=42&redirect_uri=otheruri&app_id=id" and ngx.var.host == ngx.var.backend_host then
+        ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized></status>')
         ngx.exit(200)
       else
         ngx.exit(403)
@@ -348,6 +350,7 @@ Location: http://example.com/redirect\?code=\w+&state=clientstate
       content_by_lua_block {
         expected = "provider_key=fookey&service_id=42&app_key=client_secret&redirect_uri=redirect_uri&app_id=client_id"
         if ngx.var.args == expected and ngx.var.host == ngx.var.backend_host then
+          ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized><application><key>client_secret</key></application></status>')
           ngx.exit(200)
         else
           ngx.log(ngx.ERR, 'expected: ' .. expected .. ' got: ' .. ngx.var.args)
@@ -565,3 +568,74 @@ credentials missing!
 --- no_error_log
 [error]
 
+
+=== TEST 16: calling /oauth/token returns error message on empty client secret
+Regression test for CVE-2017-7512
+--- main_config
+  env REDIS_HOST=$TEST_NGINX_REDIS_HOST;
+  env RESOLVER=$TEST_NGINX_RESOLVER;
+--- http_config
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+  init_by_lua_block {
+    require('configuration_loader').mock({
+      services = {
+        { id = 42, backend_version = 'oauth' }
+      }
+    })
+  }
+--- config
+  include $TEST_NGINX_APICAST_CONFIG;
+
+  lua_need_request_body on;
+  location = /t {
+    content_by_lua_block {
+      local authorize = require('oauth.apicast_oauth.authorize')
+      local authorized_callback = require('oauth.apicast_oauth.authorized_callback')
+      local redirect_uri = 'http://example.com/redirect'
+      local nonce = authorize.persist_nonce(42, {
+        client_id = 'foo',
+        state = 'somestate',
+        redirect_uri = redirect_uri,
+        scope = 'plan'
+      })
+      local client_data = authorized_callback.retrieve_client_data(42, { state = nonce })
+      local code = authorized_callback.generate_code(client_data)
+
+      assert(authorized_callback.persist_code(client_data, { state = 'somestate', user_id = 'someuser', redirect_uri = 'redirect_uri' }, code))
+
+      ngx.req.set_method(ngx.HTTP_POST)
+      ngx.req.set_body_data('grant_type=authorization_code&client_id=client_id&redirect_uri=redirect_uri&client_secret=&code=' .. code)
+      ngx.exec('/oauth/token')
+    }
+  }
+
+    set $backend_endpoint 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT/backend';
+    set $backend_host '127.0.0.1';
+    set $backend_authentication_type 'provider_key';
+    set $backend_authentication_value 'fookey';
+
+    location = /backend/transactions/oauth_authorize.xml {
+      content_by_lua_block {
+        expected = "provider_key=fookey&service_id=42&app_key=&app_id=client_id&redirect_uri=redirect_uri"
+        if ngx.var.args == expected and ngx.var.host == ngx.var.backend_host then
+        ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized><application><key>client_secret</key></application></status>')
+          ngx.exit(200)
+        else
+          ngx.log(ngx.ERR, 'expected: ' .. expected .. ' got: ' .. ngx.var.args)
+          ngx.exit(403)
+        end
+      }
+    }
+
+    location = /backend/services/42/oauth_access_tokens.xml {
+      content_by_lua_block {
+        ngx.exit(200)
+      }
+    }
+--- request
+GET /t
+--- response_body chomp
+{"error":"invalid_client"}
+--- error_code: 401
+--- no_error_log
+[error]


### PR DESCRIPTION
3scale Service Management API would return 200 when app_key paramater
was empty for legacy purposes. That was not expected by the
gateway which was sending empty key for verification.

This was fixed on 3scale Service Management API and empty app_key
parameter will now return 409.

However, gateway should not rely jsut on 3scale Service Management,
so it performs own validation of the client secret during Access Token
generation.