### PR TITLE
[remote_v2] do not try to load oidc when issuer is null

### DIFF
--- a/apicast/src/configuration.lua
+++ b/apicast/src/configuration.lua
@@ -157,7 +157,7 @@ function _M.parse_service(service)
         host = backend_host_override or backend.host
       },
       oidc = {
-        issuer_endpoint = proxy.oidc_issuer_endpoint
+        issuer_endpoint = proxy.oidc_issuer_endpoint ~= ngx.null and proxy.oidc_issuer_endpoint
       },
       credentials = {
         location = proxy.credentials_location or 'query',

--- a/apicast/src/configuration_loader/remote_v2.lua
+++ b/apicast/src/configuration_loader/remote_v2.lua
@@ -237,7 +237,7 @@ function _M:oidc_issuer_configuration(service)
 
   local endpoint = service.oidc.issuer_endpoint
 
-  if not endpoint then
+  if not endpoint or endpoint == ngx.null then
     return nil, 'no OIDC endpoint'
   end
 

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -62,7 +62,7 @@ describe('Configuration Remote Loader V2', function()
             proxy_config = {
               version = 13,
               environment = 'sandbox',
-              content = { id = 42, backend_version = 1 }
+              content = { id = 42, backend_version = 1, proxy = { oidc_issuer_endpoint = ngx.null } }
             }
           }
         ) }


### PR DESCRIPTION
because it is deserialized from json it can be `ngx.null`