### PR TITLE
Backend authorization cache handlers

### DIFF
--- a/.env
+++ b/.env
@@ -22,6 +22,9 @@ REDIS_HOST=redis
 # Override backend endpoint in the config globally.
 # BACKEND_ENDPOINT_OVERRIDE=https://backend.example.com
 
+# Set how to handle cached backend responses.
+# APICAST_BACKEND_CACHE_HANDLER=resilient
+
 # Set number of worker processes.
 # APICAST_WORKERS=2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Ability to configure how to cache backend authorizations [PR #396](https://github.com/3scale/apicast/pull/396)
+
 ## [3.1.0-beta1] - 2017-07-21
 
 ### Fixed

--- a/apicast/src/backend/cache_handler.lua
+++ b/apicast/src/backend/cache_handler.lua
@@ -1,0 +1,37 @@
+local setmetatable = setmetatable
+
+local _M = {
+  handlers = { }
+}
+
+local mt = {
+  __index = _M,
+  __call = function(t, ...)
+    local handler = t.handlers[t.handler]
+
+    if handler then
+      return handler(...)
+    else
+      return nil, 'missing handler'
+    end
+  end,
+}
+
+function _M.new(handler)
+  return setmetatable({ handler = handler }, mt)
+end
+
+
+function _M.handlers.strict(cache, cached_key, response, ttl)
+  if response.status == 200 then
+    ngx.log(ngx.INFO, 'apicast cache write key: ', cached_key, ', ttl: ', ttl )
+    cache:set(cached_key, 200, ttl or 0)
+    return true
+  else
+    ngx.log(ngx.NOTICE, 'apicast cache delete key: ', cached_key, ' cause status ', response.status)
+    cache:delete(cached_key)
+    return false, 'not authorized'
+  end
+end
+
+return _M

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -32,6 +32,15 @@ Defines how to load the configuration.
 Boot will require configuration when the gateway starts.
 Lazy will load it on demand on incoming request.
 
+### `APICAST_BACKEND_CACHE_HANDLER`
+
+**Values:** strict | resilient
+**Default:** strict
+
+Defines how the authorization cache behaves when backend is unavailable.
+Strict will remove cached application when backend is unavailable.
+Resilient will do so only on getting authorization denied from backend.
+
 ### `APICAST_MODULE`
 
 **Default:** "apicast"

--- a/openshift/apicast-template.yml
+++ b/openshift/apicast-template.yml
@@ -40,6 +40,8 @@ objects:
             value: "${SERVICES_LIST}"
           - name: APICAST_CONFIGURATION_LOADER
             value: "${CONFIGURATION_LOADER}"
+          - name: APICAST_BACKEND_CACHE_HANDLER
+            value: "${BACKEND_CACHE_HANDLER}"
           - name: APICAST_LOG_LEVEL
             value: "${LOG_LEVEL}"
           - name: APICAST_PATH_ROUTING_ENABLED
@@ -127,6 +129,10 @@ parameters:
 - name: CONFIGURATION_LOADER
   description: "When to load configuration. If on gateway start or incoming request. Allowed values are: lazy, boot."
   value: boot
+  required: false
+- name: BACKEND_CACHE_HANDLER
+  description: "How to handle and cache backend authorization responses. Can be one of: strict, resilient."
+  value: strict
   required: false
 - description: "Log level. One of the following: debug, info, notice, warn, error, crit, alert, or emerg."
   name: LOG_LEVEL

--- a/spec/backend/cache_handler_spec.lua
+++ b/spec/backend/cache_handler_spec.lua
@@ -1,0 +1,110 @@
+
+local _M = require('backend.cache_handler')
+local lrucache = require('resty.lrucache')
+
+
+describe('Cache Handler', function()
+
+  describe('.new', function()
+    it('has a default handler', function()
+      local handler = _M.new()
+      assert.equal(assert(_M.handlers.default), handler.handler)
+    end)
+
+    it('sets a handler', function()
+      local handler = _M.new('strict')
+
+      assert.equal('strict', handler.handler)
+    end)
+  end)
+
+  describe('call', function()
+    it('calls handler on runtime', function()
+      local handler = _M.new('test-fake')
+
+      stub(_M.handlers, 'test-fake', function() return 'return value' end)
+
+      assert.equal('return value', handler())
+    end)
+  end)
+
+  describe('strict', function()
+    local handler = _M.handlers.strict
+
+    it('caches successful response', function()
+      local cache = lrucache.new(1)
+      ngx.var = { cached_key = nil }
+
+      assert.truthy(handler(cache, 'foobar', { status = 200 }))
+
+      assert.equal(200, cache:get('foobar'))
+    end)
+
+    it('not caches in post action', function()
+      local cache = lrucache.new(1)
+      ngx.var = { cached_key = 'foobar' } -- means it is performed in post_action
+
+      assert.truthy(handler(cache, 'foobar', { status = 200 }))
+
+      assert.falsy(cache:get('foobar'))
+    end)
+
+    it('deletes cache on forbidden response', function()
+      local cache = lrucache.new(1)
+      cache:set('foobar', 200)
+
+      assert.falsy(handler(cache, 'foobar', { status = 403 }))
+
+      assert.falsy(cache:get('foobar'))
+    end)
+
+    it('deletes cache on server errors', function()
+      local cache = lrucache.new(1)
+      cache:set('foobar', 200)
+
+      assert.falsy(handler(cache, 'foobar', { status = 503 }))
+
+      assert.falsy(cache:get('foobar'))
+    end)
+  end)
+
+
+  describe('resilient', function()
+    local handler = _M.handlers.resilient
+
+    it('caches successful response', function()
+      local cache = lrucache.new(1)
+
+      assert.truthy(handler(cache, 'foobar', { status = 200 }))
+
+      assert.equal(200, cache:get('foobar'))
+    end)
+
+    it('caches forbidden response', function()
+      local cache = lrucache.new(1)
+
+      assert.falsy(handler(cache, 'foobar', { status = 403 }))
+
+      assert.equal(403, cache:get('foobar'))
+    end)
+
+    it('not caches server errors', function()
+      local cache = lrucache.new(1)
+
+      assert.falsy(handler(cache, 'foobar', { status = 503 }))
+
+      assert.falsy(cache:get('foobar'))
+    end)
+
+    it('not overrides cache on server errors', function()
+      local cache = lrucache.new(1)
+
+      cache:set('foobar', 200)
+
+      assert.falsy(handler(cache, 'foobar', { status = 503 }))
+
+      assert.equal(200, cache:get('foobar'))
+    end)
+  end)
+
+end)

--- a/t/001-management.t
+++ b/t/001-management.t
@@ -7,7 +7,7 @@ my $apicast = $ENV{TEST_NGINX_APICAST_PATH} || "$pwd/apicast";
 $ENV{TEST_NGINX_LUA_PATH} = "$apicast/src/?.lua;;";
 $ENV{TEST_NGINX_MANAGEMENT_CONFIG} = "$apicast/conf.d/management.conf";
 
-require("t/dns.pl");
+require("$pwd/t/dns.pl");
 
 log_level('debug');
 repeat_each(2);

--- a/t/003-apicast.t
+++ b/t/003-apicast.t
@@ -9,7 +9,7 @@ $ENV{TEST_NGINX_UPSTREAM_CONFIG} = "$apicast/http.d/upstream.conf";
 $ENV{TEST_NGINX_BACKEND_CONFIG} = "$apicast/conf.d/backend.conf";
 $ENV{TEST_NGINX_APICAST_CONFIG} = "$apicast/conf.d/apicast.conf";
 
-require("t/dns.pl");
+require("$pwd/t/dns.pl");
 
 log_level('debug');
 repeat_each(2);

--- a/t/007-apicast-upstream-balancer.t
+++ b/t/007-apicast-upstream-balancer.t
@@ -5,7 +5,7 @@ my $pwd = cwd();
 my $apicast = $ENV{TEST_NGINX_APICAST_PATH} || "$pwd/apicast";
 $ENV{TEST_NGINX_LUA_PATH} = "$apicast/src/?.lua;;";
 
-require("t/dns.pl");
+require("$pwd/t/dns.pl");
 
 log_level('debug');
 repeat_each(2);

--- a/t/009-apicast-caching.t
+++ b/t/009-apicast-caching.t
@@ -73,6 +73,7 @@ yay, api backend
 apicast cache miss key: 42:value:usage%5Bhits%5D=2
 apicast cache write key: 42:value:usage%5Bhits%5D=2
 apicast cache hit key: 42:value:usage%5Bhits%5D=2
+apicast cache write key: 42:value:usage%5Bhits%5D=2
 
 === TEST 6: multi service configuration
 Two services can exist together and are split by their hostname.
@@ -219,3 +220,4 @@ yay, api backend
 apicast cache miss key: 42:value:usage%5Bhits%5D=2
 apicast cache write key: 42:value:usage%5Bhits%5D=2
 apicast cache hit key: 42:value:usage%5Bhits%5D=2
+apicast cache write key: 42:value:usage%5Bhits%5D=2

--- a/t/009-apicast-caching.t
+++ b/t/009-apicast-caching.t
@@ -73,7 +73,6 @@ yay, api backend
 apicast cache miss key: 42:value:usage%5Bhits%5D=2
 apicast cache write key: 42:value:usage%5Bhits%5D=2
 apicast cache hit key: 42:value:usage%5Bhits%5D=2
-apicast cache write key: 42:value:usage%5Bhits%5D=2
 
 === TEST 6: multi service configuration
 Two services can exist together and are split by their hostname.
@@ -220,4 +219,3 @@ yay, api backend
 apicast cache miss key: 42:value:usage%5Bhits%5D=2
 apicast cache write key: 42:value:usage%5Bhits%5D=2
 apicast cache hit key: 42:value:usage%5Bhits%5D=2
-apicast cache write key: 42:value:usage%5Bhits%5D=2

--- a/t/018-module-loading.t
+++ b/t/018-module-loading.t
@@ -7,7 +7,7 @@ my $apicast = $ENV{TEST_NGINX_APICAST_PATH} || "$pwd/apicast";
 $ENV{TEST_NGINX_LUA_PATH} = "$pwd/t/servroot/html/?.lua;$apicast/src/?.lua;;";
 $ENV{TEST_NGINX_HTTP_CONFIG} = "$apicast/http.d/init.conf";
 $ENV{TEST_NGINX_APICAST_PATH} = $apicast;
-$ENV{APICAST_MODULE} = 'custom';
+$ENV{APICAST_MODULE} = 'customfoobar';
 
 env_to_nginx(
     'APICAST_MODULE'
@@ -30,7 +30,7 @@ __DATA__
 --- request
 GET
 --- error_log
-module 'custom' not found
+module 'customfoobar' not found
 
 
 === TEST 2: print error on syntax error
@@ -43,9 +43,9 @@ module 'custom' not found
 --- request
 GET
 --- error_log
-custom.lua:1: unexpected symbol near 'not'
+customfoobar.lua:1: unexpected symbol near 'not'
 --- user_files
->>> custom.lua
+>>> customfoobar.lua
 not valid lua
 
 === TEST 3: print error on empty file
@@ -57,7 +57,7 @@ not valid lua
 --- request
 GET
 --- error_log
-module custom did not return a table but: boolean
+module customfoobar did not return a table but: boolean
 --- must_die
 --- user_files
->>> custom.lua
+>>> customfoobar.lua

--- a/t/020-backend-cache-handler.t
+++ b/t/020-backend-cache-handler.t
@@ -1,0 +1,118 @@
+use Test::Nginx::Socket::Lua 'no_plan';
+use Cwd qw(cwd);
+
+my $pwd = cwd();
+my $apicast = $ENV{TEST_NGINX_APICAST_PATH} || "$pwd/apicast";
+
+$ENV{TEST_NGINX_LUA_PATH} = "$apicast/src/?.lua;;";
+$ENV{TEST_NGINX_UPSTREAM_CONFIG} = "$apicast/http.d/upstream.conf";
+$ENV{TEST_NGINX_BACKEND_CONFIG} = "$apicast/conf.d/backend.conf";
+$ENV{TEST_NGINX_APICAST_CONFIG} = "$apicast/conf.d/apicast.conf";
+
+log_level('debug');
+repeat_each(1); # Can't be two as the second call would hit the cache
+no_root_location();
+run_tests();
+
+__DATA__
+
+=== TEST 1: resilient backend will keep calls through without backend connection
+When backend returns server error the call will be let through.
+--- main_config
+env APICAST_BACKEND_CACHE_HANDLER=resilient;
+--- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+  init_by_lua_block {
+    require('configuration_loader').mock({
+      services = {
+        {
+          id = 42,
+          backend_version = 1,
+          proxy = {
+            api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
+            proxy_rules = {
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
+            }
+          }
+        }
+      }
+    })
+
+    require('proxy').shared_cache():set('42:foo:usage%5Bhits%5D=2', 200)
+  }
+  lua_shared_dict api_keys 10m;
+--- config
+  include $TEST_NGINX_APICAST_CONFIG;
+
+  set $backend_endpoint 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT';
+
+  location /transactions/authrep.xml {
+    content_by_lua_block { ngx.exit(502) }
+  }
+
+  location /api-backend/ {
+     echo 'yay, api backend';
+  }
+
+  location = /t {
+    echo_subrequest GET /test/one -q user_key=value;
+    echo_subrequest GET /test/two -q user_key=value;
+  }
+--- request eval
+["GET /test?user_key=foo", "GET /foo?user_key=foo"]
+--- response_body eval
+["yay, api backend\x{0a}", "yay, api backend\x{0a}" ]
+--- error_code eval
+[ 200, 200 ]
+
+
+=== TEST 2: strict backend will remove cache after not successful satus
+When backend returns server error the next call will be reauthorized.
+--- main_config
+env APICAST_BACKEND_CACHE_HANDLER=strict;
+--- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+  init_by_lua_block {
+    require('configuration_loader').mock({
+      services = {
+        {
+          id = 42,
+          backend_version = 1,
+          proxy = {
+            api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
+            proxy_rules = {
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
+            }
+          }
+        }
+      }
+    })
+
+    require('proxy').shared_cache():set('42:foo:usage%5Bhits%5D=2', 200)
+  }
+  lua_shared_dict api_keys 10m;
+--- config
+  include $TEST_NGINX_APICAST_CONFIG;
+
+  set $backend_endpoint 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT';
+
+  location /transactions/authrep.xml {
+    content_by_lua_block { ngx.exit(502) }
+  }
+
+  location /api-backend/ {
+     echo 'yay, api backend';
+  }
+
+  location = /t {
+    echo_subrequest GET /test/one -q user_key=value;
+    echo_subrequest GET /test/two -q user_key=value;
+  }
+--- request eval
+["GET /test?user_key=foo", "GET /foo?user_key=foo"]
+--- response_body eval
+["yay, api backend\x{0a}", "nil" ]
+--- error_code eval
+[ 200, 403 ]


### PR DESCRIPTION
Extract how cache is treated based on the backend response into a module.
It allows extension by adding custom handlers like:

```lua
local cache_handler = require('backend.cache_handler')

function cache_handler.handlers.custom(cache, cached_key, response, ttl)
  cache:add(...)
  return true or false
end
```

* strict is the original handler
  - it removes cached key on any non successful response

* resilient is the new handler 
  - stores response in cache only when it was not a server error

It also allows overriding `proxy.shared_cache` method to create custom cache instance for all proxies.
That can be useful when replacing local shared memory cache with something like redis.

# TODO

- [x] integration test