### PR TITLE
[remote_v2] ignore empty APICAST_SERVICES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Ability to configure how to cache backend authorizations [PR #396](https://github.com/3scale/apicast/pull/396)
 
+### Fixed
+
+- [THREESCALE-281](https://issues.jboss.org/browse/THREESCALE-281) Not loading services when APICAST\_SERVICES is empty [PR #401](https://github.com/3scale/apicast/pull/401)
+
 ## [3.1.0-beta1] - 2017-07-21
 
 ### Fixed

--- a/apicast/src/configuration_loader/remote_v2.lua
+++ b/apicast/src/configuration_loader/remote_v2.lua
@@ -1,5 +1,6 @@
 local setmetatable = setmetatable
 local format = string.format
+local len = string.len
 local ipairs = ipairs
 local insert = table.insert
 local rawset = rawset
@@ -183,15 +184,13 @@ end
 local services_subset = function()
   local services = resty_env.get('APICAST_SERVICES')
 
-  if services then
+  if services and len(services) > 0 then
     local ids = re.split(services, ',', 'oj')
     for i=1, #ids do
       ids[i] = { service = { id = tonumber(ids[i]) } }
     end
-    services = ids
+    return ids
   end
-
-  return services
 end
 
 function _M:services()

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -52,6 +52,19 @@ describe('Configuration Remote Loader V2', function()
       assert.equal(2, #services)
       assert.same({ { service = { id = 11 } }, { service = { id = 42 } } }, services)
     end)
+
+    it('ignores APICAST_SERVICES when empty', function()
+      env.set('APICAST_SERVICES', '')
+
+      test_backend.expect{ url = "http://example.com/admin/api/services.json" }.
+        respond_with{ status = 200, body = cjson.encode({ services = { { service = { id = 1 }} }}) }
+
+      local services = loader:services()
+
+      assert.truthy(services)
+      assert.equal(1, #services)
+      assert.same({ { service = { id = 1 } } }, services)
+    end)
   end)
 
   describe(':config', function()


### PR DESCRIPTION
OpenShift template defaults to empty value.
That results in not loading any configurations when using the OpenShift template.