### PR TITLE
[oidc] don't crash when config is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - OIDC is now used based on settings on the API Manager [PR #405](https://github.com/3scale/apicast/pull/405)
 
-## [3.1.0-beta1] - 2017-07-21
+## [3.1.0-beta2] - 2017-08-21
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- OIDC is now used based on settings on the API Manager [PR #405](https://github.com/3scale/apicast/pull/405)
+
 ## [3.1.0-beta1] - 2017-07-21
 
 ### Added

--- a/apicast/src/configuration.lua
+++ b/apicast/src/configuration.lua
@@ -134,6 +134,7 @@ function _M.parse_service(service)
   return Service.new({
       id = tostring(service.id or 'default'),
       backend_version = backend_version,
+      authentication_method = proxy.authentication_method or backend_version,
       hosts = proxy.hosts or { 'localhost' }, -- TODO: verify localhost is good default
       api_backend = proxy.api_backend,
       error_auth_failed = proxy.error_auth_failed,

--- a/apicast/src/configuration/service.lua
+++ b/apicast/src/configuration/service.lua
@@ -171,16 +171,14 @@ function _M:extract_credentials()
 end
 
 function _M:oauth()
-  if self.backend_version ~= 'oauth' then
-    return nil, 'not oauth'
-  end
+  local authentication = self.authentication_method or self.backend_version
 
-  local oidc = self.oidc
-
-  if oidc and oidc.issuer then
+  if authentication == 'oidc' then
     return oauth.oidc.new(self)
-  else
+  elseif authentication == 'oauth' then
     return oauth.apicast.new(self)
+  else
+    return nil, 'not oauth'
   end
 end
 

--- a/apicast/src/oauth/oidc.lua
+++ b/apicast/src/oauth/oidc.lua
@@ -27,8 +27,9 @@ local mt = {
 }
 
 function _M.new(service)
-  local issuer = service.oidc.issuer
-  local config = service.oidc.config or {}
+  local oidc = service.oidc
+  local issuer = oidc.issuer or oidc.issuer_endpoint
+  local config = oidc.config or {}
   local openid = config.openid or {}
 
   return setmetatable({

--- a/spec/configuration/service_spec.lua
+++ b/spec/configuration/service_spec.lua
@@ -163,7 +163,7 @@ describe('Service object', function()
   describe(':oauth()', function()
     describe('backend_version=oauth', function()
       it('returns OIDC object when there is OIDC config', function()
-        local service = Service.new({backend_version = 'oauth', oidc = { issuer = 'http://example.com' }})
+        local service = Service.new({authentication_method = 'oidc', oidc = { issuer = 'http://example.com' }})
 
         local oauth = service:oauth()
 

--- a/t/019-apicast-oidc.t
+++ b/t/019-apicast-oidc.t
@@ -32,6 +32,7 @@ __DATA__
         { id = 42,
           backend_version = 'oauth',
           proxy = {
+            authentication_method = 'oidc',
             oidc_issuer_endpoint = 'https://example.com/auth/realms/apicast',
             api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
             proxy_rules = {


### PR DESCRIPTION
Also use new field `authentication_method` to determine OIDC Service instead of by loading the configuration

That means you'll get authentication parameters missing or invalid when OIDC configuration could not be loaded instead of an error.