### PR TITLE
[remote_v1] disable v1 API by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `THREESCALE\_DEPLOYMENT\_ENV` defaults to `production` [PR #406](https://github.com/3scale/apicast/pull/406)
+
 ## [3.1.0-beta1] - 2017-07-21
 
 ### Added

--- a/apicast/bin/apicast
+++ b/apicast/bin/apicast
@@ -61,13 +61,14 @@ usage () {
 	  -s <signal> Send signal to a master process: stop, quit, reopen, reload
 	  -p <pid> Path to the PID file.
 	  -b Load configuration on boot.
+	  -e Deployment environment. Can be staging or production.
 USAGE
 }
 
 main=("")
 args=("")
 
-while getopts ":dc:hvbqi:rw:m:s:p:" opt; do
+while getopts ":dc:hvbqi:rw:m:s:p:e:" opt; do
   case "${opt}" in
     d)
       daemon="on"
@@ -86,6 +87,9 @@ while getopts ":dc:hvbqi:rw:m:s:p:" opt; do
       ;;
     i)
       export APICAST_CONFIGURATION_CACHE="${OPTARG}"
+      ;;
+    e)
+      export THREESCALE_DEPLOYMENT_ENV="${OPTARG}"
     ;;
     w)
       worker_processes=${OPTARG}
@@ -111,6 +115,8 @@ while getopts ":dc:hvbqi:rw:m:s:p:" opt; do
       ;;
   esac
 done
+
+export THREESCALE_DEPLOYMENT_ENV=${THREESCALE_DEPLOYMENT_ENV-production}
 
 main+=("daemon ${daemon};")
 main+=("worker_processes ${worker_processes};")

--- a/apicast/src/configuration_loader/remote_v2.lua
+++ b/apicast/src/configuration_loader/remote_v2.lua
@@ -88,7 +88,7 @@ function _M:index(host)
     return nil, 'wrong endpoint url'
   end
 
-  local env = resty_env.get('THREESCALE_DEPLOYMENT_ENV')
+  local env = resty_env.value('THREESCALE_DEPLOYMENT_ENV')
 
   if not env then
     return nil, 'missing environment'
@@ -147,7 +147,7 @@ function _M:call(environment)
     return nil, 'not initialized'
   end
 
-  local env = environment or resty_env.get('THREESCALE_DEPLOYMENT_ENV')
+  local env = environment or resty_env.value('THREESCALE_DEPLOYMENT_ENV')
   if not env then
     return nil, 'missing environment'
   end

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -103,8 +103,8 @@ Allows to specify a custom DNS resolver that will be used by OpenResty. If the `
 
 ### `THREESCALE_DEPLOYMENT_ENV`
 
-**Values:** sandbox | production  
-**Default:** no value
+**Values:** staging | production
+**Default:** production
 
 The value of this environment variable will be used to define the environment for which the configuration will be downloaded from 3scale (Staging or Production), when using new APIcast.
 


### PR DESCRIPTION
Default to production environment on V2 API

Sets `THREESCALE_DEPLOYMENT_ENV` to `production` by default.
You can set it to empty value to disable this and use V1 API.