### PR TITLE
[location.d] new extension block for location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Support for extending APIcast location block with snippets of nginx configuration [PR #407][https://github.com/3scale/apicast/pull/407]
+
 ### Changed
 
 - `THREESCALE\_DEPLOYMENT\_ENV` defaults to `production` [PR #406](https://github.com/3scale/apicast/pull/406)

--- a/apicast/conf.d/apicast.conf
+++ b/apicast/conf.d/apicast.conf
@@ -89,6 +89,8 @@ location / {
   proxy_set_header Connection "";
 
   post_action @out_of_band_authrep_action;
+
+  include ../apicast.d/location.d/*.conf;
 }
 
 location = /_threescale/oauth_store_token {


### PR DESCRIPTION
main apicast entrypoint can be now customized
with snippets of nginx configuration

the path is `apicast.d/location.d/*.conf`

fixes #399