### PR TITLE
[ngx] disable client_max_body_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `THREESCALE\_DEPLOYMENT\_ENV` defaults to `production` [PR #406](https://github.com/3scale/apicast/pull/406)
 - OIDC is now used based on settings on the API Manager [PR #405](https://github.com/3scale/apicast/pull/405)
+- No limit on body size from the client sent to the server [PR #410](https://github.com/3scale/apicast/pull/410)
 
 ## [3.1.0-beta2] - 2017-08-21
 

--- a/apicast/http.d/core.conf
+++ b/apicast/http.d/core.conf
@@ -1,0 +1,1 @@
+client_max_body_size 0;


### PR DESCRIPTION
fixes https://github.com/3scale/apicast/issues/380

APIcast will now send unlimited body size from the client to the server.