### PR TITLE
Example Dockerfile for apicast_cors.lua

### DIFF
--- a/examples/cors/Dockerfile
+++ b/examples/cors/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/3scale-amp20/apicast-gateway:1.0
+
+COPY apicast_cors.lua /opt/app-root/app/src/
+COPY cors.conf /opt/app-root/app/apicast.d/
+


### PR DESCRIPTION
This example uses the productised container image.