### PR TITLE
[remote_v2] don't crash when endpoint is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Crash on empty OIDC Issuer endpoint [PR #408](https://github.com/3scale/apicast/pull/408)
 - Handle partial credentials [PR #409](https://github.com/3scale/apicast/pull/409)
+- Crash when configuration endpoint was missing [PR #417](https://github.com/3scale/apicast/pull/417)
 
 ### Changed
 

--- a/apicast/src/configuration_loader/remote_v2.lua
+++ b/apicast/src/configuration_loader/remote_v2.lua
@@ -204,8 +204,13 @@ function _M:services()
     return nil, 'not initialized'
   end
 
-  local url = resty_url.join(self.endpoint, '/admin/api/services.json')
+  local endpoint = self.endpoint
 
+  if not endpoint then
+    return nil, 'no endpoint'
+  end
+
+  local url = resty_url.join(self.endpoint, '/admin/api/services.json')
   local res, err = http_client.get(url)
 
   if not res and err then
@@ -281,6 +286,9 @@ function _M:config(service, environment, version)
 
   if not http_client then return nil, 'not initialized' end
 
+  local endpoint = self.endpoint
+  if not endpoint then return nil, 'no endpoint' end
+
   local id = service and service.id
 
   if not id then return nil, 'invalid service, missing id' end
@@ -290,7 +298,7 @@ function _M:config(service, environment, version)
   local version_override = resty_env.get(format('APICAST_SERVICE_%s_CONFIGURATION_VERSION', id))
 
   local url = resty_url.join(
-    self.endpoint,
+    endpoint,
     '/admin/api/services/', id , '/proxy/configs/', environment, '/',
     format('%s.json', version_override or version)
   )

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -16,6 +16,18 @@ describe('Configuration Remote Loader V2', function()
 
   after_each(function() test_backend.verify_no_outstanding_expectations() end)
 
+  describe('loader without endpoint', function()
+    before_each(function() loader = _M.new() end)
+
+    it('wont crash when getting services', function()
+      assert.same({ nil, 'no endpoint' }, { loader:services() })
+    end)
+
+    it('wont crash when getting config', function()
+      assert.same({ nil, 'no endpoint' }, { loader:config() })
+    end)
+  end)
+
   describe('http_client #http', function()
     it('has correct user agent', function()
       test_backend.expect{ url = 'http://example.com/t', headers = { ['User-Agent'] = tostring(user_agent) } }


### PR DESCRIPTION
resty-url happily concatenates nil which makes the http client crash