### PR TITLE
[bin] improve busted runner

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,11 +1,14 @@
+local path = require('pl.path')
+local root = path.currentdir()
+
 return {
   _all = {
-    helper = 'spec/spec_helper.lua',
+    helper = path.join(root, 'spec/spec_helper.lua'),
   },
   default = {
     verbose = true,
     ['shuffle-tests'] = true,
     ['shuffle-files'] = true,
-    lpath = "./spec/?.lua;./apicast/src/?.lua;"
+    lpath = path.join(root, 'spec/?.lua;')  .. path.join(root, 'apicast/src/?.lua;'),
   },
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,5 +1,6 @@
 std = 'ngx_lua+lua52' -- lua52 has table.pack
 
-files["spec"] = {std = "+busted"}
+busted = {std = "+busted"}
+files["**/spec/**/*_spec.lua"] = busted
 
 globals = { 'ngx', 'unpack', 'rawlen' }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - OIDC is now used based on settings on the API Manager [PR #405](https://github.com/3scale/apicast/pull/405)
 - No limit on body size from the client sent to the server [PR #410](https://github.com/3scale/apicast/pull/410)
 - Print module loading errors only when it failed to load [PR #415](https://github.com/3scale/apicast/pull/415)
+- `bin/busted` rewritten to support different working directories [PR #418](https://github.com/3scale/apicast/pull/418)
 
 ## [3.1.0-beta2] - 2017-08-21
 

--- a/bin/busted
+++ b/bin/busted
@@ -1,3 +1,21 @@
-#!/usr/bin/env sh
+#!/usr/bin/env perl
 
-exec resty --http-include spec/fixtures/echo.conf bin/busted.lua "$@"
+use strict;
+use warnings FATAL => 'all';
+
+use File::Basename;
+use Cwd;
+
+my $dirname = dirname(__FILE__);
+my $cwd = getcwd();
+
+chdir "$dirname/..";
+
+my $apicast = getcwd();
+
+exec '/usr/bin/env', 'resty',
+    '--http-include', "$apicast/spec/fixtures/echo.conf",
+    "$apicast/bin/busted.lua",
+    '--config-file', "$apicast/.busted",
+    '--directory', "$cwd",
+    @ARGV;

--- a/examples/cors/spec/cors_spec.lua
+++ b/examples/cors/spec/cors_spec.lua
@@ -1,0 +1,7 @@
+local _M = require 'cors'
+
+describe('cors', function()
+	it('is', function()
+		assert.match('CORS', _M._NAME)
+	end)
+end)


### PR DESCRIPTION
* it is in Perl instead of Shell
* it is aware of current working directory
* can run tests in different folders
* can load code in different folders

example:

```shell
bin/busted -C examples/cors
```

or from within different directory:

```shell
../../bin/busted
```