### PR TITLE
[resty.resolver] fix double empty search scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Crash on empty OIDC Issuer endpoint [PR #408](https://github.com/3scale/apicast/pull/408)
 - Handle partial credentials [PR #409](https://github.com/3scale/apicast/pull/409)
 - Crash when configuration endpoint was missing [PR #417](https://github.com/3scale/apicast/pull/417)
+- Fix double queries to not fully qualified domains [PR #419](https://github.com/3scale/apicast/pull/419)
 
 ### Changed
 

--- a/apicast/src/resty/resolver.lua
+++ b/apicast/src/resty/resolver.lua
@@ -72,7 +72,7 @@ function _M.parse_nameservers(path)
 
   ngx.log(ngx.DEBUG, '/etc/resolv.conf:\n', resolv_conf)
 
-  local search = { '' }
+  local search = { }
   local nameservers = { search = search }
   local resolver = getenv('RESOLVER')
   local domains = match(resolv_conf, 'search%s+([^\n]+)')

--- a/spec/resty/resolver_spec.lua
+++ b/spec/resty/resolver_spec.lua
@@ -118,6 +118,13 @@ describe('resty.resolver', function()
     end)
   end)
 
+  describe('.search', function()
+    it('contains empty scope', function ()
+
+      assert.same({''}, resty_resolver.search)
+    end)
+  end)
+
   describe('.parse_nameservers', function()
     local tmpname
 
@@ -140,8 +147,8 @@ describe('resty.resolver', function()
     it('returns search domains', function()
       local search = resty_resolver.parse_nameservers(tmpname).search
 
-      assert.equal(3, #search)
-      assert.same({ '', 'localdomain.example.com', 'local' },  search)
+      assert.equal(2, #search)
+      assert.same({ 'localdomain.example.com', 'local' },  search)
     end)
 
   end)


### PR DESCRIPTION
resolver already has default empty search scope
so returning it in the parsed resolv.conf
would result in being used twice - duplicating queries