### PR TITLE
[dnsmasq] don't forward domainless queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - No limit on body size from the client sent to the server [PR #410](https://github.com/3scale/apicast/pull/410)
 - Print module loading errors only when it failed to load [PR #415](https://github.com/3scale/apicast/pull/415)
 - `bin/busted` rewritten to support different working directories [PR #418](https://github.com/3scale/apicast/pull/418)
+- dnsmasq started in docker will not forward queries without domain [PR #421](https://github.com/3scale/apicast/pull/421)
 
 ## [3.1.0-beta2] - 2017-08-21
 

--- a/apicast/.s2i/bin/run
+++ b/apicast/.s2i/bin/run
@@ -36,7 +36,7 @@ fi
 
 dnsmasq --listen-address=127.0.0.1 --port=5353 \
   --all-servers --no-host --no-hosts \
-  --cache-size=1000 --no-negcache \
+  --cache-size=1000 --no-negcache --domain-needed \
   --server="${RESOLVER:-}" \
   --log-facility=- ${DNSMASQ_OPTIONS:-} \
 


### PR DESCRIPTION
improves performance as it does not send queries to upstream dns servers
that have invalid scope