### PR TITLE
Add dockerized development environment

### DIFF
--- a/Dockerfile-development
+++ b/Dockerfile-development
@@ -1,0 +1,50 @@
+FROM quay.io/3scale/s2i-openresty-centos7:master
+LABEL maintainer="dortiz@redhat.com"
+
+USER root
+
+# 'default' user is defined in the base image
+ARG USER_NAME=default
+ARG USER_HOME=/home/centos
+
+RUN yum -y update \
+ && yum -y install perl-CPAN sudo \
+ && yum -y autoremove \
+ && yum -y clean all
+
+RUN mkdir ${USER_HOME} \
+ && chown -R ${USER_NAME}: ${USER_HOME} \
+ && echo "${USER_NAME} ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/${USER_NAME} \
+ && chmod 0440 /etc/sudoers.d/${USER_NAME}
+
+USER ${USER_NAME}
+
+# envs required by cpan
+ENV PATH="/opt/app-root/src/perl5/bin${PATH:+:${PATH}}"
+ENV PERL5LIB="/opt/app-root/src/perl5/lib/perl5${PERL5LIB:+:${PERL5LIB}}"
+ENV PERL_LOCAL_LIB_ROOT="/opt/app-root/src/perl5${PERL_LOCAL_LIB_ROOT:+:${PERL_LOCAL_LIB_ROOT}}"
+ENV PERL_MB_OPT="--install_base \"/opt/app-root/src/perl5\""
+ENV PERL_MM_OPT="INSTALL_BASE=/opt/app-root/src/perl5"
+ENV SHELL=/bin/bash
+
+ENV PATH=/usr/local/openresty/bin:/usr/local/openresty/luajit/bin:$PATH
+
+RUN cpan install version \
+ && cpan install Module::Metadata \
+ && cpan install Carton
+
+COPY cpanfile ${USER_HOME}
+COPY apicast/apicast-0.1-0.rockspec ${USER_HOME}/apicast/
+COPY rockspec ${USER_HOME}
+
+WORKDIR ${USER_HOME}
+
+RUN cpan install
+
+USER root
+
+RUN luarocks make apicast/apicast-0.1-0.rockspec
+RUN luarocks make rockspec
+
+USER ${USER_NAME}
+COPY . ${USER_HOME}

--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -1,0 +1,11 @@
+version: '2.1'
+services:
+  development:
+    image: apicast-development
+    depends_on:
+      - redis
+    entrypoint: "bash"
+    volumes:
+      - .:/home/centos/
+  redis:
+    image: redis

--- a/script/test
+++ b/script/test
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+COMMAND=$1
+PROJECT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+
+function run_busted_tests {
+    cd "${PROJECT_PATH}" || exit; ./bin/busted
+}
+
+function run_nginx_unit_tests {
+    cd "${PROJECT_PATH}" || exit
+
+    sudo TEST_NGINX_APICAST_PATH="${PROJECT_PATH}/apicast" \
+         TEST_NGINX_BINARY=openresty \
+         TEST_NGINX_REDIS_HOST=redis \
+         prove
+
+    # Text::Nginx runs nginx in the t/servroot dir. Clean it.
+    sudo rm -rf "${PROJECT_PATH}/t/servroot"
+}
+
+function run_all_tests {
+    run_busted_tests
+    run_nginx_unit_tests
+}
+
+case "${COMMAND}" in
+    busted)
+        run_busted_tests
+        ;;
+    nginx)
+        run_nginx_unit_tests
+        ;;
+    *)
+        run_all_tests
+        ;;
+esac


### PR DESCRIPTION
This PR adds a Dockerfile based on the builder image that installs all the dependencies required to run both the busted and the Test::Nginx tests.

The docker-compose file mounts a volume so the project source code is available in the image and sync'ed  with the local apicast directory. This way we can develop locally using our preferred environment and still be able to run the tests inside the docker container.

This PR also adds a helper bash script to run the tests.