### PR TITLE
[THREESCALE-360] fix loading configuration with null values

### DIFF
--- a/apicast/src/configuration_store.lua
+++ b/apicast/src/configuration_store.lua
@@ -101,7 +101,7 @@ function _M.store(self, config, ttl)
     local hosts = service.hosts or {}
     local id = service.id
 
-    if oidc[i] then
+    if oidc[i] ~= ngx.null then
       -- merge service and OIDC config, this is far from ideal, but easy for now
       for k,v in pairs(oidc[i] or {}) do
         service.oidc[k] = v

--- a/spec/configuration_store_spec.lua
+++ b/spec/configuration_store_spec.lua
@@ -11,6 +11,14 @@ describe('Configuration Store', function()
 
       assert.equal(service, store:find_by_id('42'))
     end)
+
+    it('stores config with OIDC', function()
+      local store = configuration.new()
+      local service_one = { id = '7', hosts = { 'example.com' } }
+      local service_two = { id = '42', hosts = { 'oidc.example.com' } }
+
+      assert(store:store({services = { service_one, service_two }, oidc = { ngx.null, ngx.null }}))
+    end)
   end)
 
   describe('.find_by_id', function()


### PR DESCRIPTION
OIDC configuration can be null, that does not work like nil