### PR TITLE
Don't pass the request headers to 3scale backend for native OAuth flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Upgraded to OpenResty 1.11.2.5-1 [PR #428](https://github.com/3scale/apicast/pull/428)
 - `/oauth/token` endpoint returns an error status code, when the access token couldn't be stored in 3scale backend [PR #436](https://github.com/3scale/apicast/pull/436)]
 
+### Fixed
+
+- Request headers are not passed to the backend, preventing sending invalid Content-Type to the access token store endpoint [PR #433](https://github.com/3scale/apicast/pull/433)
+
 ## [3.1.0-rc1] - 2017-09-14
 
 ### Added
 
 - Support for extending APIcast location block with snippets of nginx configuration [PR #407](https://github.com/3scale/apicast/pull/407)
 
-### Fixes
+### Fixed
 
 - Crash on empty OIDC Issuer endpoint [PR #408](https://github.com/3scale/apicast/pull/408)
 - Handle partial credentials [PR #409](https://github.com/3scale/apicast/pull/409)

--- a/apicast/conf.d/apicast.conf
+++ b/apicast/conf.d/apicast.conf
@@ -95,6 +95,7 @@ location / {
 
 location = /_threescale/oauth_store_token {
   internal;
+  proxy_pass_request_headers off;
   proxy_set_header  X-Real-IP  $remote_addr;
   proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header  Host  "$backend_host";
@@ -108,6 +109,7 @@ location = /_threescale/oauth_store_token {
 location = /_threescale/check_credentials {
   internal;
 
+  proxy_pass_request_headers off;
   proxy_set_header  X-Real-IP  $remote_addr;
   proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header  Host  "$backend_host";


### PR DESCRIPTION
Keeping the request headers may be causing the issue with passing an incorrect `Content-Type` to the 3scale backend when storing the access token (`POST https://su1.3scale.net/services/<SERVICE_ID>/oauth_access_tokens.xml`).

The only valid content types for this endpoint are:
- `application/x-www-form-urlencoded`
- empty header (backend with then handle it as `application/x-www-form-urlencoded` implicitly)