### PR TITLE
OIDC - Add support for logout and token revocation [THREESCALE-312]

### DIFF
--- a/apicast/src/configuration_loader/remote_v2.lua
+++ b/apicast/src/configuration_loader/remote_v2.lua
@@ -122,7 +122,7 @@ function _M:index(host)
       end
       config.services[i] = proxy_config.content
     end
-
+    
     return cjson.encode(config)
   else
     return nil, 'invalid status'
@@ -275,6 +275,9 @@ function _M:oidc_issuer_configuration(service)
     ngx.log(ngx.ERR, 'invalid OIDC Issuer, expected application/json got:  ', res.headers.content_type, ' body: ', res.body)
     return nil, 'invalid JSON'
   end
+  local parts = resty_url.parse(service.oidc.issuer_endpoint)
+  config.client_id = parts.user
+  config.client_secret = parts.password
 
   issuer.openid = config
 

--- a/apicast/src/configuration_loader/remote_v2.lua
+++ b/apicast/src/configuration_loader/remote_v2.lua
@@ -122,7 +122,7 @@ function _M:index(host)
       end
       config.services[i] = proxy_config.content
     end
-    
+
     return cjson.encode(config)
   else
     return nil, 'invalid status'

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -132,7 +132,7 @@ describe('Configuration Remote Loader V2', function()
             environment = 'sandbox',
             content = {
               id = 42, backend_version = 1,
-              proxy = { oidc_issuer_endpoint = 'http://idp.example.com/auth/realms/foo/' }
+              proxy = { oidc_issuer_endpoint = 'http://admin:password@idp.example.com/auth/realms/foo/' }
             }
           }
         }
@@ -163,6 +163,8 @@ describe('Configuration Remote Loader V2', function()
       assert.same({
         config = {
           openid = {
+            client_id = 'admin',
+            client_secret = 'password',
             id_token_signing_alg_values_supported = { 'RS256' },
             issuer = 'https://idp.example.com/auth/realms/foo',
           },

--- a/spec/oauth/oidc_spec.lua
+++ b/spec/oauth/oidc_spec.lua
@@ -139,7 +139,7 @@ describe('OIDC', function()
     end)
   end)
 
-  describe(':transform_credentials with token introspection', function() 
+  describe(':transform_credentials with token introspection', function()
     local access_token = jwt:sign(rsa.private, {
         header = { typ = 'JWT', alg = 'RS256' },
         payload = {
@@ -162,19 +162,18 @@ describe('OIDC', function()
           }
         }
       },
-      extract_credentials = function() 
+      extract_credentials = function()
         return { ['access_token'] = access_token }
       end
     }
     local test_backend
 
     before_each(function() jwt_validators.set_system_clock(function() return 0 end) end)
-    before_each(function() 
+    before_each(function()
       test_backend = test_backend_client.new()
     end)
 
-    
-    it('executes token introspection to idp if enabled', function() 
+    it('executes token introspection to idp if enabled', function()
       local oidc = _M.new(service, {client = test_backend, introspection_enabled = true})
       test_backend.expect{ url = 'https://example.com/auth/realms/apicast/token/introspection' }.
         respond_with{
@@ -187,14 +186,14 @@ describe('OIDC', function()
       local credentials,_,err = oidc:transform_credentials({access_token = access_token})
       assert(credentials, err)
       assert.same({ app_id = 'foobar'}, credentials)
-      
+
       -- and do not call twice if caching results
-      credentials, _, err = oidc:transform_credentials({access_token = access_token})
+      credentials, _, _ = oidc:transform_credentials({access_token = access_token})
       assert.same({ app_id = 'foobar'}, credentials)
       test_backend.verify_no_outstanding_expectations()
     end)
 
-    it('fails transform_credentials after revoke', function() 
+    it('fails transform_credentials after revoke', function()
       local oidc = _M.new(service, {client = test_backend, introspection_enabled = true})
       test_backend.expect{ url = 'https://example.com/auth/realms/apicast/token/introspection' }.
         respond_with {
@@ -219,12 +218,12 @@ describe('OIDC', function()
 
       oidc:revoke_credentials(service)
       credentials,_,err = oidc:transform_credentials({access_token = access_token})
-      assert.falsy(credential)
+      assert.falsy(credentials)
       assert.truthy(err)
       test_backend.verify_no_outstanding_expectations()
     end)
 
-    it('fails transform_credentials if token is not active', function() 
+    it('fails transform_credentials if token is not active', function()
       local oidc = _M.new(service, {client = test_backend, introspection_enabled = true})
       test_backend.expect{ url = 'https://example.com/auth/realms/apicast/token/introspection' }.
         respond_with{
@@ -234,7 +233,7 @@ describe('OIDC', function()
           })
         }
       local credentials,_,err = oidc:transform_credentials({access_token = access_token})
-      assert.falsy(credential)
+      assert.falsy(credentials)
       assert.truthy(err)
       test_backend.verify_no_outstanding_expectations()
     end)

--- a/spec/oauth/oidc_spec.lua
+++ b/spec/oauth/oidc_spec.lua
@@ -4,6 +4,8 @@ local jwt_validators = require('resty.jwt-validators')
 local jwt = require('resty.jwt')
 
 local rsa = require('fixtures.rsa')
+local test_backend_client = require('resty.http_ng.backend.test')
+local cjson = require 'cjson'
 
 describe('OIDC', function()
 
@@ -135,6 +137,108 @@ describe('OIDC', function()
       assert.match('invalid alg', err, nil, true)
       assert.falsy(credentials, err)
     end)
+  end)
+
+  describe(':transform_credentials with token introspection', function() 
+    local access_token = jwt:sign(rsa.private, {
+        header = { typ = 'JWT', alg = 'RS256' },
+        payload = {
+          iss = 'https://example.com/auth/realms/apicast',
+          aud = 'foobar',
+          nbf = 0,
+          exp = ngx.now() + 10,
+        },
+      })
+    local service =  {
+      id = 2,
+      oidc = {
+        issuer = 'https://example.com/auth/realms/apicast',
+        config = {
+          public_key = rsa.pub,
+          openid = {
+            id_token_signing_alg_values_supported = { 'RS256' },
+            token_introspection_endpoint = 'https://example.com/auth/realms/apicast/token/introspection',
+            end_session_endpoint = 'https://example.com/auth/realms/apicast/logout',
+          }
+        }
+      },
+      extract_credentials = function() 
+        return { ['access_token'] = access_token }
+      end
+    }
+    local test_backend
+
+    before_each(function() jwt_validators.set_system_clock(function() return 0 end) end)
+    before_each(function() 
+      test_backend = test_backend_client.new()
+    end)
+
+    
+    it('executes token introspection to idp if enabled', function() 
+      local oidc = _M.new(service, {client = test_backend, introspection_enabled = true})
+      test_backend.expect{ url = 'https://example.com/auth/realms/apicast/token/introspection' }.
+        respond_with{
+          status = 200,
+          body = cjson.encode({
+              active = true
+          })
+        }
+      -- call token introspection and cache results
+      local credentials,_,err = oidc:transform_credentials({access_token = access_token})
+      assert(credentials, err)
+      assert.same({ app_id = 'foobar'}, credentials)
+      
+      -- and do not call twice if caching results
+      credentials, _, err = oidc:transform_credentials({access_token = access_token})
+      assert.same({ app_id = 'foobar'}, credentials)
+      test_backend.verify_no_outstanding_expectations()
+    end)
+
+    it('fails transform_credentials after revoke', function() 
+      local oidc = _M.new(service, {client = test_backend, introspection_enabled = true})
+      test_backend.expect{ url = 'https://example.com/auth/realms/apicast/token/introspection' }.
+        respond_with {
+          status = 200,
+          body = cjson.encode({
+            active = true
+          })
+        }
+      test_backend.expect{ url = 'https://example.com/auth/realms/apicast/logout' }.
+        respond_with {
+          status = 204,
+          body = ""
+        }
+      stub(ngx, 'say')
+      stub(ngx, 'exit')
+      stub(ngx.req , 'read_body')
+      stub(ngx.req , 'get_body_data')
+      stub(ngx, 'decode_args', function() return {refresh_token = ""} end)
+      local credentials,_,err = oidc:transform_credentials({access_token = access_token})
+      assert(credentials, err)
+      assert.same({ app_id = 'foobar'}, credentials)
+
+      oidc:revoke_credentials(service)
+      credentials,_,err = oidc:transform_credentials({access_token = access_token})
+      assert.falsy(credential)
+      assert.truthy(err)
+      test_backend.verify_no_outstanding_expectations()
+    end)
+
+    it('fails transform_credentials if token is not active', function() 
+      local oidc = _M.new(service, {client = test_backend, introspection_enabled = true})
+      test_backend.expect{ url = 'https://example.com/auth/realms/apicast/token/introspection' }.
+        respond_with{
+          status = 200,
+          body = cjson.encode({
+              active = false
+          })
+        }
+      local credentials,_,err = oidc:transform_credentials({access_token = access_token})
+      assert.falsy(credential)
+      assert.truthy(err)
+      test_backend.verify_no_outstanding_expectations()
+    end)
+
   end)
 
 end)


### PR DESCRIPTION
Hi, 

I create OpenID Connect logout and token revocation feature.[THREESCALE-312](https://issues.jboss.org/browse/THREESCALE-312)

specs are below

## add /oidc/logout endpoint 
- delete access token from cache
- add acccess token to the "revoked token cache"
- send POST request to the end_session_endpoint of IdP

When the client send a POST request to the logout endpoint with 
  header : bearer with access token 
  body : refresh_token=<_refresh token_>
then delete access token from the cache and logout from IdP. 

## add token introspection feature
- only execute when the access_token is not cached.
- add "APICAST_TOKEN_INTROSPECTION_ENABLED" config to enable this feature 


This feature covers the requests 1) token is not cached, 2) token is not expire and 3) token was revoked at IdP.