### PR TITLE
Set correct status code of the error on token store fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Changed
 
 - Upgraded to OpenResty 1.11.2.5-1 [PR #428](https://github.com/3scale/apicast/pull/428)
+- `/oauth/token` endpoint returns an error status code, when the access token couldn't be stored in 3scale backend [PR #436](https://github.com/3scale/apicast/pull/436)]
 
 ## [3.1.0-rc1] - 2017-09-14
 
 ### Added
 
-- Support for extending APIcast location block with snippets of nginx configuration [PR #407][https://github.com/3scale/apicast/pull/407]
+- Support for extending APIcast location block with snippets of nginx configuration [PR #407](https://github.com/3scale/apicast/pull/407)
 
 ### Fixes
 
@@ -26,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- `THREESCALE\_DEPLOYMENT\_ENV` defaults to `production` [PR #406](https://github.com/3scale/apicast/pull/406)
+- `THREESCALE_DEPLOYMENT_ENV` defaults to `production` [PR #406](https://github.com/3scale/apicast/pull/406)
 - OIDC is now used based on settings on the API Manager [PR #405](https://github.com/3scale/apicast/pull/405)
 - No limit on body size from the client sent to the server [PR #410](https://github.com/3scale/apicast/pull/410)
 - Print module loading errors only when it failed to load [PR #415](https://github.com/3scale/apicast/pull/415)

--- a/apicast/src/oauth/apicast_oauth/get_token.lua
+++ b/apicast/src/oauth/apicast_oauth/get_token.lua
@@ -112,6 +112,7 @@ local function get_token(params)
     if stored.status == 200 then
       send_token(token)
     else
+      ngx.status = stored.status
       ngx.say('{"error":"'..stored.body..'"}')
       ngx.exit(stored.status)
     end

--- a/t/005-apicast-oauth.t
+++ b/t/005-apicast-oauth.t
@@ -641,3 +641,77 @@ GET /t
 --- error_code: 401
 --- no_error_log
 [error]
+
+=== TEST 17: return error status code and message when access token couldn't be stored in 3scale
+--- main_config
+  env REDIS_HOST=$TEST_NGINX_REDIS_HOST;
+  env RESOLVER=$TEST_NGINX_RESOLVER;
+--- http_config
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+  init_by_lua_block {
+    require('configuration_loader').mock({
+      services = {
+        { id = 42, backend_version = 'oauth' }
+      }
+    })
+  }
+--- config
+  include $TEST_NGINX_APICAST_CONFIG;
+
+  lua_need_request_body on;
+  location = /t {
+    content_by_lua_block {
+      local authorize = require('oauth.apicast_oauth.authorize')
+      local authorized_callback = require('oauth.apicast_oauth.authorized_callback')
+      local code = 'authcode'
+      local params = { user_id = 'someuser' }
+      local client_data = {
+        client_id = 'foo',
+        secret_id = 'bar',
+        redirect_uri = 'redirect',
+        access_token = 'token'
+      }
+
+      assert(authorized_callback.persist_code(client_data, params, code))
+
+      ngx.req.set_method(ngx.HTTP_POST)
+      ngx.req.set_body_data('grant_type=authorization_code&client_id=foo&client_secret=bar&redirect_uri=redirect&code=' .. code)
+      ngx.exec('/oauth/token')
+    }
+  }
+
+    set $backend_endpoint 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT/backend';
+    set $backend_host '127.0.0.1';
+    set $service_id 42;
+    set $backend_authentication_type 'provider_key';
+    set $backend_authentication_value 'fookey';
+
+    location = /backend/transactions/oauth_authorize.xml {
+      content_by_lua_block {
+        expected = "provider_key=fookey&service_id=42&app_key=bar&app_id=foo&redirect_uri=redirect"
+        if ngx.var.args == expected and ngx.var.host == ngx.var.backend_host then
+          ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized><application><key>bar</key></application></status>')
+          ngx.exit(200)
+        else
+          ngx.log(ngx.ERR, 'expected: ' .. expected .. ' got: ' .. ngx.var.args)
+          ngx.exit(403)
+        end
+      }
+    }
+
+    location = /backend/services/42/oauth_access_tokens.xml {
+      content_by_lua_block {
+        ngx.status = 400
+        ngx.print("token couldn't be stored")
+        ngx.exit(400)
+      }
+    }
+
+--- request
+GET /t
+--- error_code: 400
+--- response_body
+{"error":"token couldn't be stored"}
+--- no_error_log
+[error]
+


### PR DESCRIPTION
In the native OAuth flow, when storing access token in 3scale backend fails, currently a `200` status code is returned. It doesn't seem to be the desired behavior, as there's the following line:
```
ngx.exit(stored.status)
```

It also provokes the following warning message:
```
*1 attempt to set status 400 via ngx.exit after sending out the response status 200
```

This PR fixes it, and returns to the client the status code that was returned by the 3scale backend on token store attempt.