### PR TITLE
Fix inconsistent mapping rules matching in POST requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Upgraded to OpenResty 1.11.2.5-1 [PR #428](https://github.com/3scale/apicast/pull/428)
 - `/oauth/token` endpoint returns an error status code, when the access token couldn't be stored in 3scale backend [PR #436](https://github.com/3scale/apicast/pull/436)]
+- URI params in POST requests are now taken into account when matching mapping rules [PR #437](https://github.com/3scale/apicast/pull/437)
 
 ### Fixed
 

--- a/apicast/src/configuration.lua
+++ b/apicast/src/configuration.lua
@@ -66,16 +66,21 @@ local function check_rule(req, rule, usage_t, matched_rules, params)
 end
 
 local function get_auth_params(method)
-  local params
+  local params = ngx.req.get_uri_args()
 
   if method == "GET" then
-    params = ngx.req.get_uri_args()
+    return params
   else
     ngx.req.read_body()
-    params = ngx.req.get_post_args()
-  end
+    local body_params = ngx.req.get_post_args()
 
-  return params
+    -- Adds to body_params URI params that are not included in the body. Doing
+    -- the reverse would be more expensive, because in general, we expect the
+    -- size of body_params to be larger than the size of params.
+    setmetatable(body_params, { __index = params })
+
+    return body_params
+  end
 end
 
 local regex_variable = '\\{[-\\w_]+\\}'

--- a/t/010-apicast-mapping-rules.t
+++ b/t/010-apicast-mapping-rules.t
@@ -62,3 +62,148 @@ GET /staging/video/encode?size=100&speed=3x&user_key=foo&speed=2x
 --- response_body
 yay, api backend
 --- error_code: 200
+
+=== TEST 2: mapping rules when POST request has url parms
+url params in a POST call are taken into account when matching mapping rules.
+
+--- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+  init_by_lua_block {
+    require('configuration_loader').mock({
+      services = {
+        {
+          id = 42,
+          backend_version = 1,
+          proxy = {
+            api_backend = 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api/',
+            proxy_rules = {
+              { pattern = '/foo?bar=baz',
+                querystring_parameters = { bar = 'baz' },
+                http_method = 'POST',
+                metric_system_name = 'bar',
+                delta = 7 }
+            }
+          }
+        },
+      }
+    })
+  }
+--- config
+  include $TEST_NGINX_APICAST_CONFIG;
+
+  set $backend_endpoint 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT';
+
+  location /api/ {
+    echo "api response";
+  }
+
+  location /transactions/authrep.xml {
+    content_by_lua_block { ngx.exit(200) }
+  }
+--- request
+POST /foo?bar=baz&user_key=somekey
+--- response_body
+api response
+--- error_code: 200
+--- response_headers
+X-3scale-matched-rules: /foo?bar=baz
+X-3scale-usage: usage%5Bbar%5D=7
+
+=== TEST 3: mapping rules when POST request has body params
+request body params in a POST call are taken into account when matching mapping rules.
+
+--- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+  init_by_lua_block {
+    require('configuration_loader').mock({
+      services = {
+        {
+          id = 42,
+          backend_version = 1,
+          proxy = {
+            api_backend = 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api/',
+            proxy_rules = {
+              { pattern = '/foo?bar=baz',
+                querystring_parameters = { bar = 'baz' },
+                http_method = 'POST',
+                metric_system_name = 'bar',
+                delta = 7 }
+            }
+          }
+        },
+      }
+    })
+  }
+--- config
+  include $TEST_NGINX_APICAST_CONFIG;
+
+  set $backend_endpoint 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT';
+
+  location /api/ {
+    echo "api response";
+  }
+
+  location /transactions/authrep.xml {
+    content_by_lua_block { ngx.exit(200) }
+  }
+--- request
+POST /foo?user_key=somekey
+bar=baz
+--- response_body
+api response
+--- error_code: 200
+--- response_headers
+X-3scale-matched-rules: /foo?bar=baz
+X-3scale-usage: usage%5Bbar%5D=7
+
+=== TEST 4: mapping rules when POST request has body params and url params
+Both body params and url params are taken into account when matching mapping
+rules. When a param is both in the url and the body, the one in the body takes
+precedence.
+
+--- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+  init_by_lua_block {
+    require('configuration_loader').mock({
+      services = {
+        {
+          id = 42,
+          backend_version = 1,
+          proxy = {
+            api_backend = 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api/',
+            proxy_rules = {
+              { pattern = '/foo?a_param=val1&another_param=val2',
+                querystring_parameters = { a_param = 'val1', another_param = 'val2' },
+                http_method = 'POST',
+                metric_system_name = 'bar',
+                delta = 7 }
+            }
+          }
+        },
+      }
+    })
+  }
+--- config
+  include $TEST_NGINX_APICAST_CONFIG;
+
+  set $backend_endpoint 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT';
+
+  location /api/ {
+    echo "api response";
+  }
+
+  location /transactions/authrep.xml {
+    content_by_lua_block { ngx.exit(200) }
+  }
+--- request
+POST /foo?a_param=val3&another_param=val2&user_key=somekey
+a_param=val1
+--- response_body
+api response
+--- error_code: 200
+--- response_headers
+X-3scale-matched-rules: /foo?a_param=val1&another_param=val2
+X-3scale-usage: usage%5Bbar%5D=7


### PR DESCRIPTION
Fixes #163 

Suppose we have this mapping rule: `POST /test?key={value}`.

Before this change, `curl -XPOST "http://localhost:8080/test?key=hello" -d "another=parameter"` did not match, but `curl -XPOST "http://localhost:8080/test" -d "key=hello&another=parameter"` did.

That's because in POST requests, body params were taken into account, but URI params were not. This PR changes that inconsistent behavior. Now both body & URI params are checked.

Please take a look at my comment here : https://github.com/3scale/apicast/compare/fix-mapping-rules-matching-post?expand=1#diff-5b5add30019fd642b1fd7ef108ef978eR75 and let me know if you would do it differently.