### PR TITLE
[THREESCALE-377] Fix ready and live endpoints content types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Request headers are not passed to the backend, preventing sending invalid Content-Type to the access token store endpoint [PR #433](https://github.com/3scale/apicast/pull/433)
+- Live and ready endpoints now set correct Content-Type header in the response[PR #441](https://github.com/3scale/apicast/pull/441)
 
 ## [3.1.0-rc1] - 2017-09-14
 

--- a/apicast/src/management.lua
+++ b/apicast/src/management.lua
@@ -9,7 +9,7 @@ local inspect = require('inspect')
 local resolver_cache = require('resty.resolver.cache')
 local env = require('resty.env')
 
-local live = cjson.encode({status = 'live', success = true})
+local live = { status = 'live', success = true }
 
 local function json_response(body, status)
   ngx.header.content_type = 'application/json; charset=utf-8'
@@ -20,14 +20,11 @@ end
 function _M.ready()
   local status = _M.status()
   local code = status.success and ngx.HTTP_OK or 412
-
-  ngx.status = code
-  ngx.say(cjson.encode(status))
+  json_response(status, code)
 end
 
 function _M.live()
-  ngx.status = ngx.HTTP_OK
-  ngx.say(live)
+  json_response(live, ngx.HTTP_OK)
 end
 
 function _M.status(config)

--- a/t/001-management.t
+++ b/t/001-management.t
@@ -30,6 +30,8 @@ env APICAST_MANAGEMENT_API=status;
 include $TEST_NGINX_MANAGEMENT_CONFIG;
 --- request
 GET /status/ready
+--- response_headers
+Content-Type: application/json; charset=utf-8
 --- response_body
 {"status":"ready","success":true}
 --- error_code: 200
@@ -46,6 +48,8 @@ env APICAST_MANAGEMENT_API=status;
 include $TEST_NGINX_MANAGEMENT_CONFIG;
 --- request
 GET /status/ready
+--- response_headers
+Content-Type: application/json; charset=utf-8
 --- response_body
 {"success":false,"status":"error","error":"not configured"}
 --- error_code: 412
@@ -65,6 +69,8 @@ env APICAST_MANAGEMENT_API=status;
   include $TEST_NGINX_MANAGEMENT_CONFIG;
 --- request
 GET /status/ready
+--- response_headers
+Content-Type: application/json; charset=utf-8
 --- response_body
 {"success":true,"status":"warning","warning":"no services"}
 --- error_code: 200
@@ -81,6 +87,8 @@ env APICAST_MANAGEMENT_API=status;
   include $TEST_NGINX_MANAGEMENT_CONFIG;
 --- request
 GET /status/live
+--- response_headers
+Content-Type: application/json; charset=utf-8
 --- response_body
 {"status":"live","success":true}
 --- error_code: 200


### PR DESCRIPTION
Both the ready and the live endpoints were returning 'text/plain', but the actual content is JSON.

Fixes https://issues.jboss.org/browse/THREESCALE-377