### PR TITLE
install dependencies by lua-rover

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,18 +37,27 @@ jobs:
       - run: make prove-docker
   build:
     docker:
-      - image: quay.io/3scale/s2i-openresty-centos7:1.11.2.5-1
+      - image: quay.io/3scale/s2i-openresty-centos7:1.11.2.5-2
         environment:
           TEST_NGINX_BINARY: openresty
           LUA_BIN_PATH: /opt/app-root/bin
+          ROVER: /usr/local/openresty/luajit/bin/rover
       - image: redis:3.2.8-alpine
     working_directory: /opt/app-root/apicast
     steps:
       - checkout
-      - run: luarocks make apicast/*.rockspec
-      - run: luarocks make rockspec
-      - run: make busted
-      - run: prove # no carton on centos
+      - restore_cache:
+          keys:
+            - apicast-rocks-{{ arch }}-{{ checksum "Roverfile.lock" }}
+            - apicast-rocks-{{ arch }}-{{ .Branch }}
+            - apicast-rocks-{{ arch }}-master
+      - run: make dependencies
+      - save_cache:
+          key: apicast-rocks-{{ arch }}-{{ checksum "Roverfile.lock" }}
+          paths:
+            - lua_modules
+      - run: ${ROVER} exec make busted
+      - run: ${ROVER} exec prove # no carton on centos
       - run: make doc
   deploy:
     <<: *S2i


### PR DESCRIPTION
* using lockfile ensures the same dependencies everywhere
* can be cached because uses one tree for all dependencies
* automatically installs rover by makefile

Please note that [lua-rover](https://github.com/3scale/lua-rover) is in alpha state. It might be horribly broken. Some features are not there yet.
Depends on https://github.com/3scale/s2i-openresty/pull/37