### PR TITLE
Policy chain - first version

### DIFF
--- a/apicast/conf.d/apicast.conf
+++ b/apicast/conf.d/apicast.conf
@@ -5,9 +5,9 @@ set_by_lua_block $deployment {
 }
 
 # TODO: enable in the future when we support SSL
-# ssl_certificate_by_lua_block { require('policy_chain').call() }
-# ssl_session_fetch_by_lua_block { require('policy_chain').call() }
-# ssl_session_store_by_lua_block { require('policy_chain').call() }
+# ssl_certificate_by_lua_block { require('executor').call() }
+# ssl_session_fetch_by_lua_block { require('executor').call() }
+# ssl_session_store_by_lua_block { require('executor').call() }
 
 location = /___http_call {
   internal;
@@ -48,11 +48,11 @@ location @out_of_band_authrep_action {
 
   set_by_lua $original_request_time 'return ngx.var.request_time';
 
-  content_by_lua_block { require('policy_chain'):post_action() }
+  content_by_lua_block { require('executor'):post_action() }
 
   log_by_lua_block {
     ngx.var.post_action_impact = ngx.var.request_time - ngx.var.original_request_time
-    require('policy_chain'):log()
+    require('executor'):log()
   }
 }
 
@@ -81,12 +81,12 @@ location / {
 
   proxy_ignore_client_abort on;
 
-  rewrite_by_lua_block { require('policy_chain'):rewrite() }
-  access_by_lua_block { require('policy_chain'):access() }
-  body_filter_by_lua_block { require('policy_chain'):body_filter() }
-  header_filter_by_lua_block { require('policy_chain'):header_filter() }
+  rewrite_by_lua_block { require('executor'):rewrite() }
+  access_by_lua_block { require('executor'):access() }
+  body_filter_by_lua_block { require('executor'):body_filter() }
+  header_filter_by_lua_block { require('executor'):header_filter() }
 
-  content_by_lua_block { require('policy_chain'):content() }
+  content_by_lua_block { require('executor'):content() }
 
   proxy_pass $proxy_pass;
   proxy_http_version 1.1;

--- a/apicast/conf.d/apicast.conf
+++ b/apicast/conf.d/apicast.conf
@@ -5,9 +5,9 @@ set_by_lua_block $deployment {
 }
 
 # TODO: enable in the future when we support SSL
-# ssl_certificate_by_lua_block { require('module').call() }
-# ssl_session_fetch_by_lua_block { require('module').call() }
-# ssl_session_store_by_lua_block { require('module').call() }
+# ssl_certificate_by_lua_block { require('policy_chain').call() }
+# ssl_session_fetch_by_lua_block { require('policy_chain').call() }
+# ssl_session_store_by_lua_block { require('policy_chain').call() }
 
 location = /___http_call {
   internal;
@@ -48,11 +48,11 @@ location @out_of_band_authrep_action {
 
   set_by_lua $original_request_time 'return ngx.var.request_time';
 
-  content_by_lua_block { require('module'):post_action() }
+  content_by_lua_block { require('policy_chain'):post_action() }
 
   log_by_lua_block {
     ngx.var.post_action_impact = ngx.var.request_time - ngx.var.original_request_time
-    require('module'):log()
+    require('policy_chain'):log()
   }
 }
 
@@ -81,12 +81,12 @@ location / {
 
   proxy_ignore_client_abort on;
 
-  rewrite_by_lua_block { require('module'):rewrite() }
-  access_by_lua_block { require('module'):access() }
-  body_filter_by_lua_block { require('module'):body_filter() }
-  header_filter_by_lua_block { require('module'):header_filter() }
+  rewrite_by_lua_block { require('policy_chain'):rewrite() }
+  access_by_lua_block { require('policy_chain'):access() }
+  body_filter_by_lua_block { require('policy_chain'):body_filter() }
+  header_filter_by_lua_block { require('policy_chain'):header_filter() }
 
-  content_by_lua_block { require('module'):content() }
+  content_by_lua_block { require('policy_chain'):content() }
 
   proxy_pass $proxy_pass;
   proxy_http_version 1.1;

--- a/apicast/http.d/init.conf
+++ b/apicast/http.d/init.conf
@@ -8,7 +8,7 @@ init_by_lua_block {
     require("resty.core")
     require('resty.resolver').init()
 
-    local module = require('module')
+    local module = require('policy_chain')
 
     if not module then
       ngx.log(ngx.EMERG, 'fatal error when loading the root module')
@@ -21,7 +21,7 @@ init_by_lua_block {
 }
 
 init_worker_by_lua_block {
-    require('module'):init_worker()
+    require('policy_chain'):init_worker()
 }
 
 lua_shared_dict init 16k;

--- a/apicast/http.d/init.conf
+++ b/apicast/http.d/init.conf
@@ -8,7 +8,7 @@ init_by_lua_block {
     require("resty.core")
     require('resty.resolver').init()
 
-    local module = require('policy_chain')
+    local module = require('executor')
 
     if not module then
       ngx.log(ngx.EMERG, 'fatal error when loading the root module')
@@ -21,7 +21,7 @@ init_by_lua_block {
 }
 
 init_worker_by_lua_block {
-    require('policy_chain'):init_worker()
+    require('executor'):init_worker()
 }
 
 lua_shared_dict init 16k;

--- a/apicast/http.d/upstream.conf
+++ b/apicast/http.d/upstream.conf
@@ -1,7 +1,7 @@
 upstream upstream {
   server 0.0.0.1:1;
 
-  balancer_by_lua_block { require('policy_chain'):balancer() }
+  balancer_by_lua_block { require('executor'):balancer() }
 
   keepalive 1024;
 }

--- a/apicast/http.d/upstream.conf
+++ b/apicast/http.d/upstream.conf
@@ -1,7 +1,7 @@
 upstream upstream {
   server 0.0.0.1:1;
 
-  balancer_by_lua_block { require('module'):balancer() }
+  balancer_by_lua_block { require('policy_chain'):balancer() }
 
   keepalive 1024;
 }

--- a/apicast/src/apicast.lua
+++ b/apicast/src/apicast.lua
@@ -3,8 +3,6 @@ local balancer = require('balancer')
 local math = math
 local setmetatable = setmetatable
 
-local configuration_loader = require('configuration_loader').new()
-local configuration_store = require('configuration_store')
 local user_agent = require('user_agent')
 
 local noop = function() end
@@ -21,7 +19,6 @@ local mt = {
 --- This is called when APIcast boots the master process.
 function _M.new()
   return setmetatable({
-    configuration = configuration_store.new(),
     -- So there is no way to use ngx.ctx between request and post_action.
     -- We somehow need to share the instance of the proxy between those.
     -- This table is used to store the proxy object with unique reqeust id key
@@ -31,18 +28,15 @@ function _M.new()
   }, mt)
 end
 
-function _M:init()
+function _M.init()
   user_agent.cache()
 
   math.randomseed(ngx.now())
   -- First calls to math.random after a randomseed tend to be similar; discard them
   for _=1,3 do math.random() end
-
-  configuration_loader.init(self.configuration)
 end
 
-function _M:init_worker()
-  configuration_loader.init_worker(self.configuration)
+function _M.init_worker()
 end
 
 function _M.cleanup()
@@ -50,20 +44,17 @@ function _M.cleanup()
   ngx.exit(499)
 end
 
-function _M:rewrite()
-  ngx.on_abort(_M.cleanup)
+function _M:rewrite(context)
+  ngx.on_abort(self.cleanup)
 
   ngx.var.original_request_id = ngx.var.request_id
 
-  local host = ngx.var.host
   -- load configuration if not configured
   -- that is useful when lua_code_cache is off
   -- because the module is reloaded and has to be configured again
 
-  local configuration = configuration_loader.rewrite(self.configuration, host)
-
-  local p = proxy.new(configuration)
-  p.set_upstream(p:set_service(host))
+  local p = proxy.new(context.configuration)
+  p.set_upstream(p:set_service(context.host))
   ngx.ctx.proxy = p
 end
 

--- a/apicast/src/apicast.lua
+++ b/apicast/src/apicast.lua
@@ -1,4 +1,3 @@
-local proxy = require('proxy')
 local balancer = require('balancer')
 local math = math
 local setmetatable = setmetatable
@@ -53,7 +52,7 @@ function _M:rewrite(context)
   -- that is useful when lua_code_cache is off
   -- because the module is reloaded and has to be configured again
 
-  local p = proxy.new(context.configuration)
+  local p = context.proxy
   p.set_upstream(p:set_service(context.host))
   ngx.ctx.proxy = p
 end

--- a/apicast/src/apicast.lua
+++ b/apicast/src/apicast.lua
@@ -53,7 +53,7 @@ function _M:rewrite(context)
   -- because the module is reloaded and has to be configured again
 
   local p = context.proxy
-  p.set_upstream(p:set_service(context.host))
+  p.set_upstream(context.service)
   ngx.ctx.proxy = p
 end
 
@@ -77,15 +77,16 @@ function _M:post_action()
   end
 end
 
-function _M:access()
+function _M:access(context)
   local p = ngx.ctx.proxy
+  ngx.ctx.service = context.service
   local post_action_proxy = self.post_action_proxy
 
   if not post_action_proxy then
     return nil, 'not initialized'
   end
 
-  local access, handler = p:call() -- proxy:access() or oauth handler
+  local access, handler = p:call(context.service) -- proxy:access() or oauth handler
 
   local ok, err
 

--- a/apicast/src/balancer.lua
+++ b/apicast/src/balancer.lua
@@ -2,7 +2,7 @@ local round_robin = require 'resty.balancer.round_robin'
 
 local _M = { default_balancer = round_robin.new() }
 
-function _M.call(_, balancer)
+function _M.call(_, _, balancer)
   balancer = balancer or _M.default_balancer
   local host = ngx.var.proxy_host -- NYI: return to lower frame
   local peers = balancer:peers(ngx.ctx[host])

--- a/apicast/src/configuration_loader.lua
+++ b/apicast/src/configuration_loader.lua
@@ -55,7 +55,7 @@ local function ttl()
 end
 
 function _M.global(contents)
-  local module = require('module')
+  local module = require('policy_chain')
 
   return _M.configure(module.configuration, contents)
 end

--- a/apicast/src/configuration_loader.lua
+++ b/apicast/src/configuration_loader.lua
@@ -55,9 +55,9 @@ local function ttl()
 end
 
 function _M.global(contents)
-  local module = require('policy_chain')
+  local context = require('executor'):context()
 
-  return _M.configure(module.configuration, contents)
+  return _M.configure(context.configuration, contents)
 end
 
 function _M.configure(configuration, contents)

--- a/apicast/src/executor.lua
+++ b/apicast/src/executor.lua
@@ -1,0 +1,35 @@
+local setmetatable = setmetatable
+
+local policy_chain = require('policy_chain')
+local linked_list = require('linked_list')
+
+local _M = { }
+
+local mt = { __index = _M }
+
+-- forward all policy methods to the policy chain
+for i=1, #(policy_chain.PHASES) do
+    local phase_name = policy_chain.PHASES[i]
+
+    _M[phase_name] = function(self, ...)
+        return self.policy_chain[phase_name](self.policy_chain, self:context(), ...)
+    end
+end
+
+function _M.new()
+    local local_chain = policy_chain.build()
+
+    local load_configuration = policy_chain.load('policy.load_configuration', local_chain)
+
+    local global_chain = policy_chain.build({ load_configuration, local_chain })
+
+    return setmetatable({ policy_chain = global_chain }, mt)
+end
+
+function _M:context()
+    local config = self.policy_chain:export()
+
+    return linked_list.readwrite({}, config)
+end
+
+return _M.new()

--- a/apicast/src/executor.lua
+++ b/apicast/src/executor.lua
@@ -1,18 +1,23 @@
-local setmetatable = setmetatable
+local resty_env = require('resty.env')
+
+if resty_env.get('APICAST_MODULE') then
+  return require('module')
+end
 
 local policy_chain = require('policy_chain')
+local policy = require('policy')
 local linked_list = require('linked_list')
+
+local setmetatable = setmetatable
 
 local _M = { }
 
 local mt = { __index = _M }
 
 -- forward all policy methods to the policy chain
-for i=1, #(policy_chain.PHASES) do
-    local phase_name = policy_chain.PHASES[i]
-
-    _M[phase_name] = function(self, ...)
-        return self.policy_chain[phase_name](self.policy_chain, self:context(phase_name), ...)
+for _,phase in policy:phases() do
+    _M[phase] = function(self, ...)
+        return self.policy_chain[phase](self.policy_chain, self:context(phase), ...)
     end
 end
 

--- a/apicast/src/executor.lua
+++ b/apicast/src/executor.lua
@@ -17,8 +17,7 @@ for i=1, #(policy_chain.PHASES) do
 end
 
 function _M.new()
-    local local_chain = policy_chain.build()
-
+    local local_chain = policy_chain.load('policy.local_chain')
     local load_configuration = policy_chain.load('policy.load_configuration', local_chain)
 
     local global_chain = policy_chain.build({ load_configuration, local_chain })

--- a/apicast/src/executor.lua
+++ b/apicast/src/executor.lua
@@ -12,23 +12,43 @@ for i=1, #(policy_chain.PHASES) do
     local phase_name = policy_chain.PHASES[i]
 
     _M[phase_name] = function(self, ...)
-        return self.policy_chain[phase_name](self.policy_chain, self:context(), ...)
+        return self.policy_chain[phase_name](self.policy_chain, self:context(phase_name), ...)
     end
 end
 
 function _M.new()
-    local local_chain = policy_chain.load('policy.local_chain')
-    local load_configuration = policy_chain.load('policy.load_configuration', local_chain)
-
-    local global_chain = policy_chain.build({ load_configuration, local_chain })
+    local global_chain = policy_chain.build({
+        'policy.load_configuration', 'policy.find_service', 'policy.local_chain'
+    })
 
     return setmetatable({ policy_chain = global_chain }, mt)
 end
 
-function _M:context()
-    local config = self.policy_chain:export()
+local function build_context(executor)
+    local config = executor.policy_chain:export()
 
     return linked_list.readwrite({}, config)
+end
+
+local function shared_build_context(executor)
+    local ctx = ngx.ctx or {}
+    local context = ctx.context
+
+    if not context then
+        context = build_context(executor)
+
+        ctx.context = context
+    end
+
+    return context
+end
+
+function _M:context(phase)
+    if phase == 'init' then
+        return build_context(self)
+    end
+
+    return shared_build_context(self)
 end
 
 return _M.new()

--- a/apicast/src/executor.lua
+++ b/apicast/src/executor.lua
@@ -4,12 +4,6 @@
 -- when calling the policy chain methods. This 'context' contains information
 -- shared among policies.
 
-local resty_env = require('resty.env')
-
-if resty_env.get('APICAST_MODULE') then
-  return require('module')
-end
-
 local policy_chain = require('policy_chain')
 local policy = require('policy')
 local linked_list = require('linked_list')

--- a/apicast/src/executor.lua
+++ b/apicast/src/executor.lua
@@ -1,3 +1,9 @@
+--- Executor module
+-- The executor has a policy chain and will simply forward the calls it
+-- receives to that policy chain. It also manages the 'context' that is passed
+-- when calling the policy chain methods. This 'context' contains information
+-- shared among policies.
+
 local resty_env = require('resty.env')
 
 if resty_env.get('APICAST_MODULE') then
@@ -54,6 +60,9 @@ local function shared_build_context(executor)
     return context
 end
 
+--- Shared context among policies
+-- @tparam string phase Nginx phase
+-- @treturn linked_list The context. Note: The list returned is 'read-write'.
 function _M:context(phase)
     if phase == 'init' then
         return build_context(self)

--- a/apicast/src/executor.lua
+++ b/apicast/src/executor.lua
@@ -12,6 +12,12 @@ local setmetatable = setmetatable
 
 local _M = { }
 
+local DEFAULT_POLICIES = {
+    'policy.load_configuration',
+    'policy.find_service',
+    'policy.local_chain'
+}
+
 local mt = { __index = _M }
 
 -- forward all policy methods to the policy chain
@@ -21,12 +27,12 @@ for _,phase in policy.phases() do
     end
 end
 
-function _M.new()
-    local global_chain = policy_chain.build({
-        'policy.load_configuration', 'policy.find_service', 'policy.local_chain'
-    })
+local function global_chain()
+    return policy_chain.build(DEFAULT_POLICIES)
+end
 
-    return setmetatable({ policy_chain = global_chain }, mt)
+function _M.new()
+    return setmetatable({ policy_chain = global_chain() }, mt)
 end
 
 local function build_context(executor)

--- a/apicast/src/executor.lua
+++ b/apicast/src/executor.lua
@@ -15,7 +15,7 @@ local _M = { }
 local mt = { __index = _M }
 
 -- forward all policy methods to the policy chain
-for _,phase in policy:phases() do
+for _,phase in policy.phases() do
     _M[phase] = function(self, ...)
         return self.policy_chain[phase](self.policy_chain, self:context(phase), ...)
     end

--- a/apicast/src/linked_list.lua
+++ b/apicast/src/linked_list.lua
@@ -1,0 +1,45 @@
+local setmetatable = setmetatable
+
+local _M = {
+
+}
+
+local noop = function() end
+
+
+local empty_t = setmetatable({}, { __newindex = noop })
+local __index = function(t,k)
+    return t.current[k] or t.next[k]
+end
+
+local ro_mt = {
+    __index = __index,
+    __newindex = noop,
+}
+
+local rw_mt = {
+    __index = __index,
+    __newindex = function(t, k, v)
+        t.current[k] = v
+    end
+}
+
+local function linked_list(item, next, mt)
+    return setmetatable({
+        current = item or empty_t,
+        next = next or empty_t
+    }, mt)
+end
+
+local function readonly_linked_list(item, next)
+    return linked_list(item, next, ro_mt)
+end
+
+local function readwrite_linked_list(item, next)
+    return linked_list(item, next, rw_mt)
+end
+
+_M.readonly = readonly_linked_list
+_M.readwrite = readwrite_linked_list
+
+return _M

--- a/apicast/src/linked_list.lua
+++ b/apicast/src/linked_list.lua
@@ -1,4 +1,5 @@
 local setmetatable = setmetatable
+local error = error
 
 local _M = {
 
@@ -14,7 +15,9 @@ end
 
 local ro_mt = {
     __index = __index,
-    __newindex = noop,
+    __newindex = function()
+        error("readonly list")
+    end,
 }
 
 local rw_mt = {

--- a/apicast/src/management.lua
+++ b/apicast/src/management.lua
@@ -1,7 +1,7 @@
 local _M = {}
 
 local cjson = require('cjson')
-local module = require('module')
+local module = require('policy_chain')
 local router = require('router')
 local configuration_parser = require('configuration_parser')
 local configuration_loader = require('configuration_loader')

--- a/apicast/src/policy.lua
+++ b/apicast/src/policy.lua
@@ -1,0 +1,26 @@
+local _M = {}
+
+local setmetatable = setmetatable
+local policy_chain = require('policy_chain')
+
+local noop = function() end
+
+function _M.new(name)
+    local policy = {
+        _NAME = name or 'policy',
+        _VERSION = '0.0',
+    }
+    local mt = { __index = policy }
+
+    function policy.new()
+        return setmetatable({}, mt)
+    end
+
+    for i=1,#(policy_chain.PHASES) do
+        policy[policy_chain.PHASES[i]] = noop
+    end
+
+    return policy, mt
+end
+
+return _M

--- a/apicast/src/policy.lua
+++ b/apicast/src/policy.lua
@@ -1,8 +1,14 @@
-local _M = {}
+local _M = {
+    PHASES = {
+        'init', 'init_worker',
+        'rewrite', 'access', 'balancer',
+        'header_filter', 'body_filter',
+        'post_action',  'log'
+    }
+}
 
 local setmetatable = setmetatable
 local ipairs = ipairs
-local policy_chain = require('policy_chain')
 
 local noop = function() end
 
@@ -22,15 +28,15 @@ function _M.new(name, version)
         return setmetatable({}, mt)
     end
 
-    for _, phase in _M.phases() do
+    for _, phase in _M:phases() do
         policy[phase] = noop
     end
 
     return policy
 end
 
-function _M.phases()
-    return ipairs(policy_chain.PHASES)
+function _M:phases()
+    return ipairs(self.PHASES)
 end
 
 return _M

--- a/apicast/src/policy.lua
+++ b/apicast/src/policy.lua
@@ -1,6 +1,7 @@
 local _M = {}
 
 local setmetatable = setmetatable
+local ipairs = ipairs
 local policy_chain = require('policy_chain')
 
 local noop = function() end
@@ -21,11 +22,15 @@ function _M.new(name, version)
         return setmetatable({}, mt)
     end
 
-    for i=1,#(policy_chain.PHASES) do
-        policy[policy_chain.PHASES[i]] = noop
+    for _, phase in _M.phases() do
+        policy[phase] = noop
     end
 
     return policy
+end
+
+function _M.phases()
+    return ipairs(policy_chain.PHASES)
 end
 
 return _M

--- a/apicast/src/policy.lua
+++ b/apicast/src/policy.lua
@@ -1,10 +1,10 @@
-local _M = {
-    PHASES = {
-        'init', 'init_worker',
-        'rewrite', 'access', 'balancer',
-        'header_filter', 'body_filter',
-        'post_action',  'log'
-    }
+local _M = { }
+
+local PHASES = {
+    'init', 'init_worker',
+    'rewrite', 'access', 'balancer',
+    'header_filter', 'body_filter',
+    'post_action',  'log'
 }
 
 local setmetatable = setmetatable
@@ -28,15 +28,15 @@ function _M.new(name, version)
         return setmetatable({}, mt)
     end
 
-    for _, phase in _M:phases() do
+    for _, phase in _M.phases() do
         policy[phase] = noop
     end
 
     return policy
 end
 
-function _M:phases()
-    return ipairs(self.PHASES)
+function _M.phases()
+    return ipairs(PHASES)
 end
 
 return _M

--- a/apicast/src/policy.lua
+++ b/apicast/src/policy.lua
@@ -5,10 +5,15 @@ local policy_chain = require('policy_chain')
 
 local noop = function() end
 
-function _M.new(name)
+--- Initialize new policy
+-- Returns a new policy that you can extend however you want.
+-- @tparam string name Name of the new policy.
+-- @tparam string version Version of the new policy. Default value is 0.0
+-- @treturn policy New policy
+function _M.new(name, version)
     local policy = {
-        _NAME = name or 'policy',
-        _VERSION = '0.0',
+        _NAME = name,
+        _VERSION = version ,
     }
     local mt = { __index = policy }
 
@@ -20,7 +25,7 @@ function _M.new(name)
         policy[policy_chain.PHASES[i]] = noop
     end
 
-    return policy, mt
+    return policy
 end
 
 return _M

--- a/apicast/src/policy.lua
+++ b/apicast/src/policy.lua
@@ -20,7 +20,7 @@ local noop = function() end
 function _M.new(name, version)
     local policy = {
         _NAME = name,
-        _VERSION = version ,
+        _VERSION = version or '0.0',
     }
     local mt = { __index = policy }
 

--- a/apicast/src/policy.lua
+++ b/apicast/src/policy.lua
@@ -1,3 +1,11 @@
+--- Policy module
+-- Policies should define a method for each of the nginx phases (rewrite,
+-- access, etc.) in which they want to run code. When Apicast runs each of
+-- those phases, if the policy has been loaded, it will run the code in the
+-- method with the phase name. So for example, if we want to define a policy
+-- that needs to execute something in the rewrite phase, we need to write
+-- a 'rewrite' method.
+
 local _M = { }
 
 local PHASES = {

--- a/apicast/src/policy/echo.lua
+++ b/apicast/src/policy/echo.lua
@@ -1,0 +1,8 @@
+local policy = require('policy')
+local _M = policy.new('Echo Policy')
+
+function _M.access()
+  ngx.log(ngx.DEBUG, ngx.var.request)
+end
+
+return _M

--- a/apicast/src/policy/find_service.lua
+++ b/apicast/src/policy/find_service.lua
@@ -1,0 +1,73 @@
+local next = next
+
+local policy = require('policy')
+local _M = policy.new('Find Service Policy')
+local configuration_store = require 'configuration_store'
+local new = _M.new
+
+local function find_service_strict(configuration, host)
+  local found
+  local services = configuration:find_by_host(host)
+
+  for s=1, #services do
+    local service = services[s]
+    local hosts = service.hosts or {}
+
+    for h=1, #hosts do
+      if hosts[h] == host and service == configuration:find_by_id(service.id) then
+        found = service
+        break
+      end
+    end
+    if found then break end
+  end
+
+  return found or ngx.log(ngx.WARN, 'service not found for host ', host)
+end
+
+local function find_service_cascade(configuration, host)
+  local found
+  local request = ngx.var.request
+  local services = configuration:find_by_host(host)
+
+  for s=1, #services do
+    local service = services[s]
+    local hosts = service.hosts or {}
+
+    for h=1, #hosts do
+      if hosts[h] == host then
+        local name = service.system_name or service.id
+        ngx.log(ngx.DEBUG, 'service ', name, ' matched host ', hosts[h])
+        local usage, matched_patterns = service:extract_usage(request)
+
+        if next(usage) and matched_patterns ~= '' then
+          ngx.log(ngx.DEBUG, 'service ', name, ' matched patterns ', matched_patterns)
+          found = service
+          break
+        end
+      end
+    end
+    if found then break end
+  end
+
+  return found or find_service_strict(configuration, host)
+end
+
+function _M.new(...)
+  local self = new(...)
+
+  if configuration_store.path_routing then
+    ngx.log(ngx.WARN, 'apicast experimental path routing enabled')
+    self.find_service = find_service_cascade
+  else
+    self.find_service = find_service_strict
+  end
+
+  return self
+end
+
+function _M:rewrite(context)
+  context.service = self.find_service(context.configuration, context.host)
+end
+
+return _M

--- a/apicast/src/policy/load_configuration.lua
+++ b/apicast/src/policy/load_configuration.lua
@@ -1,0 +1,33 @@
+local setmetatable = setmetatable
+
+local _M, mt = require('policy').new()
+
+local configuration_loader = require('configuration_loader').new()
+local configuration_store = require('configuration_store')
+
+function _M.new()
+    return setmetatable({
+        configuration = configuration_store.new(),
+    }, mt)
+end
+
+function _M:export()
+    return {
+        configuration = self.configuration
+    }
+end
+
+function _M:init()
+    configuration_loader.init(self.configuration)
+end
+
+function _M:init_worker()
+    configuration_loader.init_worker(self.configuration)
+end
+
+function _M:rewrite(context)
+    context.host = context.host or ngx.var.host
+    context.configuration = configuration_loader.rewrite(self.configuration, context.host)
+end
+
+return _M

--- a/apicast/src/policy/load_configuration.lua
+++ b/apicast/src/policy/load_configuration.lua
@@ -1,14 +1,14 @@
-local setmetatable = setmetatable
-
-local _M, mt = require('policy').new()
+local _M = require('policy').new('Load Configuration')
 
 local configuration_loader = require('configuration_loader').new()
 local configuration_store = require('configuration_store')
 
-function _M.new()
-    return setmetatable({
-        configuration = configuration_store.new(),
-    }, mt)
+local new = _M.new
+
+function _M.new(...)
+    local policy = new(...)
+    policy.configuration = configuration_store.new()
+    return policy
 end
 
 function _M:export()

--- a/apicast/src/policy/local_chain.lua
+++ b/apicast/src/policy/local_chain.lua
@@ -1,0 +1,37 @@
+local policy = require('policy')
+local Proxy = require('proxy')
+local _M = policy.new('Local Policy Chain')
+
+local policy_chain = require('policy_chain')
+
+local new = _M.new
+
+function _M.new(...)
+  local self = new(...)
+  self.policy_chain = policy_chain.build()
+  return self
+end
+
+local function build_chain(context, host)
+  local proxy = Proxy.new(context.configuration)
+
+  context.proxy = context.proxy or proxy
+  context.service = context.service or proxy:find_service(host)
+  context.policy_chain = policy_chain.build({})
+end
+
+-- forward all policy methods to the policy chain
+for _, phase in policy.phases() do
+  _M[phase] = function(self, ...)
+    return self.policy_chain[phase](self.policy_chain, ...)
+  end
+end
+
+local rewrite = _M.rewrite
+
+function _M:rewrite(context, ...)
+  build_chain(context, context.host or ngx.var.host)
+  rewrite(self, context, ...)
+end
+
+return _M

--- a/apicast/src/policy/local_chain.lua
+++ b/apicast/src/policy/local_chain.lua
@@ -12,11 +12,10 @@ function _M.new(...)
   return self
 end
 
-local function build_chain(context, host)
+local function build_chain(context)
   local proxy = Proxy.new(context.configuration)
 
   context.proxy = context.proxy or proxy
-  context.service = context.service or proxy:find_service(host)
   context.policy_chain = policy_chain.build({})
 end
 
@@ -30,7 +29,7 @@ end
 local rewrite = _M.rewrite
 
 function _M:rewrite(context, ...)
-  build_chain(context, context.host or ngx.var.host)
+  build_chain(context)
   rewrite(self, context, ...)
 end
 

--- a/apicast/src/policy/local_chain.lua
+++ b/apicast/src/policy/local_chain.lua
@@ -16,7 +16,7 @@ local function build_chain(context)
 end
 
 -- forward all policy methods to the policy chain
-for _, phase in policy.phases() do
+for _, phase in policy:phases() do
   _M[phase] = function(_, context, ...)
     local policy_chain = find_policy_chain(context)
 

--- a/apicast/src/policy/local_chain.lua
+++ b/apicast/src/policy/local_chain.lua
@@ -16,7 +16,7 @@ local function build_chain(context)
 end
 
 -- forward all policy methods to the policy chain
-for _, phase in policy:phases() do
+for _, phase in policy.phases() do
   _M[phase] = function(_, context, ...)
     local policy_chain = find_policy_chain(context)
 

--- a/apicast/src/policy/local_chain.lua
+++ b/apicast/src/policy/local_chain.lua
@@ -1,8 +1,23 @@
+local resty_env = require('resty.env')
+
 local policy = require('policy')
 local Proxy = require('proxy')
 local _M = policy.new('Local Policy Chain')
 
-local default_chain = require('policy_chain').build({ 'apicast' })
+local function build_default_chain()
+  local module
+
+  if resty_env.get('APICAST_MODULE') then
+    -- Needed to keep compatibility with the old module system.
+    module = 'module'
+  else
+    module = 'apicast'
+  end
+
+  return require('policy_chain').build({ module })
+end
+
+local default_chain = build_default_chain()
 
 local function find_policy_chain(context)
   return context.policy_chain or (context.service and context.service.policy_chain) or default_chain

--- a/apicast/src/policy/local_chain.lua
+++ b/apicast/src/policy/local_chain.lua
@@ -2,7 +2,7 @@ local policy = require('policy')
 local Proxy = require('proxy')
 local _M = policy.new('Local Policy Chain')
 
-local default_chain = require('policy_chain').build()
+local default_chain = require('policy_chain').build({ 'apicast' })
 
 local function find_policy_chain(context)
   return context.policy_chain or (context.service and context.service.policy_chain) or default_chain

--- a/apicast/src/policy/phase_logger.lua
+++ b/apicast/src/policy/phase_logger.lua
@@ -5,7 +5,7 @@
 local policy = require('policy')
 local _M = policy.new('Phase logger')
 
-for _, phase in policy:phases() do
+for _, phase in policy.phases() do
   _M[phase] = function() ngx.log(ngx.DEBUG, 'running phase: ', phase) end
 end
 

--- a/apicast/src/policy/phase_logger.lua
+++ b/apicast/src/policy/phase_logger.lua
@@ -1,0 +1,12 @@
+-- This is a simple policy. The only thing it does is log when it runs each of
+-- the nginx phases. It's useful when testing to make sure that all the phases
+-- are executed.
+
+local policy = require('policy')
+local _M = policy.new('Phase logger')
+
+for _, phase in policy:phases() do
+  _M[phase] = function() ngx.log(ngx.DEBUG, 'running phase: ', phase) end
+end
+
+return _M

--- a/apicast/src/policy_chain.lua
+++ b/apicast/src/policy_chain.lua
@@ -5,45 +5,96 @@ if resty_env.get('APICAST_MODULE') then
 end
 
 local setmetatable = setmetatable
+local insert = table.insert
+local error = error
+local rawset = rawset
+local type = type
+local require = require
+local noop = function() end
+
+local linked_list = require('linked_list')
 
 local _M = {
-
+    PHASES = {
+        'init', 'init_worker',
+        'rewrite', 'access', 'balancer',
+        'header_filter', 'body_filter',
+        'post_action',  'log'
+    }
 }
 
-local mt = { __index = _M }
+local mt = {
+    __index = _M,
+    __newindex = function(t, k ,v)
+        if t.frozen then
+            error("readonly table")
+        else
+            rawset(t, k, v)
+        end
+    end
+}
 
 function _M.build(modules)
     local chain = {}
     local list = modules or { 'apicast' }
 
     for i=1, #list do
-        chain[i] = require(list[i]).new()
+        chain[i] = _M.load(list[i])
     end
 
     return _M.new(chain)
 end
 
+function _M.load(module, ...)
+    if type(module) == 'string' then
+        return require(module).new(...)
+    else
+        return module
+    end
+end
+
 function _M.new(list)
     local chain = list or {}
 
-    return setmetatable(chain, mt)
+    local self = setmetatable(chain, mt)
+    chain.config = self:export()
+    return self:freeze()
 end
 
-local phases = {
-    'init', 'init_worker',
-    'rewrite', 'access', 'balancer',
-    'header_filter', 'body_filter',
-    'post_action',  'log'
-}
+function _M:freeze()
+    self.frozen = true
+    return self
+end
 
-for i=1, #phases do
-    local phase_name = phases[i]
+function _M:add(module)
+    insert(self, _M.load(module))
+end
 
-    _M[phase_name] = function(self, ...)
+function _M:export()
+    local chain = self.config
+
+    if chain then return chain end
+
+    for i=#self, 1, -1 do
+        local export = self[i].export or noop
+        chain = linked_list.readonly(export(self[i]), chain)
+    end
+
+    return chain
+end
+
+local function call_chain(phase_name)
+    return function(self, ...)
         for i=1, #self do
             self[i][phase_name](self[i], ...)
         end
     end
+end
+
+for i=1, #(_M.PHASES) do
+    local phase_name = _M.PHASES[i]
+
+    _M[phase_name] = call_chain(phase_name)
 end
 
 return _M.build()

--- a/apicast/src/policy_chain.lua
+++ b/apicast/src/policy_chain.lua
@@ -1,0 +1,49 @@
+local resty_env = require('resty.env')
+
+if resty_env.get('APICAST_MODULE') then
+    return require('module')
+end
+
+local setmetatable = setmetatable
+
+local _M = {
+
+}
+
+local mt = { __index = _M }
+
+function _M.build(modules)
+    local chain = {}
+    local list = modules or { 'apicast' }
+
+    for i=1, #list do
+        chain[i] = require(list[i]).new()
+    end
+
+    return _M.new(chain)
+end
+
+function _M.new(list)
+    local chain = list or {}
+
+    return setmetatable(chain, mt)
+end
+
+local phases = {
+    'init', 'init_worker',
+    'rewrite', 'access', 'balancer',
+    'header_filter', 'body_filter',
+    'post_action',  'log'
+}
+
+for i=1, #phases do
+    local phase_name = phases[i]
+
+    _M[phase_name] = function(self, ...)
+        for i=1, #self do
+            self[i][phase_name](self[i], ...)
+        end
+    end
+end
+
+return _M.build()

--- a/apicast/src/policy_chain.lua
+++ b/apicast/src/policy_chain.lua
@@ -1,9 +1,3 @@
-local resty_env = require('resty.env')
-
-if resty_env.get('APICAST_MODULE') then
-    return require('module')
-end
-
 local setmetatable = setmetatable
 local insert = table.insert
 local error = error
@@ -13,14 +7,10 @@ local require = require
 local noop = function() end
 
 local linked_list = require('linked_list')
+local policy = require('policy')
 
 local _M = {
-    PHASES = {
-        'init', 'init_worker',
-        'rewrite', 'access', 'balancer',
-        'header_filter', 'body_filter',
-        'post_action',  'log'
-    }
+
 }
 
 local mt = {
@@ -92,10 +82,8 @@ local function call_chain(phase_name)
     end
 end
 
-for i=1, #(_M.PHASES) do
-    local phase_name = _M.PHASES[i]
-
-    _M[phase_name] = call_chain(phase_name)
+for _,phase in policy:phases() do
+    _M[phase] = call_chain(phase)
 end
 
 return _M.build()

--- a/apicast/src/policy_chain.lua
+++ b/apicast/src/policy_chain.lua
@@ -47,6 +47,7 @@ end
 
 function _M.load(module, ...)
     if type(module) == 'string' then
+        ngx.log(ngx.DEBUG, 'loading policy module: ', module)
         return require(module).new(...)
     else
         return module

--- a/apicast/src/policy_chain.lua
+++ b/apicast/src/policy_chain.lua
@@ -69,10 +69,6 @@ function _M.new(list)
 
     local self = setmetatable(chain, mt)
     chain.config = self:export()
-    return self:freeze()
-end
-
-function _M:freeze()
     self.frozen = true
     return self
 end

--- a/apicast/src/policy_chain.lua
+++ b/apicast/src/policy_chain.lua
@@ -6,7 +6,6 @@
 -- order that the policies have in the chain.
 
 local setmetatable = setmetatable
-local insert = table.insert
 local error = error
 local rawset = rawset
 local type = type
@@ -76,10 +75,6 @@ end
 function _M:freeze()
     self.frozen = true
     return self
-end
-
-function _M:add(module)
-    insert(self, _M.load(module))
 end
 
 --- Export the shared context of the chain

--- a/apicast/src/policy_chain.lua
+++ b/apicast/src/policy_chain.lua
@@ -82,7 +82,7 @@ local function call_chain(phase_name)
     end
 end
 
-for _,phase in policy:phases() do
+for _,phase in policy.phases() do
     _M[phase] = call_chain(phase)
 end
 

--- a/examples/configuration/echo.json
+++ b/examples/configuration/echo.json
@@ -14,6 +14,10 @@
           "endpoint": "http://127.0.0.1:8081",
           "host": "echo"
         },
+        "policy_chain": [
+          { "name": "policy.echo" },
+          { "name": "apicast" }
+        ],
         "proxy_rules": [
           {
             "http_method": "GET",

--- a/spec/apicast_spec.lua
+++ b/spec/apicast_spec.lua
@@ -30,7 +30,7 @@ describe('APIcast module', function()
         return 'post_ok'
       end)
 
-      local ok, err = apicast:access()
+      local ok, err = apicast:access({})
 
       assert.same('ok', ok)
       assert.falsy(err)
@@ -43,7 +43,7 @@ describe('APIcast module', function()
         -- return nothing for example
       end)
 
-      local ok, err = apicast:access()
+      local ok, err = apicast:access({})
 
       assert.falsy(ok)
       assert.falsy(err)

--- a/spec/executor_spec.lua
+++ b/spec/executor_spec.lua
@@ -1,0 +1,35 @@
+describe('executor', function()
+  local phases = {
+    'init', 'init_worker',
+    'rewrite', 'access', 'balancer',
+    'header_filter', 'body_filter',
+    'post_action',  'log'
+  }
+
+  it('forwards all the policy methods to the policy chain', function()
+    local executor = require 'executor'
+
+    -- Policies included by default in the executor
+    local default_executor_chain = {
+      require 'policy.load_configuration',
+      require 'policy.find_service',
+      require 'policy.local_chain'
+    }
+
+    -- Stub all the nginx phases methods for each of the policies
+    for _, phase in ipairs(phases) do
+      for _, policy in ipairs(default_executor_chain) do
+        stub(policy, phase)
+      end
+    end
+
+    -- For each one of the nginx phases, verify that when called on the
+    -- executor, each one of the policies executes the code for that phase.
+    for _, phase in ipairs(phases) do
+      executor[phase](executor)
+      for _, policy in ipairs(default_executor_chain) do
+        assert.stub(policy[phase]).was_called()
+      end
+    end
+  end)
+end)

--- a/spec/linked_list_spec.lua
+++ b/spec/linked_list_spec.lua
@@ -14,7 +14,7 @@ describe('linked_list', function()
     it('returns a list that cannot be modified', function()
       local list = linked_list.readonly({ a = 1 })
 
-      list.abc = 123
+      assert.has_error(function() list.abc = 123 end, 'readonly list')
       assert.is_nil(list.abc)
     end)
 

--- a/spec/linked_list_spec.lua
+++ b/spec/linked_list_spec.lua
@@ -1,0 +1,58 @@
+local linked_list = require 'linked_list'
+
+describe('linked_list', function()
+  describe('readonly', function()
+    it('returns a list that finds elements in the correct order', function()
+      local list = linked_list.readonly(
+        { a = 1 }, linked_list.readonly({ b = 2 }, { c = 3, a = 10 }))
+
+      assert.equals(1, list.a) -- appears twice; returns the first
+      assert.equals(2, list.b)
+      assert.equals(3, list.c)
+    end)
+
+    it('returns a list that cannot be modified', function()
+      local list = linked_list.readonly({ a = 1 })
+
+      list.abc = 123
+      assert.is_nil(list.abc)
+    end)
+
+    it('returns a list that has pointers to current and next elements', function()
+      local list = linked_list.readonly(
+        { a = 1 }, linked_list.readonly({ b = 2 }, { c = 3 }))
+
+      assert.same({ a = 1 }, list.current)
+      assert.same({ b = 2 }, list.next.current)
+      assert.same({ c = 3 }, list.next.next)
+    end)
+  end)
+
+  describe('readwrite', function()
+    it('returns a list that finds elements in the correct order', function()
+      local list = linked_list.readwrite(
+        { a = 1 }, linked_list.readwrite({ b = 2 }, { c = 3, a = 10 }))
+
+      assert.equals(1, list.a) -- appears twice; returns the first
+      assert.equals(2, list.b)
+      assert.equals(3, list.c)
+    end)
+
+    it('returns a list that can be modified', function()
+      local list = linked_list.readwrite({ a = 1 })
+
+      list.abc = 123
+      assert.equals(123, list.abc)
+      assert.same({ a = 1, abc = 123 }, list.current)
+    end)
+
+    it('returns a list that has pointers to current and next elements', function()
+      local list = linked_list.readwrite(
+        { a = 1 }, linked_list.readwrite({ b = 2 }, { c = 3 }))
+
+      assert.same({ a = 1 }, list.current)
+      assert.same({ b = 2 }, list.next.current)
+      assert.same({ c = 3 }, list.next.next)
+    end)
+  end)
+end)

--- a/spec/policy/find_service_spec.lua
+++ b/spec/policy/find_service_spec.lua
@@ -1,0 +1,142 @@
+local configuration = require('configuration')
+
+describe('find_service', function()
+  describe('.rewrite', function()
+    describe('when path routing is enabled', function()
+      it('finds the service by matching rules and stores it in the given context', function()
+        require('configuration_store').path_routing = true
+
+        -- We access ngx.var.request and ngx.req.get_uri_args directly in the
+        -- code, so we need to mock them. We should probably try to avoid this
+        -- kind of coupling.
+        ngx.var = { request = 'GET /def HTTP/1.1' }
+        ngx.req = { get_uri_args = function() return {} end }
+
+        local find_service_policy = require('policy.find_service').new()
+        local host = 'example.com'
+
+        local service_1 = configuration.parse_service({
+          id = 42,
+          proxy = {
+            hosts = { host },
+            proxy_rules = { { pattern = '/abc', http_method = 'GET',
+                              metric_system_name = 'hits', delta = 1 } }
+          }
+        })
+
+        local service_2 = configuration.parse_service({
+          id = 43,
+          proxy = {
+            hosts = { host },
+            proxy_rules = { { pattern = '/def', http_method = 'GET',
+                              metric_system_name = 'hits', delta = 2 } }
+          }
+        })
+
+        local service_3 = configuration.parse_service({
+          id = 44,
+          proxy = {
+            hosts = { host },
+            proxy_rules = { { pattern = '/ghi', http_method = 'GET',
+                              metric_system_name = 'hits', delta = 3 } }
+          }
+        })
+
+        local configuration_store = require('configuration_store').new()
+        configuration_store:store(
+          { services = { service_1, service_2, service_3 } })
+
+        local context = { host = host, configuration = configuration_store }
+        find_service_policy:rewrite(context)
+
+        assert.equal(service_2, context.service)
+      end)
+
+      describe('and no rules are matched', function()
+        it('finds a service for the host in the context and stores the service there', function()
+          require('configuration_store').path_routing = true
+          ngx.var = { request = 'GET /abc HTTP/1.1' }
+          ngx.req = { get_uri_args = function() return {} end }
+
+          local host = 'example.com'
+          local find_service_policy = require('policy.find_service').new()
+
+          local service = configuration.parse_service({
+            id = 42,
+            proxy = {
+              hosts = { host },
+              proxy_rules = { { pattern = '/', http_method = 'GET',
+                                metric_system_name = 'hits', delta = 1 } }
+            }
+          })
+
+          local configuration_store = require('configuration_store').new()
+          configuration_store:add(service)
+
+          local context = { host = host, configuration = configuration_store }
+
+          find_service_policy:rewrite(context)
+          assert.same(service, context.service)
+        end)
+      end)
+
+      describe('and no rules are matches and there is not a service for the host', function()
+        it('stores nil in the service field of the given context', function()
+          require('configuration_store').path_routing = true
+          ngx.var = { request = 'GET /abc HTTP/1.1' }
+          ngx.req = { get_uri_args = function() return {} end }
+
+          local find_service_policy = require('policy.find_service').new()
+          local configuration_store = require('configuration_store').new()
+
+          local context = {
+            host = 'example.com',
+            configuration = configuration_store
+          }
+
+          find_service_policy:rewrite(context)
+          assert.is_nil(context.service)
+        end)
+      end)
+    end)
+
+    describe('when path routing is disabled', function()
+      require('configuration_store').path_routing = false
+
+      it('finds the service of the host in the given context and stores it there', function()
+        local find_service_policy = require('policy.find_service').new()
+
+        local host = 'example.com'
+        local service = configuration.parse_service({
+          id = 42,
+          proxy = {
+            hosts = { host },
+            proxy_rules = { { pattern = '/', http_method = 'GET',
+                              metric_system_name = 'hits', delta = 1 } }
+          }
+        })
+        local configuration_store = require('configuration_store').new()
+        configuration_store:add(service)
+
+        local context = { host = host, configuration = configuration_store }
+        find_service_policy:rewrite(context)
+        assert.same(service, context.service)
+      end)
+
+      describe('and there is not a service for the host', function()
+        it('stores nil in the service field of the given context', function()
+          local find_service_policy = require('policy.find_service').new()
+          local configuration_store = require('configuration_store').new()
+
+          local context = {
+            host = 'example.com',
+            configuration = configuration_store
+          }
+
+          find_service_policy:rewrite(context)
+          assert.is_nil(context.service)
+        end)
+      end)
+    end)
+  end)
+end)

--- a/spec/policy/load_configuration_spec.lua
+++ b/spec/policy/load_configuration_spec.lua
@@ -1,0 +1,18 @@
+describe('load_configuration', function()
+  describe('.new', function()
+    it('initializes the policy with a configuration')
+    local load_config_policy = require('policy.load_configuration').new()
+    assert.not_nil(load_config_policy)
+  end)
+
+  describe('.export', function()
+    it('returns a table with the configuration of the policy', function()
+      local load_config_policy = require('policy.load_configuration').new()
+      assert.same({ configuration = load_config_policy.configuration },
+                  load_config_policy:export())
+    end)
+  end)
+
+  -- TODO: test .init(), .init_worker(), and .rewrite(). Right now it is
+  -- difficult because of the coupling with configuration_store.
+end)

--- a/spec/policy_chain_spec.lua
+++ b/spec/policy_chain_spec.lua
@@ -125,9 +125,9 @@ describe('policy_chain', function()
 
       local shared_data = chain:export()
 
-      -- This does not raise, but it does not do anything.
-      shared_data.new_shared_data = 'some_data'
-
+      assert.has_error(function()
+        shared_data.new_shared_data = 'some_data'
+      end, 'readonly list')
       assert.is_nil(shared_data.new_shared_data)
     end)
 

--- a/spec/policy_chain_spec.lua
+++ b/spec/policy_chain_spec.lua
@@ -1,0 +1,150 @@
+local policy = require 'policy'
+
+describe('policy_chain', function()
+  local phases = {
+    'init', 'init_worker',
+    'rewrite', 'access', 'balancer',
+    'header_filter', 'body_filter',
+    'post_action',  'log'
+  }
+
+  it('defines a method for each of the nginx phases supported', function()
+    local policy_chain = require 'policy_chain'
+
+    for _, phase in ipairs(phases) do
+      assert.equals('function', type(policy_chain[phase]))
+    end
+  end)
+
+  it('when calling one of the nginx phases, calls that phase on each of its policies', function()
+    -- Define a policy an stub its phase methods
+    local custom_policy_1 = policy.new('policy_1')
+    custom_policy_1.init = function () end
+    custom_policy_1.rewrite = function() end
+    stub(custom_policy_1, 'init')
+    stub(custom_policy_1, 'rewrite')
+
+    -- Define another policy and stub its phase methods
+    local custom_policy_2 = policy.new('policy_2')
+    custom_policy_2.init = function () end
+    custom_policy_2.access = function() end
+    stub(custom_policy_2, 'init')
+    stub(custom_policy_2, 'access')
+
+    -- Build the policy chain
+    local policy_chain = require 'policy_chain'
+    local chain = policy_chain.build({ custom_policy_1, custom_policy_2 })
+
+    chain:init()
+    assert.stub(custom_policy_1.init).was_called()
+    assert.stub(custom_policy_2.init).was_called()
+
+    chain:rewrite()
+    assert.stub(custom_policy_1.rewrite).was_called()
+
+    chain:access()
+    assert.stub(custom_policy_2.access).was_called()
+  end)
+
+  it('uses APIcast as default when no policies are specified', function()
+    local apicast = require 'apicast'
+    local policy_chain = require 'policy_chain'
+
+    -- Stub apicast methods to avoid calling them. We are just interested in
+    -- knowing whether they were called.
+    for _, phase in ipairs(phases) do
+      stub(apicast, phase)
+    end
+
+    for _, phase in ipairs(phases) do
+      policy_chain[phase](policy_chain)
+      assert.stub(apicast[phase]).was_called()
+    end
+  end)
+
+  it('calls the policies in the order specified when building the chain', function()
+    -- Each policy inserts its name in a table so we know the order in which
+    -- they were run.
+    local execution_order = {}
+
+    local policies = { policy.new('1'), policy.new('2'), policy.new('3') }
+    for _, custom_policy in ipairs(policies) do
+      custom_policy['init'] = function()
+        table.insert(execution_order, custom_policy._NAME)
+      end
+    end
+
+    local policy_chain = require 'policy_chain'
+    local sorted_policies = { policies[2], policies[3], policies[1] }
+    local chain = policy_chain.build(sorted_policies)
+
+    chain:init()
+    assert.same({'2', '3', '1'}, execution_order)
+  end)
+
+  it('does not allow to modify phase methods after the chain has been built', function()
+    local policy_chain = require 'policy_chain'
+
+    for _, phase in ipairs(phases) do
+      assert.has_error(function()
+        policy_chain[phase] = function() end
+      end, 'readonly table')
+    end
+  end)
+
+  it('does not allow to add new methods to the chain after it has been built', function()
+    local policy_chain = require 'policy_chain'
+
+    assert.has_error(function()
+      policy_chain['new_phase'] = function() end
+    end, 'readonly table')
+  end)
+
+  describe('.export', function()
+    it('returns the data exposed by each of its policies', function()
+      local policy_1 = policy.new('1')
+      policy_1.export = function() return { shared_data_1 = '1' } end
+
+      local policy_2 = policy.new('2')
+      policy_2.export = function() return { shared_data_2 = '2' } end
+
+      local policy_chain = require 'policy_chain'
+      local chain = policy_chain.build({ policy_1, policy_2 })
+
+      local shared_data = chain:export()
+      assert.equal('1', shared_data['shared_data_1'])
+      assert.equal('2', shared_data['shared_data_2'])
+    end)
+
+    it('returns a read-only list', function()
+      local policy_1 = policy.new('1')
+      policy_1.export = function() return { shared_data = '1' } end
+
+      local policy_chain = require 'policy_chain'
+      local chain = policy_chain.build({ policy_1 })
+
+      local shared_data = chain:export()
+
+      -- This does not raise, but it does not do anything.
+      shared_data.new_shared_data = 'some_data'
+
+      assert.is_nil(shared_data.new_shared_data)
+    end)
+
+    describe('when several policies expose the same data', function()
+      it('returns the data exposed by the policy that comes first in the chain', function()
+        local policy_1 = policy.new('custom_reporter')
+        policy_1.export = function() return { shared_data_1 = '1' } end
+
+        local policy_2 = policy.new('custom_authorizer')
+        policy_2.export = function() return { shared_data_1 = '2' } end
+
+        local policy_chain = require 'policy_chain'
+        local chain = policy_chain.build({ policy_1, policy_2 })
+
+        local shared_data = chain:export()
+        assert.equal('1', shared_data['shared_data_1'])
+      end)
+    end)
+  end)
+end)

--- a/spec/policy_spec.lua
+++ b/spec/policy_spec.lua
@@ -1,0 +1,56 @@
+local policy = require 'policy'
+
+describe('policy', function()
+  local phases = {
+    'init', 'init_worker',
+    'rewrite', 'access', 'balancer',
+    'header_filter', 'body_filter',
+    'post_action',  'log'
+  }
+
+  describe('.new', function()
+    it('allows to set a name for the policy', function()
+      local my_policy_name = 'custom_mapping_rules'
+      local my_policy = policy.new(my_policy_name)
+
+      assert.equals(my_policy_name, my_policy._NAME)
+    end)
+
+    it('allows to set a version for the policy', function()
+      local my_policy_version = '2.0'
+      local my_policy = policy.new('my_policy', my_policy_version)
+
+      assert.equals(my_policy_version, my_policy._VERSION)
+    end)
+
+    it('defines a method for each of the nginx phases; they do nothing by default', function()
+      local my_policy = policy.new('custom_authorizer')
+
+      for _, phase in policy:phases() do
+        -- To be precise, we should check that the function is defined, returns
+        -- nil, and it does not have any side-effects. Checking the latter is
+        -- complicated so we'll leave it for now.
+        assert.not_nil(my_policy[phase])
+        assert.is_nil(my_policy[phase]())
+      end
+    end)
+
+    it('allows to set a custom function for each nginx phase', function()
+      local my_policy = policy.new('custom_authorizer')
+      my_policy.access = function() return 'custom_access_ran' end
+
+      assert.equals('custom_access_ran', my_policy.access())
+    end)
+  end)
+
+  describe('.phases', function()
+    it('returns the nginx phases where policies can run, sorted by order of execution', function()
+      local res = {}
+      for _, phase in policy:phases() do
+        table.insert(res, phase)
+      end
+
+      assert.same(phases, res)
+    end)
+  end)
+end)

--- a/spec/policy_spec.lua
+++ b/spec/policy_spec.lua
@@ -31,7 +31,7 @@ describe('policy', function()
     it('defines a method for each of the nginx phases; they do nothing by default', function()
       local my_policy = policy.new('custom_authorizer')
 
-      for _, phase in policy:phases() do
+      for _, phase in policy.phases() do
         -- To be precise, we should check that the function is defined, returns
         -- nil, and it does not have any side-effects. Checking the latter is
         -- complicated so we'll leave it for now.
@@ -51,7 +51,7 @@ describe('policy', function()
   describe('.phases', function()
     it('returns the nginx phases where policies can run, sorted by order of execution', function()
       local res = {}
-      for _, phase in policy:phases() do
+      for _, phase in policy.phases() do
         table.insert(res, phase)
       end
 

--- a/spec/policy_spec.lua
+++ b/spec/policy_spec.lua
@@ -23,6 +23,11 @@ describe('policy', function()
       assert.equals(my_policy_version, my_policy._VERSION)
     end)
 
+    it('set the version to 0.0 when not specified', function()
+      local my_policy = policy.new('my_policy')
+      assert.equals('0.0', my_policy._VERSION)
+    end)
+
     it('defines a method for each of the nginx phases; they do nothing by default', function()
       local my_policy = policy.new('custom_authorizer')
 

--- a/spec/proxy_spec.lua
+++ b/spec/proxy_spec.lua
@@ -15,31 +15,31 @@ describe('Proxy', function()
   end)
 
   describe(':call', function()
+    local service
     before_each(function()
       ngx.var = { backend_endpoint = 'http://localhost:1853' }
-      configuration:add(Service.new({ id = 42, hosts = { 'localhost' }}))
+      service = Service.new({ id = 42, hosts = { 'localhost' }})
     end)
 
     it('has authorize function after call', function()
-      proxy:call('localhost')
+      proxy:call(service)
 
       assert.truthy(proxy.authorize)
       assert.same('function', type(proxy.authorize))
     end)
 
     it('returns access function', function()
-      local access = proxy:call('localhost')
+      local access = proxy:call(service)
 
       assert.same('function', type(access))
     end)
 
     it('returns oauth handler when matches oauth route', function()
-      local service = configuration:find_by_id(42)
       service.backend_version = 'oauth'
       stub(ngx.req, 'get_method', function() return 'GET' end)
       ngx.var.uri = '/authorize'
 
-      local access, handler = proxy:call('localhost')
+      local access, handler = proxy:call(service)
 
       assert.equal(nil, access)
       assert.same('function', type(handler))
@@ -66,7 +66,7 @@ describe('Proxy', function()
     assert.same('function', type(proxy.post_action))
   end)
 
-  it('finds service by host', function()
+  pending('finds service by host', function()
     local example = { id = 42, hosts = { 'example.com'} }
 
     configuration:add(example)
@@ -75,7 +75,7 @@ describe('Proxy', function()
     assert.falsy(proxy:find_service('unknown'))
   end)
 
-  it('does not return old configuration when new one is available', function()
+  pending('does not return old configuration when new one is available', function()
     local foo = { id = '42', hosts = { 'foo.example.com'} }
     local bar = { id = '42', hosts = { 'bar.example.com'} }
 

--- a/spec/proxy_spec.lua
+++ b/spec/proxy_spec.lua
@@ -66,15 +66,6 @@ describe('Proxy', function()
     assert.same('function', type(proxy.post_action))
   end)
 
-  pending('finds service by host', function()
-    local example = { id = 42, hosts = { 'example.com'} }
-
-    configuration:add(example)
-
-    assert.same(example, proxy:find_service('example.com'))
-    assert.falsy(proxy:find_service('unknown'))
-  end)
-
   pending('does not return old configuration when new one is available', function()
     local foo = { id = '42', hosts = { 'foo.example.com'} }
     local bar = { id = '42', hosts = { 'bar.example.com'} }

--- a/spec/proxy_spec.lua
+++ b/spec/proxy_spec.lua
@@ -66,18 +66,6 @@ describe('Proxy', function()
     assert.same('function', type(proxy.post_action))
   end)
 
-  pending('does not return old configuration when new one is available', function()
-    local foo = { id = '42', hosts = { 'foo.example.com'} }
-    local bar = { id = '42', hosts = { 'bar.example.com'} }
-
-    configuration:add(foo, -1) -- expired record
-    assert.equal(foo, proxy:find_service('foo.example.com'))
-
-    configuration:add(bar, -1) -- expired record
-    assert.equal(bar, proxy:find_service('bar.example.com'))
-    assert.falsy(proxy:find_service('foo.example.com'))
-  end)
-
   describe('.get_upstream', function()
     local get_upstream
     before_each(function() get_upstream = proxy.get_upstream end)

--- a/t/apicast-policy-chains.t
+++ b/t/apicast-policy-chains.t
@@ -1,0 +1,65 @@
+use lib 't';
+use TestAPIcast 'no_plan';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: custom policy chain
+This test uses the phase logger policy to verify that all of its phases are run
+when we use a policy chain that contains it. The policy chain also contains the
+normal apicast policy, so we can check that the authorize flow continues
+working. Notice that 'post_action' and 'log' are not ran. There's no
+post_action defined and log only runs when post_action runs.
+init and init_worker are not run either. They are not executed in policies
+defined at the service level.
+
+--- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+  init_by_lua_block {
+    require('configuration_loader').mock({
+      services = {
+        {
+          id = 42,
+          backend_version = 1,
+          backend_authentication_type = 'service_token',
+          backend_authentication_value = 'token-value',
+          proxy = {
+            policy_chain = { { name = 'policy.phase_logger' }, { name = 'apicast' } },
+            api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
+            proxy_rules = {
+              {
+                http_method = "GET",
+                pattern = "/test",
+                metric_system_name = "hits",
+                delta = 1
+              }
+            }
+          }
+        }
+      }
+    })
+  }
+
+--- config
+  include $TEST_NGINX_APICAST_CONFIG;
+
+  location /transactions/authrep.xml {
+    content_by_lua_block { ngx.exit(200) }
+  }
+
+  location /api-backend/ {
+     echo 'yay, api backend';
+  }
+--- request
+GET /test?user_key=abc
+--- response_body
+yay, api backend
+--- error_code: 200
+--- error_log chomp
+running phase: rewrite
+running phase: access
+running phase: balancer
+running phase: header_filter
+running phase: body_filter


### PR DESCRIPTION
Early prototype of how we could chain policies.

Policies can export data that is stored in read only structure and resolved in order they are defined in.
So values can be overlaid, but not overridden and only the latest one is being used.
This would allow overriding some internal structures being passed between policies.

Context object is passed to each policy phase invocation method. This context object has last layer mutable so policies can pass data.

Policy chain is itself a policy. All phase methods are compatible. So policy chain can contain policy chains.
This is used to split the chain into two: global and local. Global chain is responsible for loading configuration and local can be created based on downloaded configuration. 


# TODO

- [x] ~ figure out how installed policies can change the nginx template ~ **https://github.com/3scale/apicast/issues/477**
  - the list of policies enabled globally can be defined by some global config
  - the important piece is how would the policy be able to extend the nginx template
  - consider how policies would interact with each other and blocks that could extend
  - decide if it is template manipulation (like something like https://github.com/spree/deface ) or some dsl compiled to nginx config