### PR TITLE
Pin base image version in the Dockerfile for development

### DIFF
--- a/Dockerfile-development
+++ b/Dockerfile-development
@@ -1,4 +1,4 @@
-FROM quay.io/3scale/s2i-openresty-centos7:master
+FROM quay.io/3scale/s2i-openresty-centos7:1.11.2.5-1
 LABEL maintainer="dortiz@redhat.com"
 
 USER root


### PR DESCRIPTION
The 'master' version (`s2i-openresty-centos7::1.11.2.5-2`) breaks the development environment. It's related to luarocks permissions. Let's use the previous one to keep working until I adapt the Dockerfile and scripts to the new one, and maybe start using lua-rover too.