### PR TITLE
fix failing master build

### DIFF
--- a/t/003-apicast.t
+++ b/t/003-apicast.t
@@ -656,6 +656,7 @@ There are defaults defined for the error message, the content-type, and the
 status code (429).
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";
+  include $TEST_NGINX_UPSTREAM_CONFIG;
   init_by_lua_block {
     require('configuration_loader').mock({
       services = {
@@ -698,6 +699,7 @@ Limits exceeded
 === TEST 19: configurable limits exceeded error
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";
+  include $TEST_NGINX_UPSTREAM_CONFIG;
   init_by_lua_block {
     require('configuration_loader').mock({
       services = {

--- a/t/014-apicast-async-reporting.t
+++ b/t/014-apicast-async-reporting.t
@@ -156,7 +156,7 @@ api response
 --- error_code: 200
 --- error_log
 backend client uri: https://127.0.0.1:1953/transactions/authrep.xml?service_token=token-value&service_id=42&usage%5Bhits%5D=1&user_key=foo ok: true status: 200
---- wait: 1
+--- wait: 3
 
 === TEST 3: uses endpoint host as Host header
 when connecting to the backend
@@ -218,4 +218,4 @@ $::dns->("localhost.example.com", "127.0.0.1")
 [error]
 --- error_log
 backend client uri: http://localhost.example.com:1984/transactions/authrep.xml?service_token=service-token&service_id=42&usage%5Bhits%5D=2&user_key=val ok: true status: 200
---- wait: 1
+--- wait: 3

--- a/t/014-apicast-async-reporting.t
+++ b/t/014-apicast-async-reporting.t
@@ -213,7 +213,7 @@ all ok
 --- error_code: 200
 --- udp_listen: 1953
 --- udp_reply eval
-$::dns->("localhost.example.com", "127.0.0.1")
+$::dns->("localhost.example.com", "127.0.0.1", 60)
 --- no_error_log
 [error]
 --- error_log


### PR DESCRIPTION
* add missing upstream definitions
* increase wait timeout so we actually get real error in the console
* increase dns ttl so it does not expire before second run