### PR TITLE
[s2i] always pull runtime image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ builder-image: ## Build builder image
 runtime-image: PULL_POLICY ?= always
 runtime-image: IMAGE_NAME = apicast-runtime-test
 runtime-image: ## Build runtime image
-	$(S2I) build . $(BUILDER_IMAGE) $(IMAGE_NAME) --context-dir=apicast --runtime-image=$(RUNTIME_IMAGE) --pull-policy=$(PULL_POLICY)
+	$(S2I) build . $(BUILDER_IMAGE) $(IMAGE_NAME) --context-dir=apicast --runtime-image=$(RUNTIME_IMAGE) --pull-policy=$(PULL_POLICY) --runtime-pull-policy=$(PULL_POLICY)
 
 push: ## Push image to the registry
 	docker tag $(IMAGE_NAME) $(REGISTRY)/$(IMAGE_NAME)


### PR DESCRIPTION
Fixes 
```
[12:07:18]  <michal>	ERROR: An error occurred: could not download file ("/opt/app" -> "/var/folders/4j/8_8n41pn79x__h1005mb3jnm0000gn/T/s2i533282500/upload/runtimeArtifacts/s2i-runtime-artifact969452182") from container 7f2e601c0abc2a270d4ebbc834739ea39d89638a0b007db08ec88a5b5c70b8d8: Error response from daemon: {"message":"Could not find the file /opt/app in container 7f2e601c0abc2a270d4ebbc834739ea39d89638a0b007db08ec88a5b5c70b8d8"}
```

when running `make runtime-image` when stale image is already in docker.