### PR TITLE
blackbox tests using Test::Nginx 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ apicast/logs/
 *.rock
 lua_modules/
 tmp/benchmark/
+apicast/config/test.lua

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 luacov.*.out
 local/
-t/servroot/
+t/servroot*/
 doc/api/
 node_modules
 .vagrant/

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ apicast/logs/
 *.rock
 lua_modules/
 tmp/benchmark/
-apicast/config/test.lua

--- a/apicast/conf/nginx.conf.liquid
+++ b/apicast/conf/nginx.conf.liquid
@@ -91,4 +91,6 @@ http {
   {% for file in "sites.d/*.conf" | filesystem %}
     {% include file %}
   {% endfor %}
+
+  {{ sites_d }}
 }

--- a/apicast/conf/nginx.conf.liquid
+++ b/apicast/conf/nginx.conf.liquid
@@ -7,19 +7,20 @@ env OPENSSL_VERIFY;
 
 {% for env in env -%}
   {%- if env.name | starts_with: 'APICAST_', 'THREESCALE_' %}
-    env {{ env.name }};
+    env {{ env.name }}={{ env.value }};
   {%- endif -%}
 {%- endfor %}
 
 daemon {{ daemon | default: 'off' }};
 master_process {{ master_process | default: 'on' }};
 worker_processes {{ worker_processes | default: 'auto' }};
+pid {{ pid | default: 'nginx.pid' }};
 
 {% for file in "main.d/*.conf" | filesystem %}
   {% include file %}
 {% endfor %}
 
-error_log /dev/null emerg;
+error_log {{ error_log | default: '/dev/null' }} {{  log_level | default: 'emerg' }};
 
 events {
   worker_connections  16192;
@@ -74,7 +75,7 @@ http {
   server {
     access_log /dev/stdout time;
 
-    listen 8080;
+    listen {{ port.apicast | default: 8080 }};
 
     server_name _;
     underscores_in_headers on;

--- a/apicast/src/apicast/cli/start.lua
+++ b/apicast/src/apicast/cli/start.lua
@@ -103,6 +103,9 @@ function mt:__call(options)
     context.prefix = dir
     context.ca_bundle = pl.path.abspath(context.ca_bundle or pl.path.join(dir, 'conf', 'ca-bundle.crt'))
 
+    -- also use env from the config file
+    update_env(config.env or {})
+
     local nginx = nginx_config(context, dir, path, env)
 
     local log_level = get_log_level(self, options)

--- a/apicast/src/apicast/cli/start.lua
+++ b/apicast/src/apicast/cli/start.lua
@@ -76,7 +76,9 @@ local function get_log_level(self, options)
 end
 
 function mt:__call(options)
-    local openresty = resty_env.get('APICAST_OPENRESTY_BINARY') or pick_openesty(self.openresty)
+    local openresty = resty_env.value('APICAST_OPENRESTY_BINARY') or
+                      resty_env.value('TEST_NGINX_BINARY') or
+                      pick_openesty(self.openresty)
     local dir = resty_env.get('APICAST_DIR') or pl.path.abspath('.')
     local config = configuration.new(dir)
     local path = options.template

--- a/apicast/src/apicast/configuration.lua
+++ b/apicast/src/apicast/configuration.lua
@@ -25,8 +25,8 @@ end
 function _M:load(env)
     local environment = env or self.default_environment
     local root = self.root
-    local name = ("%s.lua"):format(environment)
-    local path = pl_path.join(root, 'config', name)
+    local name = resty_env.value('APICAST_ENVIRONMENT_CONFIG') or ("%s.lua"):format(environment)
+    local path = pl_path.abspath(name, pl_path.join(root, 'config'))
 
     print('loading config for: ', environment, ' environment from ', path)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     environment:
       TEST_NGINX_BINARY: openresty
       TEST_NGINX_REDIS_HOST: redis
-    command: "'$$TEST_NGINX_BINARY -V; cd ; prove; exit $$?'"
+    command: "'$$TEST_NGINX_BINARY -V; cd ; rover exec prove; exit $$?'"
     dns_search:
       - example.com
     depends_on:

--- a/t/TestAPIcastBlackbox.pm
+++ b/t/TestAPIcastBlackbox.pm
@@ -1,0 +1,73 @@
+package TestAPIcastBlackbox;
+use strict;
+use warnings FATAL => 'all';
+use v5.10.1;
+
+use lib 't';
+use TestAPIcast  -Base;
+use File::Copy "move";
+use File::Temp qw/ tempfile /;
+
+add_block_preprocessor(sub {
+    my $block = shift;
+    my $seq = $block->seq_num;
+    my $name = $block->name;
+
+    $block->set_value("config", "$name ($seq)");
+});
+
+my $write_nginx_config = sub {
+    my $block = shift;
+
+    my $ConfFile = $Test::Nginx::Util::ConfFile;
+    my $Workers = $Test::Nginx::Util::Workers;
+    my $MasterProcessEnabled = $Test::Nginx::Util::MasterProcessEnabled;
+    my $DaemonEnabled = $Test::Nginx::Util::DaemonEnabled;
+    my $err_log_file = $block->error_log_file || $Test::Nginx::Util::ErrLogFile;
+    my $LogLevel = $Test::Nginx::Util::LogLevel;
+    my $PidFile = $Test::Nginx::Util::PidFile;
+    my $AccLogFile = $Test::Nginx::Util::AccLogFile;
+    my $ServerPort = $Test::Nginx::Util::ServerPort;
+
+    my ($conf, $configuration) = tempfile();
+    print $conf $block->configuration;
+    close $conf;
+
+    open my $out, ">apicast/config/test.lua" or Test::Nginx::Util::bail_out "Can't open $ConfFile for writing: $!\n";
+
+    print $out <<_EOC_;
+return {
+    worker_processes = '$Workers',
+    master_process = '$MasterProcessEnabled',
+    daemon = '$DaemonEnabled',
+    error_log = '$err_log_file',
+    log_level = '$LogLevel',
+    pid = '$PidFile',
+    lua_code_cache = 'on',
+    access_log = '$AccLogFile',
+    port = { apicast = '$ServerPort' },
+    env = { APICAST_CONFIGURATION = 'file://$configuration', APICAST_CONFIGURATION_LOADER = 'boot' },
+}
+_EOC_
+    close $out;
+
+    my $apicast = `bin/apicast --boot --test --environment test --configuration $configuration 2>&1`;
+    if ($apicast =~ /configuration file (?<file>.+?) test is successful/)
+    {
+        move($+{file}, $Test::Nginx::Util::ConfFile);
+    } else {
+        warn "Missing config file: $Test::Nginx::Util::ConfFile";
+        warn $apicast;
+    }
+};
+
+BEGIN {
+    no warnings 'redefine';
+
+    sub Test::Nginx::Util::write_config_file ($$) {
+        my $block = shift;
+        return $write_nginx_config->($block);
+    }
+}
+
+1;

--- a/t/TestAPIcastBlackbox.pm
+++ b/t/TestAPIcastBlackbox.pm
@@ -16,7 +16,7 @@ add_block_preprocessor(sub {
     my $configuration = Test::Nginx::Util::expand_env_in_config($block->configuration);
     my $backend = $block->backend;
     my $upstream = $block->upstream;
-    my $sites_d = $block->sites_d;
+    my $sites_d = $block->sites_d || '';
     my $ServerPort = $Test::Nginx::Util::ServerPort;
 
     if (defined $backend) {

--- a/t/TestAPIcastBlackbox.pm
+++ b/t/TestAPIcastBlackbox.pm
@@ -9,6 +9,10 @@ use TestAPIcast  -Base;
 use File::Copy "move";
 use File::Temp qw/ tempfile /;
 
+BEGIN {
+    $ENV{APICAST_OPENRESTY_BINARY} = $ENV{TEST_NGINX_BINARY};
+}
+
 add_block_preprocessor(sub {
     my $block = shift;
     my $seq = $block->seq_num;

--- a/t/TestAPIcastBlackbox.pm
+++ b/t/TestAPIcastBlackbox.pm
@@ -33,9 +33,8 @@ my $write_nginx_config = sub {
     print $conf $block->configuration;
     close $conf;
 
-    open my $out, ">apicast/config/test.lua" or Test::Nginx::Util::bail_out "Can't open $ConfFile for writing: $!\n";
-
-    print $out <<_EOC_;
+    my ($env, $env_file) = tempfile();
+    print $env <<_EOC_;
 return {
     worker_processes = '$Workers',
     master_process = '$MasterProcessEnabled',
@@ -49,7 +48,9 @@ return {
     env = { APICAST_CONFIGURATION = 'file://$configuration', APICAST_CONFIGURATION_LOADER = 'boot' },
 }
 _EOC_
-    close $out;
+    close $env;
+
+    $ENV{APICAST_ENVIRONMENT_CONFIG} = $env_file;
 
     my $apicast = `bin/apicast --boot --test --environment test --configuration $configuration 2>&1`;
     if ($apicast =~ /configuration file (?<file>.+?) test is successful/)

--- a/t/apicast-blackbox.t
+++ b/t/apicast-blackbox.t
@@ -1,6 +1,7 @@
 use lib 't';
 use TestAPIcastBlackbox 'no_plan';
 
+repeat_each(1);
 run_tests();
 
 __DATA__
@@ -24,3 +25,50 @@ GET /
 --- response_body chomp
 credentials missing!
 --- error_code: 401
+
+=== TEST 2 api backend gets the request
+It asks backend and then forwards the request to the api.
+--- ONLY
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
+      local args = ngx.var.args
+      if args == expected then
+        ngx.exit(200)
+      else
+        ngx.log(ngx.ERR, expected, ' did not match: ', args)
+        ngx.exit(403)
+      end
+    }
+  }
+--- upstream
+  location / {
+     echo 'yay, api backend: $http_host';
+  }
+--- request
+GET /?user_key=value
+--- response_body
+yay, api backend: test
+--- error_code: 200
+--- error_log
+apicast cache miss key: 42:value:usage%5Bhits%5D=2
+--- no_error_log
+[error]

--- a/t/apicast-blackbox.t
+++ b/t/apicast-blackbox.t
@@ -28,7 +28,6 @@ credentials missing!
 
 === TEST 2 api backend gets the request
 It asks backend and then forwards the request to the api.
---- ONLY
 --- configuration
 {
   "services": [

--- a/t/apicast-blackbox.t
+++ b/t/apicast-blackbox.t
@@ -1,0 +1,26 @@
+use lib 't';
+use TestAPIcastBlackbox 'no_plan';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: authentication credentials missing
+The message is configurable as well as the status.
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": 1,
+      "proxy": {
+        "error_auth_missing": "credentials missing!",
+        "error_status_auth_missing": 401
+      }
+    }
+  ]
+}
+--- request
+GET /
+--- response_body chomp
+credentials missing!
+--- error_code: 401


### PR DESCRIPTION
This implements a base test class to provide blackbox testing of APIcast using the Test::Nginx framework.

Blackbox tests should define just JSON config.
They definitely should not hook into nginx configuration by setting or changing variables.
This makes the blackbox tests much more maintainable solution for the future.

Depends on https://github.com/3scale/apicast/pull/478

@3scale/qe this might be poking a bit into your turf, but still has no interaction with rest of the platform. It is meant for just static configuration.