### PR TITLE
[resty.resolver] try to resolve upstream peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Added
 
 - New policy chains system. This allows users to write custom policies to configure what Apicast can do on each of the Nginx phases [PR #450](https://github.com/3scale/apicast/pull/450)
+- Resolver can resolve nginx upstreams [PR #478](https://github.com/3scale/apicast/pull/478)
 
 ## [3.2.0-alpha1]
 

--- a/t/TestAPIcast.pm
+++ b/t/TestAPIcast.pm
@@ -3,6 +3,10 @@ use strict;
 use warnings FATAL => 'all';
 use v5.10.1;
 
+BEGIN {
+    $ENV{TEST_NGINX_BINARY} ||= 'openresty';
+}
+
 use Test::Nginx::Socket::Lua -Base;
 
 use Cwd qw(cwd);

--- a/t/resolver.t
+++ b/t/resolver.t
@@ -37,3 +37,33 @@ nameservers: 3 127.0.1.15353 1.2.3.453 4.5.6.753
 >>> resolv.conf
 nameserver 1.2.3.4
 nameserver 4.5.6.7
+
+
+=== TEST 2: uses upstream peers
+When upstream is defined with the same name use its peers.
+--- http_config
+lua_package_path "$TEST_NGINX_LUA_PATH";
+upstream some_name {
+  server 1.2.3.4:5678;
+  server 2.3.4.5:6789;
+}
+--- config
+  location = /t {
+    content_by_lua_block {
+      local resolver = require('resty.resolver'):instance()
+      local servers = resolver:get_servers('some_name')
+
+      ngx.say('servers: ', #servers)
+      for i=1, #servers do
+        ngx.say(servers[i].address, ':', servers[i].port)
+      end
+    }
+  }
+--- request
+GET /t
+--- response_body
+servers: 2
+1.2.3.4:5678
+2.3.4.5:6789
+--- no_error_log
+[error]


### PR DESCRIPTION
* defining an upstream can be used as a shortcut to skip DNS resolution
* if an upstream is defined with the same name then use the peers

extracted from https://github.com/3scale/apicast/pull/474