### PR TITLE
Enable the 'no_body' option when authorizing against 3scale backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - New policy chains system. This allows users to write custom policies to configure what Apicast can do on each of the Nginx phases [PR #450](https://github.com/3scale/apicast/pull/450)
 - Resolver can resolve nginx upstreams [PR #478](https://github.com/3scale/apicast/pull/478)
+- Calls 3scale backend with the 'no_body' option enabled. This reduces network traffic in cases where APIcast does not need to parse the response body [PR #483](https://github.com/3scale/apicast/pull/483)
 
 ## [3.2.0-alpha1]
 

--- a/spec/backend_client_spec.lua
+++ b/spec/backend_client_spec.lua
@@ -5,7 +5,8 @@ local test_backend_client = require 'resty.http_ng.backend.test'
 describe('backend client', function()
 
   local test_backend
-  local options_header_val = 'rejection_reason_header=1'
+  local options_header_oauth = 'rejection_reason_header=1'
+  local options_header_no_oauth = 'rejection_reason_header=1&no_body=1'
 
   before_each(function() test_backend = test_backend_client.new() end)
 
@@ -22,7 +23,7 @@ describe('backend client', function()
         url = 'http://example.com/transactions/authrep.xml?' ..
             ngx.encode_args({ auth = service.backend_authentication.value, service_id = service.id }),
         headers = { host = 'example.com',
-                    ['3scale-options'] = options_header_val }
+                    ['3scale-options'] = options_header_no_oauth }
       }.respond_with{ status = 200 }
       local backend_client = assert(_M:new(service, test_backend))
 
@@ -43,7 +44,7 @@ describe('backend client', function()
         url = 'http://example.com/transactions/authrep.xml?' ..
             ngx.encode_args({ auth = service.backend_authentication.value, service_id = service.id }) ..
             '&usage%5Bhits%5D=1&user_key=foobar',
-        headers = { ['3scale-options'] = options_header_val }
+        headers = { ['3scale-options'] = options_header_no_oauth }
       }.respond_with{ status = 200 }
       local backend_client = assert(_M:new(service, test_backend))
 
@@ -62,7 +63,7 @@ describe('backend client', function()
       test_backend.expect{
         url = 'http://example.com/transactions/authrep.xml?service_id=42',
         headers = { host = 'foo.example.com',
-                    ['3scale-options'] = options_header_val }
+                    ['3scale-options'] = options_header_no_oauth }
       }.respond_with{ status = 200 }
       local backend_client = assert(_M:new(service, test_backend))
 
@@ -80,7 +81,7 @@ describe('backend client', function()
       })
       test_backend.expect{
         url = 'http://example.com/transactions/oauth_authrep.xml?service_id=42',
-        headers = { ['3scale-options'] = options_header_val }
+        headers = { ['3scale-options'] = options_header_oauth }
       }.respond_with{ status = 200 }
       local backend_client = assert(_M:new(service, test_backend))
 
@@ -103,7 +104,7 @@ describe('backend client', function()
         url = 'http://example.com/transactions/authorize.xml?' ..
             ngx.encode_args({ auth = service.backend_authentication.value, service_id = service.id }),
         headers = { host = 'example.com',
-                    ['3scale-options'] = options_header_val }
+                    ['3scale-options'] = options_header_no_oauth }
       }.respond_with{ status = 200 }
       local backend_client = assert(_M:new(service, test_backend))
 
@@ -124,7 +125,7 @@ describe('backend client', function()
         url = 'http://example.com/transactions/authorize.xml?' ..
             ngx.encode_args({ auth = service.backend_authentication.value, service_id = service.id }) ..
             '&usage%5Bhits%5D=1&user_key=foobar',
-        headers = { ['3scale-options'] = options_header_val }
+        headers = { ['3scale-options'] = options_header_no_oauth }
       }.respond_with{ status = 200 }
       local backend_client = assert(_M:new(service, test_backend))
 
@@ -143,7 +144,7 @@ describe('backend client', function()
       test_backend.expect{
         url = 'http://example.com/transactions/authorize.xml?service_id=42',
         headers = { host = 'foo.example.com',
-                    ['3scale-options'] = options_header_val }
+                    ['3scale-options'] = options_header_no_oauth }
       }.respond_with{ status = 200 }
       local backend_client = assert(_M:new(service, test_backend))
 
@@ -161,7 +162,7 @@ describe('backend client', function()
       })
       test_backend.expect{
         url = 'http://example.com/transactions/oauth_authorize.xml?service_id=42',
-        headers = { ['3scale-options'] = options_header_val }
+        headers = { ['3scale-options'] = options_header_oauth }
       }.respond_with{ status = 200 }
       local backend_client = assert(_M:new(service, test_backend))
 

--- a/t/apicast.t
+++ b/t/apicast.t
@@ -649,7 +649,7 @@ status code (429).
 
   location /transactions/authrep.xml {
     content_by_lua_block {
-      if ngx.var['http_3scale_options'] == 'rejection_reason_header=1' then
+      if ngx.var['http_3scale_options'] == 'rejection_reason_header=1&no_body=1' then
         ngx.header['3scale-rejection-reason'] = 'limits_exceeded';
       end
       ngx.status = 409;
@@ -696,7 +696,7 @@ Limits exceeded
 
   location /transactions/authrep.xml {
     content_by_lua_block {
-      if ngx.var['http_3scale_options'] == 'rejection_reason_header=1' then
+      if ngx.var['http_3scale_options'] == 'rejection_reason_header=1&no_body=1' then
         ngx.header['3scale-rejection-reason'] = 'limits_exceeded';
       end
       ngx.status = 409;


### PR DESCRIPTION
When `no_body` is enabled via the `3scale-options-header`, backend does not return a response body. The body normally has lots of detail: metrics, limits, plans, etc. In the normal auth flow, all this information is not required. We only need to check the status code of the response. By enabling the `no_body` option, we will save some work to the 3scale backend and also reduce network traffic.

no_body cannot be enabled in the oauth flow, as there we need to parse the response body.