### PR TITLE
Adapt Docker development env to namespace changes

### DIFF
--- a/Dockerfile-development
+++ b/Dockerfile-development
@@ -34,7 +34,7 @@ RUN cpan install version \
  && cpan install Carton
 
 COPY cpanfile ${USER_HOME}
-COPY apicast/apicast-0.1-0.rockspec ${USER_HOME}/apicast/
+COPY gateway/apicast-0.1-0.rockspec ${USER_HOME}/apicast/
 COPY rockspec ${USER_HOME}
 
 WORKDIR ${USER_HOME}

--- a/script/test
+++ b/script/test
@@ -10,7 +10,7 @@ function run_busted_tests {
 function run_nginx_unit_tests {
     cd "${PROJECT_PATH}" || exit
 
-    sudo TEST_NGINX_APICAST_PATH="${PROJECT_PATH}/apicast" \
+    sudo TEST_NGINX_APICAST_PATH="${PROJECT_PATH}/gateway" \
          TEST_NGINX_BINARY=openresty \
          TEST_NGINX_REDIS_HOST=redis \
          prove


### PR DESCRIPTION
This PR simply adapts the paths used by the development Docker to the new structure introduced in https://github.com/3scale/apicast/pull/486