### PR TITLE
ability to configure policy chains globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Calls 3scale backend with the 'no_body' option enabled. This reduces network traffic in cases where APIcast does not need to parse the response body [PR #483](https://github.com/3scale/apicast/pull/483)
 - Methods to modify policy chains [PR #505](https://github.com/3scale/apicast/pull/505)
 - Ability to load several environment configurations [PR #504](https://github.com/3scale/apicast/pull/504)
+- Ability to configure policy chain from the environment configuration [PR #496](https://github.com/3scale/apicast/pull/496)
 
 ## Changed
 

--- a/examples/policy_chain/README.md
+++ b/examples/policy_chain/README.md
@@ -1,0 +1,13 @@
+# Configure Policy Chain
+
+Environment configuration can define the global policy chain. You can provide custom chain or insert policies to the default one.
+
+## Using Echo Policy
+
+[Echo policy](../../gateway/src/apicast/policy/echo.lua) accepts configuration option to terminate the request phase. See the example in [`configuration.lua`](./configuration.lua).
+
+You can start it as:
+
+```shell
+ECHO_STATUS=202 bin/apicast --environment examples/policy_chain/configuration.lua
+```

--- a/examples/policy_chain/configuration.lua
+++ b/examples/policy_chain/configuration.lua
@@ -1,0 +1,13 @@
+local resty_env = require('resty.env')
+local policy_chain = require('apicast.policy_chain').default()
+local echo_policy = require('apicast.policy.echo').new({
+  status = tonumber(resty_env.value('ECHO_STATUS') or 201),
+  exit = 'request'
+})
+
+-- add Echo policy to the chain on the 1st place
+policy_chain:insert(echo_policy, 1)
+
+return {
+  policy_chain = policy_chain
+}

--- a/gateway/http.d/init.conf
+++ b/gateway/http.d/init.conf
@@ -6,11 +6,18 @@ init_by_lua_block {
     require("resty.core")
     require('resty.resolver').init()
 
+    local env = require('apicast.cli.environment').load()
+    local context = env:context()
     local module = require('apicast.executor')
 
     if not module then
       ngx.log(ngx.EMERG, 'fatal error when loading the root module')
       os.exit(1)
+    end
+
+    if context.policy_chain then
+        module = module.new(context.policy_chain)
+        package.loaded['apicast.executor'] = module
     end
 
     module:init()

--- a/gateway/src/apicast/cli/environment.lua
+++ b/gateway/src/apicast/cli/environment.lua
@@ -16,6 +16,7 @@ local print = print
 local pairs = pairs
 local ipairs = ipairs
 local tostring = tostring
+local tonumber = tonumber
 local insert = table.insert
 local concat = table.concat
 local re = require('ngx.re')
@@ -127,6 +128,7 @@ function _M:add(env)
 
     local config = loadfile(path, 't', {
         print = print, inspect = require('inspect'), context = self._context,
+        tonumber = tonumber, tostring = tostring,
         pcall = pcall, require = require, assert = assert, error = error,
     })
 

--- a/gateway/src/apicast/cli/environment.lua
+++ b/gateway/src/apicast/cli/environment.lua
@@ -48,10 +48,12 @@ _M.default_environment = 'production'
 
 --- Default configuration.
 -- @tfield ?string ca_bundle path to CA store file
+-- @tfield ?policy_chain policy_chain @{policy_chain} instance
 -- @tfield ?{string,...} nameservers list of nameservers
 -- @table environment.default_config default configuration
 _M.default_config = {
     ca_bundle = resty_env.value('SSL_CERT_FILE'),
+    policy_chain = require('apicast.policy_chain').default(),
     nameservers = parse_nameservers(),
 }
 

--- a/gateway/src/apicast/policy/echo.lua
+++ b/gateway/src/apicast/policy/echo.lua
@@ -1,9 +1,36 @@
-local policy = require('apicast.policy')
-local _M = policy.new('Echo Policy')
+--- Echo policy
+-- Print the request back to the client and optionally set a status code.
+-- Also can interrupt the execution and skip the current phase or
+-- the whole processing of the request.
 
-function _M.rewrite()
+local _M = require('apicast.policy').new('Echo Policy')
+
+local tonumber = tonumber
+local new = _M.new
+
+function _M.new(configuration)
+  local policy = new(configuration)
+
+  if configuration then
+    policy.status = tonumber(configuration.status)
+    policy.exit = configuration.exit
+  end
+
+  return policy
+end
+
+function _M:rewrite()
+  if self.status then
+    ngx.status = self.status
+  end
+
   ngx.say(ngx.var.request)
-  ngx.exit(0)
+
+  if self.exit == 'request' then
+    return ngx.exit(ngx.status)
+  elseif self.exit == 'phase' then
+    return ngx.exit(0)
+  end
 end
 
 return _M


### PR DESCRIPTION
closes https://github.com/3scale/apicast/issues/481


It is possible to return a table with field `policy_chain` that is going to be used as the policy chain instead of the default one.

Example:


```lua
local policy_chain = require('apicast.policy_chain').default()

policy_chain:insert(mypolicy)

return {
  policy_chain = policy_chain
}
```