### PR TITLE
Delete 'ONLY' in cors test

### DIFF
--- a/t/apicast-policy-cors.t
+++ b/t/apicast-policy-cors.t
@@ -105,7 +105,6 @@ Access-Control-Allow-Credentials: true
 === TEST 3: CORS actual request with custom config
 This tests a CORS actual (not preflight) request. We use a custom config to set
 the CORS headers in the response.
---- ONLY
 --- configuration
 {
   "services": [


### PR DESCRIPTION
This was probably set up for debugging in the past and I forgot to delete it.