### PR TITLE
examples/configuration/echo: use full namespace in the apicast policy

### DIFF
--- a/examples/configuration/echo.json
+++ b/examples/configuration/echo.json
@@ -15,7 +15,7 @@
           "host": "echo"
         },
         "policy_chain": [
-          { "name": "apicast" }
+          { "name": "apicast.policy.apicast" }
         ],
         "proxy_rules": [
           {


### PR DESCRIPTION
This is to avoid deprecation messages:
`loader.lua:40: DEPRECATION: file renamed - change: require("apicast")
to: require("apicast.policy.apicast")`