### PR TITLE
fix rover loading code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Namespace all APIcast code in `apicast` folder. Possible BREAKING CHANGE for some customizations. [PR #486](https://github.com/3scale/apicast/pull/486)
 
+## Fixed
+
+- Loading installed luarocks from outside rover [PR #503](https://github.com/3scale/apicast/pull/503)
+
 ## [3.2.0-alpha1]
 
 ## Added

--- a/gateway/bin/cli
+++ b/gateway/bin/cli
@@ -3,6 +3,9 @@
 local ok, setup = pcall(require, 'rover.setup')
 
 if ok then
+    -- preload apicast before openresty lua paths are removed
+    require('apicast.executor')
+
     setup()
 else
     package.path = './src/?.lua;' .. package.path

--- a/gateway/http.d/init.conf
+++ b/gateway/http.d/init.conf
@@ -3,8 +3,6 @@ init_by_lua_block {
     -- require('jit.p').start('vl')
     -- require('jit.dump').start('bsx', 'jit.log')
 
-    pcall(require, 'luarocks.loader')
-
     require("resty.core")
     require('resty.resolver').init()
 


### PR DESCRIPTION
It was possible for `luarocks.loader` to break rover scope
and load code from your home directory.
Now only rover dependencies are available after running `rover.setup`.
So all code has to be preloaded before running it.