### PR TITLE
[circleci] parallelize Test::Nginx suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,11 @@ jobs:
             - lua_modules
       - run: mkdir -p tmp/junit
       - run: $(make rover) exec make busted
-      - run: JUNIT_OUTPUT_FILE=tmp/junit/prove.xml make prove HARNESS=TAP::Harness::JUnit
+      - run:
+          command: make prove
+          environment:
+            JUNIT_OUTPUT_FILE: tmp/junit/prove.xml
+            HARNESS: TAP::Harness::JUnit
       - store_test_results:
           path: tmp/junit
       - store_artifacts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Ability to load several environment configurations [PR #504](https://github.com/3scale/apicast/pull/504)
 - Ability to configure policy chain from the environment configuration [PR #496](https://github.com/3scale/apicast/pull/496)
 - Load environment variables defined in the configuration [PR #507](https://github.com/3scale/apicast/pull/507)
+- Allow configuration of the echo/management/fake backend ports [PR #506](https://github.com/3scale/apicast/pull/506)
 
 ## Changed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     environment:
       TEST_NGINX_BINARY: openresty
       TEST_NGINX_REDIS_HOST: redis
-    command: "'$$TEST_NGINX_BINARY -V; cd ; rover exec prove; exit $$?'"
+    command: "'$$TEST_NGINX_BINARY -V; cd ; make prove; exit $$?'"
     dns_search:
       - example.com
     depends_on:

--- a/gateway/conf/nginx.conf.liquid
+++ b/gateway/conf/nginx.conf.liquid
@@ -54,15 +54,15 @@ http {
   {% endfor %}
 
   server {
-    listen 8090;
+    listen {{ port.management | default: 8090 }};
 
-    server_name _;
+    server_name management _;
 
     {% include "conf.d/management.conf" %}
   }
 
   server {
-    listen 8081;
+    listen {{ port.backend | default: 8081 }};
 
     server_name backend;
 
@@ -70,7 +70,7 @@ http {
   }
 
   server {
-    listen 8081 default_server;
+    listen {{ port.echo | default: 8081 }} default_server;
 
     server_name echo _;
 

--- a/t/TestAPIcastBlackbox.pm
+++ b/t/TestAPIcastBlackbox.pm
@@ -79,6 +79,9 @@ my $write_nginx_config = sub {
     my $PidFile = $Test::Nginx::Util::PidFile;
     my $AccLogFile = $Test::Nginx::Util::AccLogFile;
     my $ServerPort = $Test::Nginx::Util::ServerPort;
+    my $backend_port = TestAPIcast::get_random_port();
+    my $management_port = TestAPIcast::get_random_port();
+    my $echo_port = TestAPIcast::get_random_port();
 
     my $sites_d = $block->sites_d;
 
@@ -111,7 +114,12 @@ return {
     pid = '$PidFile',
     lua_code_cache = 'on',
     access_log = '$AccLogFile',
-    port = { apicast = '$ServerPort' },
+    port = {
+      apicast = '$ServerPort',
+      management = '$management_port',
+      backend = '$backend_port',
+      echo = '$echo_port',
+    },
     env = {
         THREESCALE_CONFIG_FILE = [[$configuration_file]],
         APICAST_CONFIGURATION_LOADER = 'boot',

--- a/t/apicast-async-reporting.t
+++ b/t/apicast-async-reporting.t
@@ -146,7 +146,7 @@ backend client uri: https://127.0.0.1:1953/transactions/authrep.xml?service_toke
 === TEST 3: uses endpoint host as Host header
 when connecting to the backend
 --- main_config
-env RESOLVER=127.0.0.1:1953;
+env RESOLVER=127.0.0.1:$TEST_NGINX_RANDOM_PORT;
 --- http_config
 include $TEST_NGINX_UPSTREAM_CONFIG;
 lua_package_path "$TEST_NGINX_LUA_PATH";
@@ -196,11 +196,11 @@ GET /t?user_key=val
 --- response_body
 all ok
 --- error_code: 200
---- udp_listen: 1953
+--- udp_listen random_port
 --- udp_reply dns
 [ "localhost.example.com", "127.0.0.1", 60 ]
 --- no_error_log
 [error]
---- error_log
-backend client uri: http://localhost.example.com:1984/transactions/authrep.xml?service_token=service-token&service_id=42&usage%5Bhits%5D=2&user_key=val ok: true status: 200
+--- error_log env
+backend client uri: http://localhost.example.com:$TEST_NGINX_SERVER_PORT/transactions/authrep.xml?service_token=service-token&service_id=42&usage%5Bhits%5D=2&user_key=val ok: true status: 200
 --- wait: 3

--- a/t/apicast-upstream-balancer.t
+++ b/t/apicast-upstream-balancer.t
@@ -15,7 +15,7 @@ location /t {
     local resty_resolver = require 'resty.resolver'
     local dns_client = require 'resty.dns.resolver'
 
-    local dns = dns_client:new{ nameservers = { { "127.0.0.1", 1953 } } }
+    local dns = dns_client:new{ nameservers = { { "127.0.0.1", $TEST_NGINX_RANDOM_PORT } } }
     local resolver = resty_resolver.new(dns)
 
     local servers = resolver:get_servers('3scale.net')
@@ -31,7 +31,7 @@ location /t {
     ngx.say(require('cjson').encode(upstream))
   }
 }
---- udp_listen: 1953
+--- udp_listen random_port
 --- udp_reply dns
 [ "localhost", "127.0.0.1" ]
 --- request
@@ -116,7 +116,7 @@ location /t {
     local resty_resolver = require 'resty.resolver'
     local dns_client = require 'resty.dns.resolver'
 
-    local dns = dns_client:new{ nameservers = { { "127.0.0.1", 1953 } } }
+    local dns = dns_client:new{ nameservers = { { "127.0.0.1", $TEST_NGINX_RANDOM_PORT } } }
     local resolver = resty_resolver.new(dns)
 
     ngx.ctx.upstream = resolver:get_servers('localhost', { port = $TEST_NGINX_SERVER_PORT })
@@ -124,7 +124,7 @@ location /t {
 
   proxy_pass http://upstream/api;
 }
---- udp_listen: 1953
+--- udp_listen random_port
 --- udp_reply dns
 [ "localhost", "127.0.0.1" ]
 --- request

--- a/t/apicast.t
+++ b/t/apicast.t
@@ -557,7 +557,7 @@ X-3scale-usage: usage%5Bhits%5D=2
 === TEST 16: uses endpoint host as Host header
 when connecting to the backend
 --- main_config
-env RESOLVER=127.0.0.1:1953;
+env RESOLVER=127.0.0.1:$TEST_NGINX_RANDOM_PORT;
 --- http_config
   include $TEST_NGINX_UPSTREAM_CONFIG;
   lua_package_path "$TEST_NGINX_LUA_PATH";
@@ -605,7 +605,7 @@ GET /t?user_key=val
 --- response_body
 all ok
 --- error_code: 200
---- udp_listen: 1953
+--- udp_listen random_port
 --- udp_reply dns
 [ "localhost.example.com", "127.0.0.1", 3600 ]
 --- no_error_log

--- a/t/configuration-loading-boot-with-config.t
+++ b/t/configuration-loading-boot-with-config.t
@@ -15,8 +15,8 @@ __DATA__
 === TEST 1: require configuration file to exist
 should exit when the config file is missing
 --- must_die
---- configuration_file
-t/servroot/html/config.json
+--- configuration_file env
+$TEST_NGINX_SERVER_ROOT/html/config.json
 --- error_log
 config.json: No such file or directory
 --- user_files
@@ -25,8 +25,8 @@ config.json: No such file or directory
 === TEST 2: require valid json file
 should exit when the file has invalid json
 --- must_die
---- configuration_file
-t/servroot/html/config.json
+--- configuration_file env
+$TEST_NGINX_SERVER_ROOT/html/config.json
 --- error_log
 Expected value but found invalid token at character 1
 --- user_files
@@ -35,8 +35,8 @@ not valid json
 
 === TEST 3: empty json file
 should continue as empty json is enough
---- configuration_file
-t/servroot/html/config.json
+--- configuration_file env
+$TEST_NGINX_SERVER_ROOT/html/config.json
 --- request
 GET
 --- error_code: 404

--- a/t/management.t
+++ b/t/management.t
@@ -152,7 +152,7 @@ Could not resolve GET /foobar - nil
 exposes boot function
 --- main_config
 env THREESCALE_PORTAL_ENDPOINT=http://localhost.local:$TEST_NGINX_SERVER_PORT/config/;
-env RESOLVER=127.0.0.1:1953;
+env RESOLVER=127.0.0.1:$TEST_NGINX_RANDOM_PORT;
 env APICAST_MANAGEMENT_API=debug;
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";
@@ -166,7 +166,7 @@ POST /boot
 --- response_body
 {"status":"ok","config":{"services":[{"id":42}]}}
 --- error_code: 200
---- udp_listen: 1953
+--- udp_listen random_port
 --- udp_reply dns
 [ "localhost.local", "127.0.0.1", 60 ]
 --- no_error_log
@@ -176,7 +176,7 @@ POST /boot
 keeps the same configuration
 --- main_config
 env THREESCALE_PORTAL_ENDPOINT=http://localhost.local:$TEST_NGINX_SERVER_PORT/config/;
-env RESOLVER=127.0.0.1:1953;
+env RESOLVER=127.0.0.1:$TEST_NGINX_RANDOM_PORT;
 env APICAST_MANAGEMENT_API=debug;
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";
@@ -195,7 +195,7 @@ POST /test
 {"status":"ok","config":{"services":[{"id":42}]}}
 {"status":"ok","config":{"services":[{"id":42}]}}
 --- error_code: 200
---- udp_listen: 1953
+--- udp_listen random_port
 --- udp_reply dns
 [ "localhost.local", "127.0.0.1", 60 ]
 --- no_error_log


### PR DESCRIPTION
Reduces CircleCI `prove` from 53 to 13s.
Automatically runs prove in parallel when `nproc` is available. And `make prove` will run tests in randomized directories and ports.

To achieve this all tests need to allocate a random port to listen on. That includes the TCP/UDP servers provided by Test::Nginx to stub DNS server.

The environment configuration can now configure echo/management/backend ports:

```lua
return {
  port = {
      apicast = '8080',
      management = '8090',
      backend = '8081',
      echo = '8081',
    },
}
```
