### PR TITLE
[t] rewrite config loading test using blackbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Methods to modify policy chains [PR #505](https://github.com/3scale/apicast/pull/505)
 - Ability to load several environment configurations [PR #504](https://github.com/3scale/apicast/pull/504)
 - Ability to configure policy chain from the environment configuration [PR #496](https://github.com/3scale/apicast/pull/496)
+- Load environment variables defined in the configuration [PR #507](https://github.com/3scale/apicast/pull/507)
 
 ## Changed
 

--- a/gateway/http.d/init.conf
+++ b/gateway/http.d/init.conf
@@ -8,6 +8,12 @@ init_by_lua_block {
 
     local env = require('apicast.cli.environment').load()
     local context = env:context()
+
+    local resty_env = require('resty.env')
+    for k,v in pairs(context.env or {}) do
+      resty_env.set(k,v)
+    end
+
     local module = require('apicast.executor')
 
     if not module then

--- a/t/configuration-loading-boot-with-config.t
+++ b/t/configuration-loading-boot-with-config.t
@@ -1,14 +1,10 @@
 use lib 't';
-use TestAPIcast 'no_plan';
+use TestAPIcastBlackbox 'no_plan';
 
-$ENV{TEST_NGINX_HTTP_CONFIG} = "$TestAPIcast::path/http.d/init.conf";
 $ENV{APICAST_CONFIGURATION_LOADER} = 'boot';
-$ENV{THREESCALE_CONFIG_FILE} = 't/servroot/html/config.json';
 
 env_to_nginx(
     'APICAST_CONFIGURATION_LOADER',
-    'TEST_NGINX_APICAST_PATH',
-    'THREESCALE_CONFIG_FILE'
 );
 
 log_level('warn');
@@ -18,13 +14,9 @@ __DATA__
 
 === TEST 1: require configuration file to exist
 should exit when the config file is missing
---- http_config
-  include $TEST_NGINX_HTTP_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
---- config
 --- must_die
---- request
-GET
+--- configuration_file
+t/servroot/html/config.json
 --- error_log
 config.json: No such file or directory
 --- user_files
@@ -32,13 +24,9 @@ config.json: No such file or directory
 
 === TEST 2: require valid json file
 should exit when the file has invalid json
---- http_config
-  include $TEST_NGINX_HTTP_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
---- config
 --- must_die
---- request
-GET
+--- configuration_file
+t/servroot/html/config.json
 --- error_log
 Expected value but found invalid token at character 1
 --- user_files
@@ -47,12 +35,11 @@ not valid json
 
 === TEST 3: empty json file
 should continue as empty json is enough
---- http_config
-  include $TEST_NGINX_HTTP_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
---- config
+--- configuration_file
+t/servroot/html/config.json
 --- request
 GET
+--- error_code: 404
 --- user_files
 >>> config.json
 {}


### PR DESCRIPTION
An example of what we would have to do if the init_by_lua_block
would contain some liquid - we would have to use only blackbox tests
and not include the `init.conf` in the Test::Nginx tests
