### PR TITLE
[resty.resolver] support ipv6 resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Fixed
 
 - Loading installed luarocks from outside rover [PR #503](https://github.com/3scale/apicast/pull/503)
+- Support IPv6 addresses in `/etc/resolv.conf` [PR #511](https://github.com/3scale/apicast/pull/511)
 
 ## [3.2.0-alpha1]
 

--- a/bin/busted
+++ b/bin/busted
@@ -14,6 +14,7 @@ chdir "$dirname/..";
 my $apicast = getcwd();
 
 exec '/usr/bin/env', 'resty',
+    '--errlog-level', 'alert',
     '--http-include', "$apicast/spec/fixtures/echo.conf",
     "$apicast/bin/busted.lua",
     '--config-file', "$apicast/.busted",

--- a/gateway/src/resty/resolver.lua
+++ b/gateway/src/resty/resolver.lua
@@ -53,6 +53,14 @@ local function read_resolv_conf(path)
   return output or "", err
 end
 
+local function ipv4(address)
+  return re_match(address, '^([0-9]{1,3}\\.){3}[0-9]{1,3}$', 'oj')
+end
+
+local function ipv6(address)
+  return re_match(address, '^\\[[a-f\\d:]+\\]$', 'oj')
+end
+
 local nameserver = {
   mt = {
     __tostring = function(t)
@@ -62,6 +70,10 @@ local nameserver = {
 }
 
 function nameserver.new(host, port)
+  if not ipv4(host) and not ipv6(host) then
+    -- then it is likely ipv6 without [ ] around
+    host = format('[%s]', host)
+  end
   return setmetatable({ host, port or default_resolver_port }, nameserver.mt)
 end
 

--- a/spec/resty/resolver_spec.lua
+++ b/spec/resty/resolver_spec.lua
@@ -129,8 +129,36 @@ describe('resty.resolver', function()
     pending('does query when cached cname missing address')
   end)
 
+  describe('.parse_resolver', function()
+
+    it("handles invalid data", function()
+      assert.same({'foobar', 'invalid address'}, { resty_resolver.parse_resolver('foobar') })
+    end)
+
+    it("handles missing data", function()
+      assert.same({}, { resty_resolver.parse_resolver() })
+    end)
+
+    it("parses ipv4 without port", function()
+      assert.same({'192.168.0.1', 53}, resty_resolver.parse_resolver('192.168.0.1'))
+    end)
+
+    it("parses ipv4 with port", function()
+      assert.same({'192.168.0.1', '5353'}, resty_resolver.parse_resolver('192.168.0.1:5353'))
+    end)
+
+    it("parses ipv6 without port", function()
+      assert.same({'[dead::beef:5353]', 53}, resty_resolver.parse_resolver('dead::beef:5353'))
+    end)
+
+    it("parses ipv6 with port", function()
+      assert.same({'[dead::beef]', '5353'}, resty_resolver.parse_resolver('[dead::beef]:5353'))
+    end)
+  end)
+
   describe('.parse_nameservers', function()
     local tmpname
+    local resty_env = require('resty.env')
 
     before_each(function()
       tmpname = io.tmpfile()
@@ -155,6 +183,22 @@ describe('resty.resolver', function()
       assert.same({ 'localdomain.example.com', 'local' },  search)
     end)
 
+    it('ignores invalid RESOLVER', function()
+      resty_env.set('RESOLVER', 'invalid-nameserver')
+
+      local nameservers = resty_resolver.parse_nameservers('')
+
+      assert.equal(0, #nameservers)
+    end)
+
+    it('uses correct RESOLVER', function()
+      resty_env.set('RESOLVER', '192.168.0.1:53')
+
+      local nameservers = resty_resolver.parse_nameservers('')
+
+      assert.equal(1, #nameservers)
+      assert.same({'192.168.0.1', '53'}, nameservers[1])
+    end)
   end)
 
 end)

--- a/t/resolver.t
+++ b/t/resolver.t
@@ -66,3 +66,27 @@ servers: 2
 2.3.4.5:6789
 --- no_error_log
 [error]
+
+
+=== TEST 3: can have ipv6 RESOLVER
+RESOLVER env variable can be IPv6 address
+--- main_config
+env RESOLVER=[dead::beef]:5353;
+--- http_config
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+  init_worker_by_lua_block {
+    require('resty.resolver').init('$TEST_NGINX_RESOLV_CONF')
+  }
+--- config
+  location = /t {
+    content_by_lua_block {
+      local nameservers = require('resty.resolver').nameservers()
+      ngx.say('nameservers: ', #nameservers, ' ', tostring(nameservers[1]))
+    }
+  }
+--- request
+GET /t
+--- response_body
+nameservers: 1 [dead::beef]:5353
+--- user_files
+>>> resolv.conf

--- a/t/resolver.t
+++ b/t/resolver.t
@@ -2,13 +2,10 @@ use lib 't';
 use TestAPIcast 'no_plan';
 
 $ENV{TEST_NGINX_HTTP_CONFIG} = "$TestAPIcast::path/http.d/*.conf";
-$ENV{RESOLVER} = '127.0.1.1:5353';
+$ENV{TEST_NGINX_RESOLVER} = '127.0.1.1:5353';
 
 $ENV{TEST_NGINX_RESOLV_CONF} = "$Test::Nginx::Util::HtmlDir/resolv.conf";
 
-env_to_nginx(
-    'RESOLVER'
-);
 master_on();
 log_level('warn');
 run_tests();
@@ -17,9 +14,11 @@ __DATA__
 
 === TEST 1: uses all resolvers
 both RESOLVER env variable and resolvers in resolv.conf should be used
+--- main_config
+env RESOLVER=$TEST_NGINX_RESOLVER;
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";
-  init_by_lua_block {
+  init_worker_by_lua_block {
     require('resty.resolver').init('$TEST_NGINX_RESOLV_CONF')
   }
 --- config


### PR DESCRIPTION
Fixes https://github.com/3scale/apicast/issues/510

@nmasse-itix do you mind trying it out?

# TODO

* [x] write unit tests
* [x] try with ipv6 tunnel