### PR TITLE
[cli] detect local rover installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+## Fixed
+
+- Detecting local rover installation from the CLI [PR #519](https://github.com/3scale/apicast/pull/519)
+
 ## [3.2.0-alpha2] - 2017-11-30
 
 ## Added

--- a/gateway/bin/apicast
+++ b/gateway/bin/apicast
@@ -10,6 +10,8 @@ my $bindir = $apicast . '/bin';
 my $lua_path = $ENV{LUA_PATH};
 my $cwd = getcwd();
 
+$ENV{PATH} .= ":$cwd/lua_modules/bin";
+
 chomp(my $rover = `which rover`);
 if ($rover) { $rover = abs_path($rover) }
 


### PR DESCRIPTION
to fix the rover detection on systems that don't have `lua_modules/bin` on the PATH


/cc @mayorova @kevprice83 