### PR TITLE
[bin] don't print warning when which/rover is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Fixed
 
 - Detecting local rover installation from the CLI [PR #519](https://github.com/3scale/apicast/pull/519)
+- Use more `command` instead of `which` to work in plain shell [PR #521](https://github.com/3scale/apicast/pull/521)
 
 ## [3.2.0-alpha2] - 2017-11-30
 

--- a/gateway/bin/apicast
+++ b/gateway/bin/apicast
@@ -12,7 +12,7 @@ my $cwd = getcwd();
 
 $ENV{PATH} .= ":$cwd/lua_modules/bin";
 
-chomp(my $rover = `which rover`);
+chomp(my $rover = `command -v rover 2>/dev/null`);
 if ($rover) { $rover = abs_path($rover) }
 
 if ($rover && !$lua_path) {


### PR DESCRIPTION
just don't print any error output when trying to detect rover