### PR TITLE
[cli] load apicast loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Detecting local rover installation from the CLI [PR #519](https://github.com/3scale/apicast/pull/519)
 - Use more `command` instead of `which` to work in plain shell [PR #521](https://github.com/3scale/apicast/pull/521)
 - Fixed rockspec so APIcast can be installed by luarocks [PR #523](https://github.com/3scale/apicast/pull/523)
+- Fix loading renamed APIcast code [PR #525](https://github.com/3scale/apicast/pull/525)
 
 ## [3.2.0-alpha2] - 2017-11-30
 

--- a/gateway/src/apicast/cli.lua
+++ b/gateway/src/apicast/cli.lua
@@ -1,3 +1,5 @@
+require('apicast.loader')
+
 local command_target = '_cmd'
 local parser = require('argparse')() {
     name = "APIcast",


### PR DESCRIPTION
because the main APICAST_MODULE is loaded in the CLI
and it could have deprecated requires, we need to initialize the loader
that takes case of the deprecations

```
ERROR: ./src/apicast/policy_chain.lua:47: module apicast.module could not be loaded
stack traceback:
	./src/apicast/policy_chain.lua:47: in function 'build_default_chain'
	./src/apicast/policy/local_chain.lua:20: in main chunk
	[C]: in function 'require'
	./src/apicast/policy_chain.lua:76: in function 'load'
	./src/apicast/policy_chain.lua:47: in function 'default'
	./src/apicast/cli/environment.lua:57: in main chunk
	[C]: in function 'require'
	./src/apicast/cli/command/start.lua:12: in main chunk
```