### PR TITLE
Fix ldocs formatting in the CORS policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed rockspec so APIcast can be installed by luarocks [PR #523](https://github.com/3scale/apicast/pull/523)
 - Fix loading renamed APIcast code [PR #525](https://github.com/3scale/apicast/pull/525)
 - Fix `apicast` command when installed from luarocks [PR #527](https://github.com/3scale/apicast/pull/527)
+- Fix lua docs formatting in the CORS policy [PR #530](https://github.com/3scale/apicast/pull/530)
 
 ## Changed
 

--- a/gateway/src/apicast/policy/cors/policy.lua
+++ b/gateway/src/apicast/policy/cors/policy.lua
@@ -2,10 +2,12 @@
 -- This policy enables CORS (Cross Origin Resource Sharing) request handling.
 -- The policy is configurable. Users can specify the values for the following
 -- headers in the response:
+--
 --   - Access-Control-Allow-Headers
 --   - Access-Control-Allow-Methods
 --   - Access-Control-Allow-Origin
 --   - Access-Control-Allow-Credentials
+--
 -- By default, those headers are set so all the requests are allowed. For
 -- example, if the request contains the 'Origin' header set to 'example.com',
 -- by default, 'Access-Control-Allow-Origin' in the response will be set to


### PR DESCRIPTION
Introduce extra empty lines so the list shows correctly with one item per line.