### PR TITLE
[loader] fix invalid deprecation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Consolidate apicast-0.1-0.rockspec into apicast-scm-1.rockspec [PR #526](https://github.com/3scale/apicast/pull/526)
 - Deprecated `Configuration.extract_usage` in favor of `Service.get_usage` [PR #531](https://github.com/3scale/apicast/pull/531)
 - Extract Test::APIcast to own package on CPAN [PR #528](https://github.com/3scale/apicast/pull/528)
-- Load policies by the APIcast loader instead of changing load path [PR #532](https://github.com/3scale/apicast/pull/532)
+- Load policies by the APIcast loader instead of changing load path [PR #532](https://github.com/3scale/apicast/pull/532), [PR #536](https://github.com/3scale/apicast/pull/536)
 
 ## [3.2.0-alpha2] - 2017-11-30
 

--- a/gateway/src/apicast/loader.lua
+++ b/gateway/src/apicast/loader.lua
@@ -24,10 +24,15 @@ local function loader(name, path)
 end
 
 --- Try to load a policy. Policies can have a `.policy` suffix.
-local function policy_namespace(name, path)
+local function policy_loader(name, path)
   local policy = name .. '.policy'
 
-  local found, err = loader(policy, path or package.path)
+  return loader(policy, path or package.path)
+end
+
+--- Searcher has to return the loader or an error message.
+local function policy_searcher(name, path)
+  local found, err = policy_loader(name, path)
 
   return found or err
 end
@@ -37,7 +42,7 @@ local function prefix_loader(name, path)
   local found, err = loader(prefixed, path)
 
   if not found then
-    found = policy_namespace(prefixed, path)
+    found = policy_loader(prefixed, path)
   end
 
   if found then
@@ -52,7 +57,7 @@ local function rename_loader(name, path)
   local found, err = loader(new, path)
 
   if not found then
-    found = policy_namespace(new, path)
+    found = policy_loader(new, path)
   end
 
   if found then
@@ -74,5 +79,5 @@ local function apicast_namespace(name)
   end
 end
 
-table.insert(package.searchers, policy_namespace)
+table.insert(package.searchers, policy_searcher)
 table.insert(package.searchers, apicast_namespace)


### PR DESCRIPTION
namespace deprecation message would show even when not necessary as the prefix searcher would always return something (loader or an error message) showing deprecation warnings for files like `apicast.moonscript`.

I don't really know how to trigger it to test it.