### PR TITLE
[vagrant] use fedora 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Definition of JSON schemas for policy configurations [PR #522](https://github.com/3scale/apicast/pull/522)
 - URL rewriting policy [PR #529](https://github.com/3scale/apicast/pull/529)
 - Liquid template can find files in current folder too [PR #533](https://github.com/3scale/apicast/pull/533)
+- `bin/apicast` respects `APICAST_OPENRESTY_BINARY` and `TEST_NGINX_BINARY` environment [PR #540](https://github.com/3scale/apicast/pull/540)
 
 ## Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,15 @@ busted: dependencies $(ROVER) ## Test Lua.
 nginx:
 	@ ($(NGINX) -V 2>&1) > /dev/null
 
-prove: HARNESS ?= TAP::Harness
-prove: export TEST_NGINX_RANDOMIZE=1
-prove: $(ROVER) nginx ## Test nginx
+cpan:
 ifeq ($(CPANM),)
 	$(error Missing cpanminus. Install it by running `curl -L https://cpanmin.us | perl - App::cpanminus`)
 endif
 	$(CPANM) --installdeps ./gateway
+
+prove: HARNESS ?= TAP::Harness
+prove: export TEST_NGINX_RANDOMIZE=1
+prove: $(ROVER) nginx cpan ## Test nginx
 	$(ROVER) exec prove -j$(NPROC) --harness=$(HARNESS) 2>&1 | awk '/found ONLY/ { print "FAIL: because found ONLY in test"; print; exit 1 }; { print }'
 
 prove-docker: apicast-source

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ cpan:
 ifeq ($(CPANM),)
 	$(error Missing cpanminus. Install it by running `curl -L https://cpanmin.us | perl - App::cpanminus`)
 endif
-	$(CPANM) --installdeps ./gateway
+	$(CPANM) --notest --installdeps ./gateway
 
 prove: HARNESS ?= TAP::Harness
 prove: export TEST_NGINX_RANDOMIZE=1

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -35,5 +35,5 @@ wrk --connections 100 --threads 10 --duration 300 'http://localhost:8080/?user_k
 And in another terminal you can create flamegraphs:
 
 ```shell
-lj-lua-stacks.sxx  -x `pgrep openresty` --skip-badvars --arg time=30 | fix-lua-bt - | stackcollapse-stap.pl | flamegraph.pl > app/graph.svg
+lj-lua-stacks.sxx  -x `pgrep openresty` --skip-badvars --arg time=30 | fix-lua-bt - | stackcollapse-stap.pl | flamegraph.pl > /vagrant/graph.svg
 ```

--- a/gateway/bin/apicast
+++ b/gateway/bin/apicast
@@ -82,7 +82,13 @@ _LUA_
     $bin = $lua_file;
 }
 
+
 my @resty_args = ();
+
+my $nginx = $ENV{APICAST_OPENRESTY_BINARY} || $ENV{TEST_NGINX_BINARY};
+if (defined $nginx) {
+    push @resty_args, '--nginx', $nginx;
+}
 
 # Add directories to the lua load path.
 # APIcast source and a local src directory.

--- a/gateway/cpanfile
+++ b/gateway/cpanfile
@@ -1,3 +1,2 @@
 requires 'Test::APIcast', '0.03';
-requires 'JSON::WebToken';
-requires 'Crypt::OpenSSL::RSA';
+requires 'Crypt::JWT';

--- a/t/apicast-oidc.t
+++ b/t/apicast-oidc.t
@@ -66,12 +66,12 @@ __DATA__
 GET /test
 --- error_code: 200
 --- more_headers eval
-use JSON::WebToken;
-my $jwt = JSON::WebToken->encode({
+use Crypt::JWT qw(encode_jwt);
+my $jwt = encode_jwt(payload => {
   aud => 'appid',
   nbf => 0,
   iss => 'https://example.com/auth/realms/apicast',
-  exp => time + 10 }, $::rsa, 'RS256');
+  exp => time + 10 }, key => \$::rsa, alg => 'RS256');
 "Authorization: Bearer $jwt"
 --- no_error_log
 [error]


### PR DESCRIPTION
Change Vagrant box from CentOS to Fedora so we can use the latest tooling.
For development it makes sense to use latest profiling tooling like eBPF, perftools, SystemTap, ...
In centos all those tools are quite ancient because of the 3.11 kernel.

* support for running/testing with different openresty binaries
* install cpan dependencies inside vagrant
* run redis inside vagrant
* respect APICAST_DIR
* performance tune nginx config
* link all tools from openresty systemtap toolkit  
  
  