### PR TITLE
Extract rejection reason in Proxy instead of CacheHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Extract Test::APIcast to own package on CPAN [PR #528](https://github.com/3scale/apicast/pull/528)
 - Load policies by the APIcast loader instead of changing load path [PR #532](https://github.com/3scale/apicast/pull/532), [PR #536](https://github.com/3scale/apicast/pull/536)
 - Add `src` directory to the Lua load path when using CLI [PR #533](https://github.com/3scale/apicast/pull/533)
+- Move rejection reason parsing from CacheHandler to Proxy [PR #541](https://github.com/3scale/apicast/pull/541)
 
 ## [3.2.0-alpha2] - 2017-11-30
 


### PR DESCRIPTION
Extracting the rejection reason and checking if the request has been authorized has nothing to do with the cache. We only need to check the response status and a header. This is why I'd rather not have this in the cache_handler module.

Apart from that, this change will simplify the implementation of the caching policy.