### PR TITLE
[libexec] improve path resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix `apicast` command when installed from luarocks [PR #527](https://github.com/3scale/apicast/pull/527)
 - Fix lua docs formatting in the CORS policy [PR #530](https://github.com/3scale/apicast/pull/530)
 - `post_action` phase not being called in the policy_chain [PR #539](https://github.com/3scale/apicast/pull/539)
+- Failing to execute `libexec/boot` on some systems [PR #544](https://github.com/3scale/apicast/pull/544)
 
 ## Changed
 

--- a/gateway/libexec/run
+++ b/gateway/libexec/run
@@ -1,10 +1,24 @@
-#!/usr/bin/env sh
+#!/usr/bin/env perl
+use Cwd qw(getcwd abs_path);
+use File::Basename qw(dirname basename);
+use File::Temp qw(tempfile);
+use File::Spec::Functions qw(catfile);
 
-ssl=$(mktemp -q)
+my $libexec = abs_path(dirname(abs_path(__FILE__)));
+my $apicast = $ENV{APICAST_DIR} || catfile($libexec, '..');
 
-certificate=${SSL_CERT_FILE:-"$(pwd)/conf/ca-bundle.crt"}
+my $ssl_cert_file = $ENV{SSL_CERT_FILE} || catfile($apicast, 'conf', 'ca-bundle.crt');
+my $lua_file = catfile($libexec, basename(__FILE__) . '.lua');
+my $errlog_level = $ENV{APICAST_LOG_LEVEL} || 'warn';
 
-echo "lua_ssl_verify_depth 5;" >> "${ssl}"
-echo "lua_ssl_trusted_certificate \"${certificate}\";" >> "${ssl}"
+my ($fh, $ssl_conf_file) = tempfile();
 
-exec resty --http-include "${ssl}" "libexec/$(basename "$0").lua" "$@"
+print $fh <<_NGINX_;
+lua_ssl_verify_depth 5;
+lua_ssl_trusted_certificate "${ssl_cert_file}";
+_NGINX_
+
+exec 'resty',
+    '--errlog-level', $errlog_level,
+    '--http-include', $ssl_conf_file,
+    $lua_file, @ARGV;

--- a/gateway/src/apicast/configuration_loader.lua
+++ b/gateway/src/apicast/configuration_loader.lua
@@ -90,8 +90,9 @@ end
 -- Cosocket API is not available in the init_by_lua* context (see more here: https://github.com/openresty/lua-nginx-module#cosockets-not-available-everywhere)
 -- For this reason a new process needs to be started to download the configuration through 3scale API
 function _M.run_external_command(cmd, cwd)
-  local config, err, code = util.system(format('cd %s && libexec/%s',
-    cwd or env.get('TEST_NGINX_APICAST_PATH') or '.',
+  local config, err, code = util.system(format('cd %s && %s/libexec/%s',
+    cwd or  '.',
+    env.get('APICAST_DIR') or env.get('TEST_NGINX_APICAST_PATH') or '.',
     cmd or 'boot'))
 
   -- Try to read the file in current working directory before changing to the prefix.


### PR DESCRIPTION
Improve libexec by:

* Don't change current directory so all relative configuration files can be resolved
* Respect APICAST_DIR
* Use Perl script that is aware of where it is stored on the filesystem
* Respect APICAST_LOG_LEVEL environment 