### PR TITLE
fixes typos

### DIFF
--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -2,7 +2,7 @@
 
 APIcast v2 has a number of parameters configured as [environment variables](#environment-variables) that can modify the behavior of the gateway. The following reference provides descriptions of these parameters.
 
-Note that when deploying APIcast v2 with OpenShift, some of thee parameters can be configured via OpenShift template parameters. The latter can be consulted directly in the [template](https://raw.githubusercontent.com/3scale/apicast/master/openshift/apicast-template.yml).
+Note that when deploying APIcast v2 with OpenShift, some of these parameters can be configured via OpenShift template parameters. The latter can be consulted directly in the [template](https://raw.githubusercontent.com/3scale/apicast/master/openshift/apicast-template.yml).
 
 ## Environment variables
 
@@ -14,7 +14,7 @@ Defines the name of the Lua module that implements custom logic overriding the e
 
 **Default:** _stderr_
 
-Defines the file that will store the OpenResty error log. It is used by `bin/apicast` in the `error_log` directive. Refer to [NGINX documentation](http://nginx.org/en/docs/ngx_core_module.html#error_log) for more information. The file pathcan be either absolute, or relative to the prefix directory (`apicast` by default) 
+Defines the file that will store the OpenResty error log. It is used by `bin/apicast` in the `error_log` directive. Refer to [NGINX documentation](http://nginx.org/en/docs/ngx_core_module.html#error_log) for more information. The file path can be either absolute, or relative to the prefix directory (`apicast` by default) 
 
 ### `APICAST_LOG_LEVEL`
 
@@ -64,12 +64,12 @@ When this parameter is set to _true_, the gateway will use path-based routing in
 **Default:** \<empty\> (_false_)
 
 When set to _true_, APIcast will log the response code of the response returned by the API backend in 3scale. In some plans this information can later be consulted from the 3scale admin portal.
-Find more information about the Response Codes feature on the [3scale support site](https://support.3scale.net/docs/analytics/response-codes-tracking).
+Find more information about the Response Codes feature on the [3scale support site](https://access.redhat.com/documentation/en-us/red_hat_3scale/2.saas/html/analytics/response-codes-tracking).
 
 ### `APICAST_SERVICES`
 **Value:** a comma-separated list of service IDs
 
-Used to filter the services configured in the 3scale API Manager, and only use the configuration for specific services in the gateway, discarding those services IDs of which are not specified in the list.
+Used to filter the services configured in the 3scale API Manager, and only use the configuration for specific services in the gateway, discarding those services' IDs that are not specified in the list.
 Service IDs can be found on the **Dashboard > APIs** page, tagged as _ID for API calls_.
 
 ### `APICAST_CONFIGURATION_CACHE`
@@ -83,19 +83,19 @@ Specifies the interval (in seconds) that the configuration will be stored for. T
 
 **Default:** "127.0.0.1"
 
-APIcast requires a running Redis instance for OAuth 2.0 flow. `REDIS_HOST` parameter is used to set the hostname of the IP of the Redis instance.
+APIcast requires a running Redis instance for OAuth 2.0 Authorization code flow. `REDIS_HOST` parameter is used to set the hostname of the IP of the Redis instance.
 
 ### `REDIS_PORT`
 
 **Default:** 6379
 
-APIcast requires a running Redis instance for OAuth 2.0 flow. `REDIS_PORT` parameter can be used to set the port of the Redis instance.
+APIcast requires a running Redis instance for OAuth 2.0 Authorization code flow. `REDIS_PORT` parameter can be used to set the port of the Redis instance.
 
 ### `REDIS_URL`
 
 **Default:** no value
 
-APIcast requires a running Redis instance for OAuth 2.0 flow. `REDIS_URL` parameter can be used to set the full URI as DSN format like: `redis://PASSWORD@HOST:PORT/DB`. Takes precedence over `REDIS_PORT` and `REDIS_HOST`.
+APIcast requires a running Redis instance for OAuth 2.0 Authorization code flow. `REDIS_URL` parameter can be used to set the full URI as DSN format like: `redis://PASSWORD@HOST:PORT/DB`. Takes precedence over `REDIS_PORT` and `REDIS_HOST`.
 
 ### `APICAST_OAUTH_TOKENS_TTL`
 
@@ -119,7 +119,7 @@ The value will also be used in the header `X-3scale-User-Agent` in the authorize
 
 ### `THREESCALE_PORTAL_ENDPOINT`
 
-URI that includes your password and portal endpoint in following format: `<schema>://<password>@<admin-portal-domain>`. The `<password>` can be either the [provider key](https://support.3scale.net/docs/terminology#apikey) or an [access token](https://support.3scale.net/docs/terminology#tokens) for the 3scale Account Management API. `<admin-portal-domain>` is the URL used to log into the admin portal.
+URI that includes your password and portal endpoint in the following format: `<schema>://<password>@<admin-portal-domain>`. The `<password>` can be either the [provider key](https://support.3scale.net/docs/terminology#apikey) or an [access token](https://support.3scale.net/docs/terminology#tokens) for the 3scale Account Management API. `<admin-portal-domain>` is the URL used to log into the admin portal.
 
 **Example**: `https://access-token@account-admin.3scale.net`.
 
@@ -158,7 +158,7 @@ You should enable the debug level only for debugging.
 
 Replace `${ID}` with the actual Service ID. The value should be the configuration version you can see in the configuration history on the Admin Portal.
 
-Setting it to particual version will make it not auto-update and always use that version.
+Setting it to a particular version will prevent it from auto-updating and will always use that version.
 
 ### `OPENSSL_VERIFY`
 
@@ -178,7 +178,7 @@ certificate bundle generated by [export-builtin-trusted-certs](https://github.co
 **Value:**: integer >= 0
 
 Value greater than 0 is going to enable out-of-band reporting to backend.
-This is new **experimental** feature for increasing performance. Client
-Won't see the backend latency and everything will be processed asynchronously.
-This value determines how many asynchronous reports can be running simultainesly
-before client starts being throttled by adding latency.
+This is a new **experimental** feature for increasing performance. Client
+won't see the backend latency and everything will be processed asynchronously.
+This value determines how many asynchronous reports can be running simultaneously
+before the client is throttled by adding latency.


### PR DESCRIPTION
fixes typos and old links to 3scale support site.

/cc @3scale/documentation 