### PR TITLE
[http_ng] improve performance

### DIFF
--- a/gateway/src/resty/http_ng/headers.lua
+++ b/gateway/src/resty/http_ng/headers.lua
@@ -9,8 +9,8 @@ local getmetatable = getmetatable
 local type = type
 local lower = string.lower
 local upper = string.upper
-local sub = string.sub
 local ngx_re = ngx.re
+local re_gsub = ngx_re.gsub
 
 local normalize_exceptions = {
   etag = 'ETag'
@@ -27,20 +27,17 @@ local headers_mt = {
   end
 }
 
-local capitalize = function(string)
-  return upper(sub(string, 1, 1)) .. sub(string, 2)
+local capitalize = function(m)
+  return upper(m[0])
 end
 
-local regex_parts = [[[^_-]+]]
+local letter = [[\b([a-z])]]
 
-local key_parts_capitalized = function(key)
-  local parts = {}
+local capitalize_header = function(key)
+  key = re_gsub(key, '_', '-', 'jo')
+  key = re_gsub(key, letter, capitalize, 'jo')
 
-  for matches in ngx_re.gmatch(key, regex_parts, 'jo') do
-    insert(parts, capitalize(matches[0]))
-  end
-
-  return parts
+  return key
 end
 
 headers.normalize_key = function(key)
@@ -50,7 +47,7 @@ headers.normalize_key = function(key)
     return exception
   end
 
-  return concat(key_parts_capitalized(key), '-')
+  return capitalize_header(key)
 end
 
 local header_mt = {

--- a/gateway/src/resty/http_ng/request.lua
+++ b/gateway/src/resty/http_ng/request.lua
@@ -1,4 +1,5 @@
-local match = string.match
+local find = string.find
+local sub = string.sub
 local assert = assert
 local setmetatable = setmetatable
 
@@ -19,12 +20,21 @@ local request = { }
 
 request.headers = require 'resty.http_ng.headers'
 
+local function extract_host(url)
+  local _, last = find(url, '://', 0, true)
+  local len = find(url, '/', last + 1, true)
+
+  if len then len = len - 1 end
+
+  return sub(url, last + 1, len)
+end
+
 function request.extract_headers(req)
   local options = req.options or {}
   local headers = request.headers.new(options.headers)
 
   headers.user_agent = headers.user_agent or 'APIcast (+https://www.apicast.io)'
-  headers.host = headers.host or match(req.url, "^.+://([^/]+)")
+  headers.host = headers.host or extract_host(req.url)
   headers.connection = headers.connection or 'Keep-Alive'
 
   options.headers = nil


### PR DESCRIPTION
Try to apply some smaller and bigger optimizations to improve overral performance of the client.

see profiles: https://gist.github.com/mikz/e8d29fcb60374cff1174930658da694c


# Performance


## before

```
wrk --connections 10 --threads 10 --duration 60 'http://localhost:8080/?user_key=foo'
Running 1m test @ http://localhost:8080/?user_key=foo
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     6.15ms    1.86ms  28.68ms   82.61%
    Req/Sec   163.82     22.43   373.00     71.98%
  98004 requests in 1.00m, 35.61MB read
Requests/sec:   1630.88
Transfer/sec:    606.72KB
```


## after

```
wrk --connections 10 --threads 10 --duration 60 'http://localhost:8080/?user_key=foo'
Running 1m test @ http://localhost:8080/?user_key=foo
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     5.71ms    1.45ms  40.24ms   81.81%
    Req/Sec   176.55     24.01   346.00     78.54%
  105626 requests in 1.00m, 38.37MB read
Requests/sec:   1757.55
Transfer/sec:    653.85KB
```