### PR TITLE
[proxy] split proxy:call() into rewrite and access phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `post_action` phase now shares `ngx.ctx` with the main request [PR #539](https://github.com/3scale/apicast/pull/539)
 - Decrease nginx timer resolution to improve performance and enable PCRE JIT [PR #543](https://github.com/3scale/apicast/pull/543)
 - Moved `proxy_pass` into new internal location `@upstream` [PR #535](https://github.com/3scale/apicast/pull/535)
+- Split 3scale authorization to rewrite and access phase [PR #556](https://github.com/3scale/apicast/pull/556)
 
 ## [3.2.0-alpha2] - 2017-11-30
 

--- a/spec/policy/apicast/policy_spec.lua
+++ b/spec/policy/apicast/policy_spec.lua
@@ -9,49 +9,4 @@ describe('APIcast module', function()
   it('has a version', function()
     assert.truthy(_M._VERSION)
   end)
-
-  describe(':access', function()
-
-    local apicast
-
-    before_each(function()
-      apicast = _M.new()
-      ngx.ctx.proxy = {}
-    end)
-
-    it('triggers post action when access phase succeeds', function()
-      ngx.var = { original_request_id = 'foobar' }
-
-      stub(ngx.ctx.proxy, 'call', function()
-        return function() return 'ok' end
-      end)
-
-      stub(ngx.ctx.proxy, 'post_action', function()
-        return 'post_ok'
-      end)
-
-      local ok, err = apicast:access({})
-
-      assert.same('ok', ok)
-      assert.falsy(err)
-
-      assert.same('post_ok', apicast:post_action())
-    end)
-
-    it('skips post action when access phase not executed', function()
-      stub(ngx.ctx.proxy, 'call', function()
-        -- return nothing for example
-      end)
-
-      local ok, err = apicast:access({})
-
-      assert.falsy(ok)
-      assert.falsy(err)
-
-      ngx.ctx.proxy = nil -- in post_action the ctx is not shared
-      ngx.var = { original_request_id = 'foobar' }
-
-      assert.equal(nil, apicast:post_action())
-    end)
-  end)
 end)

--- a/spec/proxy_spec.lua
+++ b/spec/proxy_spec.lua
@@ -17,39 +17,7 @@ describe('Proxy', function()
     assert.same('function', type(proxy.access))
   end)
 
-  describe(':call', function()
-    local service
-    before_each(function()
-      ngx.var = { backend_endpoint = 'http://localhost:1853' }
-      service = Service.new({ id = 42, hosts = { 'localhost' }})
-    end)
-
-    it('has authorize function after call', function()
-      proxy:call(service)
-
-      assert.truthy(proxy.authorize)
-      assert.same('function', type(proxy.authorize))
-    end)
-
-    it('returns access function', function()
-      local access = proxy:call(service)
-
-      assert.same('function', type(access))
-    end)
-
-    it('returns oauth handler when matches oauth route', function()
-      service.backend_version = 'oauth'
-      stub(ngx.req, 'get_method', function() return 'GET' end)
-      ngx.var.uri = '/authorize'
-
-      local access, handler = proxy:call(service)
-
-      assert.equal(nil, access)
-      assert.same('function', type(handler))
-    end)
-  end)
-
-  describe(':access', function()
+  describe(':rewrite', function()
     local service
     before_each(function()
       ngx.var = { backend_endpoint = 'http://localhost:1853', uri = '/a/uri' }
@@ -61,7 +29,7 @@ describe('Proxy', function()
       service.credentials = { location = 'headers' }
       service.backend_version = 2
       ngx.var.http_app_key = 'key'
-      assert.falsy(proxy:access(service))
+      assert.falsy(proxy:rewrite(service))
     end)
   end)
 


### PR DESCRIPTION
fixes https://github.com/3scale/apicast/issues/495

This allows policy authors to modify `usage` in the rewrite phase as it is being used later in the `access` phase. That can be used to for example report custom metrics matched by the policy.