### PR TITLE
Add 'allow' mode in the caching policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - URL rewriting policy [PR #529](https://github.com/3scale/apicast/pull/529)
 - Liquid template can find files in current folder too [PR #533](https://github.com/3scale/apicast/pull/533)
 - `bin/apicast` respects `APICAST_OPENRESTY_BINARY` and `TEST_NGINX_BINARY` environment [PR #540](https://github.com/3scale/apicast/pull/540)
-- Caching policy [PR #546](https://github.com/3scale/apicast/pull/546)
+- Caching policy [PR #546](https://github.com/3scale/apicast/pull/546), [PR #558](https://github.com/3scale/apicast/pull/558)
 - New phase: `content` for generating content or getting the upstream response [PR #535](https://github.com/3scale/apicast/pull/535)
 
 ## Fixed

--- a/gateway/src/apicast/policy/caching/schema.json
+++ b/gateway/src/apicast/policy/caching/schema.json
@@ -5,7 +5,7 @@
   "properties": {
     "exit": {
       "type": "caching_type",
-      "enum": ["resilient", "strict", "none"]
+      "enum": ["resilient", "strict", "allow", "none"]
     }
   }
 }

--- a/t/apicast-policy-caching.t
+++ b/t/apicast-policy-caching.t
@@ -175,3 +175,105 @@ auth error in the odd ones.
 ["yay, api backend\x{0a}", "Authentication failed", "yay, api backend\x{0a}", "Authentication failed"]
 --- error_code eval
 [ 200, 403, 200, 403 ]
+
+=== TEST 4: Caching policy configured as 'allow' with unseen request
+When the cache is configured as 'allow', all requests after the first one will
+be authorized when backend returns a 5XX if they do not have a 'denied' entry
+in the cache.
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.caching",
+            "configuration": { "caching_type": "allow" }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(502)
+    }
+  }
+--- upstream
+  location / {
+     echo 'yay, api backend';
+  }
+--- request eval
+["GET /?user_key=uk1", "GET /?user_key=uk1", "GET /?user_key=uk1"]
+--- response_body eval
+["Authentication failed", "yay, api backend\x{0a}", "yay, api backend\x{0a}"]
+--- error_code eval
+[403, 200, 200]
+
+=== TEST 5: Caching policy configured as 'allow' with previously denied request
+When the cache is configured as 'allow', requests will be denied if the last
+successful request to backend returned 'denied'.
+In order to test this, we use a backend that returns 403 on the first call, and
+502 on the rest.
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.caching",
+            "configuration": { "caching_type": "allow" }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local test_counter = ngx.shared.test_counter or 0
+      if test_counter == 0 then
+        ngx.shared.test_counter = test_counter + 1
+        ngx.exit(403)
+      else
+        ngx.shared.test_counter = test_counter + 1
+        ngx.exit(502)
+      end
+    }
+  }
+--- upstream
+  location / {
+     echo 'yay, api backend';
+  }
+--- request eval
+["GET /?user_key=uk1", "GET /?user_key=uk1", "GET /?user_key=uk1"]
+--- response_body eval
+["Authentication failed", "Authentication failed", "Authentication failed"]
+--- error_code eval
+[403, 403, 403]


### PR DESCRIPTION
This mode caches authorized and denied calls. When backend is unavailable, it will cache an authorization. In practice, this means that when backend is down _any_ request will be authorized unless last call to backend for that request returned 'deny' (status code = 4xx).

Closes #126 