### PR TITLE
Add upstream policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `bin/apicast` respects `APICAST_OPENRESTY_BINARY` and `TEST_NGINX_BINARY` environment [PR #540](https://github.com/3scale/apicast/pull/540)
 - Caching policy [PR #546](https://github.com/3scale/apicast/pull/546), [PR #558](https://github.com/3scale/apicast/pull/558)
 - New phase: `content` for generating content or getting the upstream response [PR #535](https://github.com/3scale/apicast/pull/535)
+- Upstream policy [PR #562](https://github.com/3scale/apicast/pull/562)
 
 ## Fixed
 

--- a/gateway/src/apicast/policy/upstream/policy.lua
+++ b/gateway/src/apicast/policy/upstream/policy.lua
@@ -68,7 +68,10 @@ function _M:content()
 
   for _, rule in ipairs(self.rules) do
     if match(req_uri, rule.regex) then
+      ngx.log(ngx.DEBUG, 'upstream policy uri: ', req_uri, ' regex: ', rule.regex, ' match: true')
       return change_upstream(rule.url)
+    elseif ngx.config.debug then
+      ngx.log(ngx.DEBUG, 'upstream policy uri: ', req_uri, ' regex: ', rule.regex, ' match: false')
     end
   end
 end

--- a/gateway/src/apicast/policy/upstream/policy.lua
+++ b/gateway/src/apicast/policy/upstream/policy.lua
@@ -1,0 +1,76 @@
+--- Upstream policy
+-- This policy allows to modify the host of a request based on its path.
+
+local resty_resolver = require('resty.resolver')
+local resty_url = require('resty.url')
+local format = string.format
+local ipairs = ipairs
+local match = ngx.re.match
+local table = table
+
+local _M = require('apicast.policy').new('Upstream policy')
+
+local new = _M.new
+
+local function proxy_pass(url)
+  local res = format('%s://upstream%s', url.scheme, url.path or '')
+
+  local args = ngx.var.args
+  if url.path and args then
+    res = format('%s?%s', res, args)
+  end
+
+  return res
+end
+
+local function change_upstream(url)
+  ngx.ctx.upstream = resty_resolver:instance():get_servers(
+    url.host, { port = url.port })
+
+  ngx.var.proxy_pass = proxy_pass(url)
+  ngx.req.set_header('Host', url.host)
+
+  -- We need to check that the headers have not already been sent. They could
+  -- have been sent in a different policy, for example.
+  if not ngx.headers_sent then
+    ngx.exec("@upstream")
+  end
+end
+
+-- Parses the urls in the config so we do not have to do it on each request.
+local function init_config(config)
+  if not config or not config.rules then return {} end
+
+  local res = {}
+
+  for _, rule in ipairs(config.rules) do
+    local parsed_url = resty_url.parse(rule.url)
+    table.insert(res, { regex = rule.regex, url = parsed_url })
+  end
+
+  return res
+end
+
+--- Initialize an upstream policy.
+-- @tparam[opt] table config Contains the host rewriting rules.
+-- Each rule consists of:
+--
+--   - regex: regular expression to be matched.
+--   - url: new url in case of match.
+function _M.new(config)
+  local self = new(config)
+  self.rules = init_config(config)
+  return self
+end
+
+function _M:content()
+  local req_uri = ngx.var.uri
+
+  for _, rule in ipairs(self.rules) do
+    if match(req_uri, rule.regex) then
+      return change_upstream(rule.url)
+    end
+  end
+end
+
+return _M

--- a/gateway/src/apicast/policy/upstream/schema.json
+++ b/gateway/src/apicast/policy/upstream/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Upstream policy configuration",
+  "type": "object",
+  "properties": {
+    "rules": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "regex": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": ["regex", "url"]
+      }
+    }
+  }
+}

--- a/t/apicast-policy-upstream.t
+++ b/t/apicast-policy-upstream.t
@@ -1,0 +1,318 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: single rule that matches
+In this test, we provide a rule that matches the request and sets the upstream
+to the one we have set up. If this was not working we would notice, because
+"api_backend" in the service configuration points to an invalid one.
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=uk"
+      local args = ngx.var.args
+      if args == expected then
+        ngx.exit(200)
+      else
+        ngx.log(ngx.ERR, expected, ' did not match: ', args)
+        ngx.exit(403)
+      end
+    }
+  }
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://example.com:80/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/", "url": "http://test:$TEST_NGINX_SERVER_PORT" } ]
+              }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       require('luassert').are.equal('GET /a_path?user_key=uk&a_param=a_value HTTP/1.1',
+                                     ngx.var.request)
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /a_path?user_key=uk&a_param=a_value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 2: multiple rules that match
+In this example, we provide a rule that does not match and two that do.
+Rules should be matched in order, so we set the first rule that matches to the
+upstream we have set up.
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=uk"
+      local args = ngx.var.args
+      if args == expected then
+        ngx.exit(200)
+      else
+        ngx.log(ngx.ERR, expected, ' did not match: ', args)
+        ngx.exit(403)
+      end
+    }
+  }
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://example:80/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [
+                  { "regex": "/i_dont_match", "url": "http://example.com" },
+                  { "regex": "/", "url": "http://test:$TEST_NGINX_SERVER_PORT" },
+                  { "regex": "/abc", "url": "http://example.com" }
+                ]
+              }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       require('luassert').are.equal('GET /a_path?user_key=uk&a_param=a_value HTTP/1.1',
+                                     ngx.var.request)
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /a_path?user_key=uk&a_param=a_value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 3: non-matching rules
+In this example, none of the rules match, so the request will go to the
+upstream in 'api_backend'.
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=uk"
+      local args = ngx.var.args
+      if args == expected then
+        ngx.exit(200)
+      else
+        ngx.log(ngx.ERR, expected, ' did not match: ', args)
+        ngx.exit(403)
+      end
+    }
+  }
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [
+                  { "regex": "/i_dont_match", "url": "http://example.com" },
+                  { "regex": "/i_dont_either", "url": "http://example.com" },
+                  { "regex": "/nope", "url": "http://example.com" }
+                ]
+              }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       require('luassert').are.equal('GET /a_path?user_key=uk&a_param=a_value HTTP/1.1',
+                                     ngx.var.request)
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /a_path?user_key=uk&a_param=a_value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 4: rule that matches contains url with path
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=uk"
+      local args = ngx.var.args
+      if args == expected then
+        ngx.exit(200)
+      else
+        ngx.log(ngx.ERR, expected, ' did not match: ', args)
+        ngx.exit(403)
+      end
+    }
+  }
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://example.com",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [
+                  {
+                    "regex": "/",
+                    "url": "http://test:$TEST_NGINX_SERVER_PORT/path_in_the_rule"
+                  }
+                ]
+              }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /path_in_the_rule {
+     content_by_lua_block {
+       require('luassert').are.equal('GET /path_in_the_rule?user_key=uk&a_param=a_value HTTP/1.1',
+                                     ngx.var.request)
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /some_path?user_key=uk&a_param=a_value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 5: rule that matches a POST request
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=uk"
+      local args = ngx.var.args
+      if args == expected then
+        ngx.exit(200)
+      else
+        ngx.log(ngx.ERR, expected, ' did not match: ', args)
+        ngx.exit(403)
+      end
+    }
+  }
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://example.com:80/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/", "url": "http://test:$TEST_NGINX_SERVER_PORT" } ]
+              }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       local luassert = require('luassert')
+
+       luassert.are.equal('POST /a_path HTTP/1.1', ngx.var.request)
+
+       ngx.req.read_body()
+       local post_args = ngx.req.get_post_args()
+       luassert.are.equal('uk', post_args['user_key'])
+       luassert.are.equal('a_value', post_args['a_param'])
+
+       ngx.say('yay, api backend')
+     }
+  }
+--- request
+POST /a_path
+user_key=uk&a_param=a_value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]

--- a/t/apicast-policy-upstream.t
+++ b/t/apicast-policy-upstream.t
@@ -316,3 +316,40 @@ yay, api backend
 --- error_code: 200
 --- no_error_log
 [error]
+
+
+
+=== TEST 6: without apicast policy
+Upstream policy should work if used standalone without apicast policy.
+--- configuration
+{
+  "services": [
+    {
+      "proxy": {
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/", "url": "http://test:$TEST_NGINX_SERVER_PORT" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       require('luassert').are.equal('GET /a_path? HTTP/1.1',
+                                     ngx.var.request)
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /a_path?
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]


### PR DESCRIPTION
This is a first version of the upstream policy. For now, it only allows to modify the host of a request based on a set of rules that act on its path, but we can add more functionality later.