### PR TITLE
[busted] test runner improvements

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -14,7 +14,7 @@ chdir "$dirname/..";
 my $apicast = getcwd();
 
 exec '/usr/bin/env', 'resty',
-    '--errlog-level', 'alert',
+    '--errlog-level', $ENV{APICAST_LOG_LEVEL} || 'alert',
     '--http-include', "$apicast/spec/fixtures/echo.conf",
     "$apicast/bin/busted.lua",
     '--config-file', "$apicast/.busted",

--- a/bin/busted
+++ b/bin/busted
@@ -13,6 +13,8 @@ chdir "$dirname/..";
 
 my $apicast = getcwd();
 
+$ENV{APICAST_DIR} ||= "$apicast/gateway";
+
 exec '/usr/bin/env', 'resty',
     '--errlog-level', $ENV{APICAST_LOG_LEVEL} || 'alert',
     '--http-include', "$apicast/spec/fixtures/echo.conf",


### PR DESCRIPTION
So busted tests can print debug output from nginx by setting APICAST_LOG_LEVEL.
And so that tests know where is the APIcast source code.

Extracted from #566.