### PR TITLE
policy/cors: stop setting headers twice in preflight reqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Failing to execute `libexec/boot` on some systems [PR #544](https://github.com/3scale/apicast/pull/544)
 - Detect number of CPU cores in containers by using `nproc` [PR #554](https://github.com/3scale/apicast/pull/554)
 - Running with development config in Docker [PR #555](https://github.com/3scale/apicast/pull/555)
+- Fix setting twice the headers in a pre-flight request in the CORS policy [PR #570](https://github.com/3scale/apicast/pull/570)
 
 ## Changed
 

--- a/gateway/src/apicast/policy/cors/policy.lua
+++ b/gateway/src/apicast/policy/cors/policy.lua
@@ -60,8 +60,8 @@ local function set_cors_headers(config)
   set_access_control_allow_credentials(config.allow_credentials)
 end
 
-local function cors_preflight_response(config)
-  set_cors_headers(config)
+local function cors_preflight_response()
+  -- with ngx.exit(204), header_filter is run. CORS headers will be set there.
   ngx.status = 204
   ngx.exit(ngx.status)
 end
@@ -72,9 +72,9 @@ local function is_cors_preflight()
          ngx.var.http_access_control_request_method
 end
 
-function _M:rewrite()
+function _M.rewrite(_)
   if is_cors_preflight() then
-    return cors_preflight_response(self.config)
+    return cors_preflight_response()
   end
 end
 


### PR DESCRIPTION
This PR introduces a minor improvement in the CORS policy.
In the case of a preflight request, we were setting the CORS headers twice. This PR fixes that.

Thanks @mayorova for reporting.