### PR TITLE
Fix tests that expect debug output without enabling the option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Detect number of CPU cores in containers by using `nproc` [PR #554](https://github.com/3scale/apicast/pull/554)
 - Running with development config in Docker [PR #555](https://github.com/3scale/apicast/pull/555)
 - Fix setting twice the headers in a pre-flight request in the CORS policy [PR #570](https://github.com/3scale/apicast/pull/570)
+- Fix case where debug headers are returned without enabling the option [PR #577](https://github.com/3scale/apicast/pull/577)
 
 ## Changed
 

--- a/gateway/src/apicast/proxy.lua
+++ b/gateway/src/apicast/proxy.lua
@@ -110,14 +110,15 @@ local function error_service_not_found(host)
 end
 -- End Error Codes
 
-local function get_debug_value(service)
-  return ngx.var.http_x_3scale_debug == service.backend_authentication.value
+local function debug_header_enabled(service)
+  local debug_header_value = ngx.var.http_x_3scale_debug
+  return debug_header_value and debug_header_value == service.backend_authentication.value
 end
 
 local function output_debug_headers(service, usage, credentials)
   ngx.log(ngx.INFO, 'usage: ', usage, ' credentials: ', credentials)
 
-  if get_debug_value(service) then
+  if debug_header_enabled(service) then
     ngx.header["X-3scale-matched-rules"] = ngx.ctx.matched_patterns
     ngx.header["X-3scale-credentials"]   = credentials
     ngx.header["X-3scale-usage"]         = usage

--- a/t/apicast-mapping-rules.t
+++ b/t/apicast-mapping-rules.t
@@ -62,6 +62,8 @@ url params in a POST call are taken into account when matching mapping rules.
         {
           id = 42,
           backend_version = 1,
+          backend_authentication_type = 'service_token',
+          backend_authentication_value = 'my-token',
           proxy = {
             api_backend = 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api/',
             proxy_rules = {
@@ -88,6 +90,8 @@ url params in a POST call are taken into account when matching mapping rules.
   }
 --- request
 POST /foo?bar=baz&user_key=somekey
+--- more_headers
+X-3scale-Debug: my-token
 --- response_body
 api response
 --- error_code: 200
@@ -107,6 +111,8 @@ request body params in a POST call are taken into account when matching mapping 
         {
           id = 42,
           backend_version = 1,
+          backend_authentication_type = 'service_token',
+          backend_authentication_value = 'my-token',
           proxy = {
             api_backend = 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api/',
             proxy_rules = {
@@ -134,6 +140,8 @@ request body params in a POST call are taken into account when matching mapping 
 --- request
 POST /foo?user_key=somekey
 bar=baz
+--- more_headers
+X-3scale-Debug: my-token
 --- response_body
 api response
 --- error_code: 200
@@ -155,6 +163,8 @@ precedence.
         {
           id = 42,
           backend_version = 1,
+          backend_authentication_type = 'service_token',
+          backend_authentication_value = 'my-token',
           proxy = {
             api_backend = 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api/',
             proxy_rules = {
@@ -182,6 +192,8 @@ precedence.
 --- request
 POST /foo?a_param=val3&another_param=val2&user_key=somekey
 a_param=val1
+--- more_headers
+X-3scale-Debug: my-token
 --- response_body
 api response
 --- error_code: 200

--- a/t/apicast.t
+++ b/t/apicast.t
@@ -309,6 +309,8 @@ When mapping rule has a parameter with fixed value it has to be matched.
         {
           id = 42,
           backend_version = 1,
+          backend_authentication_type = 'service_token',
+          backend_authentication_value = 'my-token',
           proxy = {
             api_backend = 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api/',
             proxy_rules = {
@@ -333,6 +335,8 @@ When mapping rule has a parameter with fixed value it has to be matched.
   }
 --- request
 GET /foo?bar=baz&user_key=somekey
+--- more_headers
+X-3scale-Debug: my-token
 --- response_body
 api response
 --- response_headers
@@ -352,6 +356,8 @@ When mapping rule has a parameter with variable value it has to exist.
         {
           id = 42,
           backend_version = 1,
+          backend_authentication_type = 'service_token',
+          backend_authentication_value = 'my-token',
           proxy = {
             api_backend = 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api/',
             proxy_rules = {
@@ -376,6 +382,8 @@ When mapping rule has a parameter with variable value it has to exist.
   }
 --- request
 GET /foo?bar={foo}&user_key=somekey
+--- more_headers
+X-3scale-Debug: my-token
 --- response_body
 api response
 --- error_code: 200


### PR DESCRIPTION
This PR fixes the tests that expect response debug headers to be set without enabling the debug option via headers.