### PR TITLE
Extract MappingRulesMatcher and Usage modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Extract `mapping_rule` module from the `configuration` module [PR #571](https://github.com/3scale/apicast/pull/571)
 - Renamed `apicast/policy/policy.lua` to `apicast/policy.lua` [PR #569](https://github.com/3scale/apicast/pull/569)
 - Sandbox loading policies [PR #566](https://github.com/3scale/apicast/pull/566)
+- Extracted `usage` and `mapping_rules_matcher` modules so they can be used from policies [PR #580](https://github.com/3scale/apicast/pull/580)
 
 ## [3.2.0-alpha2] - 2017-11-30
 

--- a/gateway/src/apicast/mapping_rules_matcher.lua
+++ b/gateway/src/apicast/mapping_rules_matcher.lua
@@ -1,0 +1,53 @@
+--- Mapping rules matcher
+-- @module mapping_rules_matcher
+-- Matches a request against a set of mapping rules and calculates the usage
+-- that needs to be authorized and reported according to the rules that match.
+
+local ipairs = ipairs
+local insert = table.insert
+local Usage = require('apicast.usage')
+
+local _M = {}
+
+--- Calculate usage from matching mapping rules.
+-- Matches a request against a set of mapping rules and returns the resulting
+-- usage and the matched rules.
+-- @tparam string method HTTP method.
+-- @tparam string uri URI.
+-- @tparam table args Request arguments.
+-- @tparam table rules Mapping rules to be matched.
+-- @treturn Usage Calculated usage.
+-- @treturn table Matched rules.
+function _M.get_usage_from_matches(method, uri, args, rules)
+  local usage = Usage.new()
+  local matched_rules = {}
+
+  for _, rule in ipairs(rules) do
+    if rule:matches(method, uri, args) then
+      -- Some rules have no delta. Send 0 in that case.
+      usage:add(rule.system_name, rule.delta or 0)
+      insert(matched_rules, rule)
+    end
+  end
+
+  return usage, matched_rules
+end
+
+--- Check if there is a mapping rule that matches.
+-- @tparam string method HTTP method.
+-- @tparam string uri URI.
+-- @tparam table args Request arguments.
+-- @tparam table rules Mapping rules to be matched.
+-- @treturn boolean Whether there is a match.
+-- @treturn integer|nil Index of the first matched rule.
+function _M.matches(method, uri, args, rules)
+  for i, rule in ipairs(rules) do
+    if rule:matches(method, uri, args) then
+      return true, i
+    end
+  end
+
+  return false
+end
+
+return _M

--- a/gateway/src/apicast/policy/apicast/policy.lua
+++ b/gateway/src/apicast/policy/apicast/policy.lua
@@ -56,7 +56,7 @@ function _M:rewrite(context)
     ngx.ctx.service = service
 
     -- it is possible that proxy:rewrite will terminate the request
-    p:rewrite(service)
+    p:rewrite(service, context)
   end
 
   p.set_upstream(service)

--- a/gateway/src/apicast/proxy.lua
+++ b/gateway/src/apicast/proxy.lua
@@ -254,7 +254,7 @@ local function handle_oauth(service)
   return oauth
 end
 
-function _M:rewrite(service)
+function _M:rewrite(service, context)
   service = _M.set_service(service or ngx.ctx.service)
 
   -- handle_oauth can terminate the request

--- a/gateway/src/apicast/usage.lua
+++ b/gateway/src/apicast/usage.lua
@@ -1,0 +1,64 @@
+--- Usage
+-- @module usage
+-- Usage to be authorized and reported against 3scale's backend.
+
+local setmetatable = setmetatable
+local ipairs = ipairs
+local insert = table.insert
+
+local _M = {}
+
+local mt = { __index = _M }
+
+--- Initialize a usage.
+-- @return usage New usage.
+function _M.new()
+  local self = setmetatable({}, mt)
+
+  -- table where the keys are metrics and the values their deltas.
+  self.deltas = {}
+
+  -- table that contains the metrics that have a delta associated.
+  -- It's useful to iterate over the deltas without using '.pairs'.
+  -- That's what we are doing in .merge().
+  -- We want to avoid using '.pairs' because is not jitted, '.ipairs' is.
+  self.metrics = {}
+
+  return self
+end
+
+--- Add a metric usage.
+-- Increases the usage of the given metric by the given value. If the metric
+-- is not in the usage, it will be included.
+-- Note that this mutates self.
+-- @tparam string metric Metric.
+-- @tparam integer value Value.
+function _M:add(metric, value)
+  if self.deltas[metric] then
+    self.deltas[metric] = self.deltas[metric] + value
+  else
+    self.deltas[metric] = value
+    insert(self.metrics, metric)
+  end
+end
+
+--- Merge usages
+-- Merges two usages. This means that:
+--
+-- 1) When a metric appears in both usages, its delta is updated in self by
+--    adding the two values.
+-- 2) When a metric does not appear in self, it is added in self.
+--
+-- Note that this mutates self.
+-- @tparam another_usage Usage Usage.
+function _M:merge(another_usage)
+  local another_usage_metrics = another_usage.metrics
+  local another_usage_deltas = another_usage.deltas
+
+  for _, metric in ipairs(another_usage_metrics) do
+    local delta = another_usage_deltas[metric]
+    self:add(metric, delta)
+  end
+end
+
+return _M

--- a/spec/mapping_rules_matcher_spec.lua
+++ b/spec/mapping_rules_matcher_spec.lua
@@ -1,0 +1,52 @@
+local mapping_rules_matcher = require('apicast.mapping_rules_matcher')
+
+describe('mapping_rules_matcher', function()
+  local func_true = function() return true end
+  local func_false = function() return false end
+
+  -- Test rules. Instead of instantiating mapping rules, we just mock the
+  -- methods and attributes we are interested in, for simplicity.
+  local rule_1 = { matches = func_true, system_name = 'hits', delta = 1 }
+  local rule_2 = { matches = func_false, system_name = 'hits', delta = 2 }
+  local rule_3 = { matches = func_true, system_name = 'hits', delta = 3 }
+  local rules = { rule_1, rule_2, rule_3 }
+
+  describe('.get_usage_from_matches', function()
+    local usage, matched_rules = mapping_rules_matcher.get_usage_from_matches(
+      'GET', '/', {}, rules)
+
+    it('returns the usage from matching the mapping rules', function()
+      assert.same({ hits = 4 }, usage.deltas)
+    end)
+
+    it('returns the rules that matched', function()
+      assert.same({ rule_1, rule_3 } , matched_rules)
+    end)
+  end)
+
+  describe('.matches', function()
+    describe('when there is a match', function()
+      local not_maching_rule = { matches = func_false }
+      local matching_rule = { matches = func_true }
+
+      it('returns true and the index of the first rule that matches', function()
+        local matches, index = mapping_rules_matcher.matches(
+          'GET', '/', {}, { not_maching_rule, matching_rule })
+
+        assert.is_true(matches)
+        assert.equals(2, index)
+      end)
+    end)
+
+    describe('when there is not a match', function()
+      local not_matching_rule = { matches = func_false }
+
+      it('returns false', function()
+        local matches = mapping_rules_matcher.matches(
+          'GET', '/', {}, { not_matching_rule })
+
+        assert.is_false(matches)
+      end)
+    end)
+  end)
+end)

--- a/spec/proxy_spec.lua
+++ b/spec/proxy_spec.lua
@@ -3,6 +3,7 @@ local lrucache = require('resty.lrucache')
 
 local configuration_store = require 'apicast.configuration_store'
 local Service = require 'apicast.configuration.service'
+local Usage = require 'apicast.usage'
 
 describe('Proxy', function()
   local configuration, proxy
@@ -63,9 +64,10 @@ describe('Proxy', function()
 
       stub(proxy, 'cache_handler').returns(true)
 
-      proxy:authorize(service, { foo = 0 }, { client_id = 'blah' }, ttl)
+      proxy:authorize(service, { ['usage[foo]'] = 0 }, { client_id = 'blah' }, ttl)
 
-      assert.spy(proxy.cache_handler).was.called_with(proxy.cache, 'client_id=blah:foo=0', response, ttl)
+      assert.spy(proxy.cache_handler).was.called_with(
+        proxy.cache, 'client_id=blah:usage%5Bfoo%5D=0', response, ttl)
     end)
 
     it('works with no ttl', function()
@@ -75,9 +77,10 @@ describe('Proxy', function()
       stub(ngx_backend, 'send', function() return response end)
       stub(proxy, 'cache_handler').returns(true)
 
-      proxy:authorize(service, { foo = 0 }, { client_id = 'blah' })
+      proxy:authorize(service, { ['usage[foo]'] = 0 }, { client_id = 'blah' })
 
-      assert.spy(proxy.cache_handler).was.called_with(proxy.cache, 'client_id=blah:foo=0', response, nil)
+      assert.spy(proxy.cache_handler).was.called_with(
+        proxy.cache, 'client_id=blah:usage%5Bfoo%5D=0', response, nil)
     end)
   end)
 

--- a/spec/proxy_spec.lua
+++ b/spec/proxy_spec.lua
@@ -64,7 +64,9 @@ describe('Proxy', function()
 
       stub(proxy, 'cache_handler').returns(true)
 
-      proxy:authorize(service, { ['usage[foo]'] = 0 }, { client_id = 'blah' }, ttl)
+      local usage = Usage.new()
+      usage:add('foo', 0)
+      proxy:authorize(service, usage, { client_id = 'blah' }, ttl)
 
       assert.spy(proxy.cache_handler).was.called_with(
         proxy.cache, 'client_id=blah:usage%5Bfoo%5D=0', response, ttl)
@@ -77,7 +79,9 @@ describe('Proxy', function()
       stub(ngx_backend, 'send', function() return response end)
       stub(proxy, 'cache_handler').returns(true)
 
-      proxy:authorize(service, { ['usage[foo]'] = 0 }, { client_id = 'blah' })
+      local usage = Usage.new()
+      usage:add('foo', 0)
+      proxy:authorize(service, usage, { client_id = 'blah' })
 
       assert.spy(proxy.cache_handler).was.called_with(
         proxy.cache, 'client_id=blah:usage%5Bfoo%5D=0', response, nil)

--- a/spec/usage_spec.lua
+++ b/spec/usage_spec.lua
@@ -1,0 +1,90 @@
+local Usage = require('apicast.usage')
+
+describe('usage', function()
+  describe('.add', function()
+    describe('when the metric is already present in the usage', function()
+      it('adds the given value to the existing one', function()
+        local usage = Usage.new()
+
+        usage:add('hits', 1)
+        assert.same({ hits = 1 }, usage.deltas )
+
+        usage:add('hits', 1)
+        assert.same({ hits = 2 }, usage.deltas)
+      end)
+    end)
+
+    describe('when the metric is not in the usage', function()
+      it('adds it with the given value', function()
+        local usage = Usage.new()
+        usage:add('hits', 1)
+
+        assert.same({ hits = 1 }, usage.deltas)
+      end)
+    end)
+  end)
+
+  describe('.merge', function()
+    describe('when a metric appears in both usages', function()
+      it('mutates self adding the deltas', function()
+        local a_usage = Usage.new()
+        a_usage:add('a', 1)
+        a_usage:add('b', 1)
+
+        local another_usage = Usage.new()
+        another_usage:add('a', 2)
+        another_usage:add('b', 2)
+
+        a_usage:merge(another_usage)
+
+        assert.same({ a = 3, b = 3 }, a_usage.deltas)
+      end)
+    end)
+
+    describe('when a metric of the given usage is not in self', function()
+      it('adds the metric in self', function()
+        local a_usage = Usage.new()
+        a_usage:add('a', 1)
+
+        local another_usage = Usage.new()
+        another_usage:add('b', 1)
+
+        a_usage:merge(another_usage)
+
+        assert.same({ a = 1, b = 1 }, a_usage.deltas)
+      end)
+    end)
+
+    describe('when the other usage does not contain any deltas', function()
+      it('leaves self unchanged', function()
+        local a_usage = Usage.new()
+        a_usage:add('a', 1)
+
+        a_usage:merge(Usage.new())
+
+        assert.same({ a = 1 }, a_usage.deltas)
+      end)
+    end)
+  end)
+
+  describe('.metrics', function()
+    it('returns a table without duplicates with all the metrics that have a delta', function()
+      local usage = Usage.new()
+      usage:add('hits', 1)
+      usage:add('hits', 1) -- try adding a metric that already exists
+      usage:add('some_metric', 1)
+
+      -- Try merging with a usage with the same metrics.
+      local another_usage = Usage.new()
+      another_usage:add('hits', 1)
+      another_usage:add('some_metric', 1)
+      usage:merge(another_usage)
+
+      local metrics = usage.metrics
+
+      -- The method does not guarantee any order in the result
+      assert.is_true((metrics[1] == 'hits' and metrics[2] == 'some_metric') or
+          (metrics[1] == 'some_metric' and metrics[2] == 'hits'))
+    end)
+  end)
+end)


### PR DESCRIPTION
This PR:
* Extracts a Usage module. This allows us to 'merge' usages hiding the internal data structures.
* Extracts a MappingRulesMatcher. This will allow us to match rules from policies.

These 2 things are needed to implement the SOAP policy (#567)