### PR TITLE
An openshift template that builds apicast from source

### DIFF
--- a/openshift/apicast-build-template.yaml
+++ b/openshift/apicast-build-template.yaml
@@ -5,15 +5,15 @@ labels:
 metadata:
   annotations:
     description: |-
-      A BuildConfig for OpenShift that builds images of Apicast from source.
-    openshift.io/display-name: Apicast BuildConfig
+      A BuildConfig for OpenShift that builds images of APIcast from source.
+    openshift.io/display-name: APIcast BuildConfig
     template.openshift.io/documentation-url: https://github.com/3scale/apicast
-    template.openshift.io/long-description: Builds images of Apicast
+    template.openshift.io/long-description: Builds images of APIcast
     template.openshift.io/provider-display-name: 3scale
     template.openshift.io/support-url: https://github.com/3scale/apicast/issues
   name: apicast-build
 parameters:
-- description: The Apicast GIT repository to build.
+- description: The APIcast GIT repository to build.
   displayName: GIT Repo URL
   name: GIT_REPO
   value: https://github.com/3scale/apicast.git

--- a/openshift/apicast-build-template.yaml
+++ b/openshift/apicast-build-template.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: apicast-build
+metadata:
+  annotations:
+    description: |-
+      A BuildConfig for OpenShift that builds images of Apicast from source.
+    openshift.io/display-name: Apicast BuildConfig
+    template.openshift.io/documentation-url: https://github.com/3scale/apicast
+    template.openshift.io/long-description: Builds images of Apicast
+    template.openshift.io/provider-display-name: 3scale
+    template.openshift.io/support-url: https://github.com/3scale/apicast/issues
+  name: apicast-build
+parameters:
+- description: The Apicast GIT repository to build.
+  displayName: GIT Repo URL
+  name: GIT_REPO
+  value: https://github.com/3scale/apicast.git
+
+- description: The GIT reference (branch/tag) to use.
+  displayName: GIT Reference
+  name: GIT_REF
+  value: master
+
+- description: The OpenResty S2I Builder Image to use.
+  displayName: OpenResty S2I Builder Image
+  name: OPENRESTY_BUILDER_IMAGE
+  value: quay.io/3scale/s2i-openresty-centos7:master
+
+objects:
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: apicast
+    name: apicast
+  spec:
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: apicast
+    name: s2i-openresty-centos7
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: ${OPENRESTY_BUILDER_IMAGE}
+      name: builder
+    - from:
+        kind: DockerImage
+        name: ${OPENRESTY_BUILDER_IMAGE}-runtime
+      name: runtime
+
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    labels:
+      app: apicast
+    name: apicast
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: apicast:latest
+    source:
+      contextDir: gateway
+      git:
+        uri: "${GIT_REPO}"
+        ref: "${GIT_REF}"
+      type: Git
+    strategy:
+      sourceStrategy:
+        forcePull: true
+        from:
+          kind: ImageStreamTag
+          name: s2i-openresty-centos7:builder
+        runtimeImage:
+          kind: ImageStreamTag
+          name: s2i-openresty-centos7:runtime
+      type: Source
+    triggers:
+    - type: ConfigChange
+    - type: ImageChange


### PR DESCRIPTION
When working on Apicast, such as developing policies or customizations, it might be good to have Continuous Integration and sometimes Continuous Delivery. 

This pull requests is a template for OpenShift that enables CI/CD. Once the template instanciated, a two-stage buildconfig is created (first a custom builder, then the apicast build using this custom builder). 

If you want to give it a try, on an OCP cluster you can use : 
```
oc process -f build-template.yaml -p GIT_REPO=https://github.com/nmasse-itix/3scale-apicast.git -p GIT_REFERENCE=openshift-builder-latest -p OPENSHIFT_BASE_IMAGE=registry.access.redhat.com/openshift3/ose:v3.7 |oc create -f -
```

Or on a minishift/OpenShift origin, you can use :
```
oc process -f build-template.yaml -p GIT_REPO=https://github.com/nmasse-itix/3scale-apicast.git -p GIT_REFERENCE=openshift-builder-latest |oc create -f -
```

The build can then be triggered from Jenkins, as usual. 
