### PR TITLE
[bin] honour APICAST_LOG_LEVEL env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Policy JSON manifest [PR #565](https://github.com/3scale/apicast/pull/565)
 - SOAP policy [PR #567](https://github.com/3scale/apicast/pull/567)
 - Ability to set custom directories to load policies from [PR #581](https://github.com/3scale/apicast/pull/581)
+- CLI is running with proper log level set by `APICAST_LOG_LEVEL` [PR #585](https://github.com/3scale/apicast/pull/585)
 
 ## Fixed
 

--- a/gateway/bin/apicast
+++ b/gateway/bin/apicast
@@ -95,6 +95,10 @@ if (defined $nginx) {
     push @resty_args, '--nginx', $nginx;
 }
 
+if (defined $ENV{APICAST_LOG_LEVEL}) {
+    push @resty_args, '--errlog-level', $ENV{APICAST_LOG_LEVEL};
+}
+
 # Add directories to the lua load path.
 # APIcast source and a local src directory.
 for my $inc ($apicast_src, 'src') {


### PR DESCRIPTION
* so the first resty instance is started with proper log level