### PR TITLE
[circleci] update s2i-openresty

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     environment:
       S2I_VERSION: "1.1.7-226afa1"
       DOCKER_COMPOSE_VERSION: "1.16.1"
-      OPENRESTY_VERSION: "1.13.6.1-rover5"
+      OPENRESTY_VERSION: "1.13.6.1-rover6"
     steps:
       - run: apk update && apk add wget make bash curl py-pip git openssh-client
       - run: |
@@ -38,7 +38,7 @@ jobs:
       - run: make lint-schema
   build:
     docker:
-      - image: quay.io/3scale/s2i-openresty-centos7:1.13.6.1-rover5
+      - image: quay.io/3scale/s2i-openresty-centos7:1.13.6.1-rover6
         environment:
           TEST_NGINX_BINARY: openresty
           LUA_BIN_PATH: /opt/app-root/bin


### PR DESCRIPTION
should result in faster builds
https://github.com/3scale/s2i-openresty/releases/tag/1.13.6.1-rover6