### PR TITLE
Fix version in json schema of example policy

### DIFF
--- a/examples/policies/ngx-example/1.0.0/apicast-policy.json
+++ b/examples/policies/ngx-example/1.0.0/apicast-policy.json
@@ -5,7 +5,7 @@
   ["This policy is meant to be just an example.",
     "It sets request headers based on the configuration.",
     "And prints a log entry for each header set. " ],
-  "version": "0.1",
+  "version": "1.0.0",
   "configuration": {
     "type": "object",
     "properties": {


### PR DESCRIPTION
Minor fix. The version of the schema did not match the version in the directory of the policy.