### PR TITLE
Update Test::APIcast to v0.07

### DIFF
--- a/gateway/conf/nginx.conf.liquid
+++ b/gateway/conf/nginx.conf.liquid
@@ -62,7 +62,7 @@ http {
   server {
     listen {{ port.management | default: 8090 }};
 
-    server_name management _;
+    server_name {{ server_name.management | default: 'management _' }};
 
     {% include "conf.d/management.conf" %}
   }

--- a/gateway/cpanfile
+++ b/gateway/cpanfile
@@ -1,2 +1,2 @@
-requires 'Test::APIcast', '0.06';
+requires 'Test::APIcast', '0.07';
 requires 'Crypt::JWT';


### PR DESCRIPTION
Updates Test::Apicast to v0.07 http://search.cpan.org/~mcichra/Test-APIcast-0.07/
This allows us to test the management API using `Test::APIcast::Blackbox`.