### PR TITLE
Endpoint to fetch JSON manifests of policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - CLI is running with proper log level set by `APICAST_LOG_LEVEL` [PR #585](https://github.com/3scale/apicast/pull/585)
 - 3scale configuration (staging/production) can be passed as `-3` or `--channel` on the CLI [PR #590](https://github.com/3scale/apicast/pull/590)
 - APIcast CLI loads environments defined by `APICAST_ENVIRONMENT` variable [PR #590](https://github.com/3scale/apicast/pull/590)
+- Endpoint in management API to retrieve all the JSON manifests of the policies [PR #592](https://github.com/3scale/apicast/pull/592)
 
 ## Fixed
 

--- a/gateway/cpanfile
+++ b/gateway/cpanfile
@@ -1,2 +1,3 @@
 requires 'Test::APIcast', '0.08';
 requires 'Crypt::JWT';
+requires 'Data::Compare';

--- a/gateway/src/apicast/policy_manifests_loader.lua
+++ b/gateway/src/apicast/policy_manifests_loader.lua
@@ -1,0 +1,99 @@
+--- Policy manifests loader
+-- Finds the manifests for the builtin policies and the other ones loaded.
+
+local pl_file = require('pl.file')
+local pl_dir = require('pl.dir')
+local pl_path = require('pl.path')
+local cjson = require('cjson')
+local format = string.format
+local ipairs = ipairs
+local insert = table.insert
+local policy_loader = require('apicast.policy_loader')
+
+local _M = {}
+
+local builtin_policy_load_path = policy_loader.builtin_policy_load_path
+local policy_load_paths = policy_loader.policy_load_paths
+
+local policy_manifest_name = 'apicast-policy.json'
+
+local function dir_iter(dir)
+  return ipairs(pl_dir.getdirectories(dir))
+end
+
+-- Returns the manifests for all the built-in policies.
+local function all_builtin_policy_manifests()
+  local manifests = {}
+
+  for _, policy_dir in dir_iter(builtin_policy_load_path()) do
+    local manifest_file = format('%s/%s', policy_dir, policy_manifest_name)
+    local manifest = pl_file.read(manifest_file)
+    if manifest then insert(manifests, cjson.decode(manifest)) end
+  end
+
+  return manifests
+end
+
+-- Returns a manifest from a 'version' directory. Policies that are not
+-- built-in, are located in a path like policies/my_policy/1.0.0.
+-- This function tries to fetch a manifest starting from that `1.0.0` directory.
+-- It looks for the json manifest, gets its version, and compares it against the
+-- version in the directory.
+-- Returns the manifest when found. When it's not present or there's a version
+-- mismatch, it returns nil.
+local function get_manifest_from_version_dir(version_dir)
+  local manifest_file = format('%s/%s', version_dir, policy_manifest_name)
+  local manifest = pl_file.read(manifest_file)
+
+  if manifest then
+    local decoded_manifest = cjson.decode(manifest)
+    local version_in_manifest = decoded_manifest.version
+    local version_in_path = pl_path.basename(version_dir)
+
+    if version_in_path == version_in_manifest then
+      return decoded_manifest
+    else
+      ngx.log(ngx.WARN,
+        'Could not load ', decoded_manifest.name,
+        ' version in manifest is ', version_in_manifest,
+        ' but version in path is ', version_in_path)
+    end
+  end
+end
+
+-- Returns all the non-built-in manifests from the paths specified by the user.
+-- These paths always follow the same pattern. It contains a directory for each
+-- policy, and each of those contain a directory for each version of that
+-- policy. The json manifest is in that 'version' directory.
+local function all_loaded_policy_manifests()
+  local manifests = {}
+
+  for _, load_path in ipairs(policy_load_paths()) do
+    if pl_path.exists(load_path) then
+      for _, policy_dir in dir_iter(load_path) do
+        for _, version_dir in dir_iter(policy_dir) do
+          local manifest = get_manifest_from_version_dir(version_dir)
+          if manifest then insert(manifests, manifest) end
+        end
+      end
+    end
+  end
+
+  return manifests
+end
+
+--- Get the manifests for all the policies. Both the builtin policies and the
+-- ones present in the directories configured as directories that can
+-- include policies.
+-- @treturn table Manifests for all the policies.
+function _M.get_all()
+  local manifests = all_builtin_policy_manifests()
+
+  for _, manifest in ipairs(all_loaded_policy_manifests()) do
+    insert(manifests, manifest)
+  end
+
+  return manifests
+end
+
+return _M

--- a/script/get_built_in_policy_manifests.sh
+++ b/script/get_built_in_policy_manifests.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This script is only used in Test::Nginx tests.
+# It prints a JSON array that includes all the manifests of the built-in
+# policies plus the ones specified in the directories received in the
+# arguments.
+
+built_in_dir=$(pwd)/gateway/src/apicast/policy
+manifest_files=$(find "$built_in_dir" "$@" -name apicast-policy.json)
+
+manifests='['
+
+for manifest_file in ${manifest_files}
+do
+    manifests+=$(cat "$manifest_file"),
+done
+
+manifests=${manifests::-1}] # Replace last ',' with ']'
+
+manifests="{\"policies\":$manifests}"
+
+echo ${manifests}

--- a/t/fixtures/policies_endpoint_test/policies/example1/1.0.0/apicast-policy.json
+++ b/t/fixtures/policies_endpoint_test/policies/example1/1.0.0/apicast-policy.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "Example policy 1",
+  "description": "Just an example.",
+  "version": "1.0.0",
+  "configuration": {
+    "type": "object",
+    "properties": {
+      "message": {
+        "type": "string",
+        "description": "A message."
+      }
+    }
+  }
+}

--- a/t/fixtures/policies_endpoint_test/policies/example1/1.0.0/example1.lua
+++ b/t/fixtures/policies_endpoint_test/policies/example1/1.0.0/example1.lua
@@ -1,0 +1,2 @@
+local Policy = require('apicast.policy').new('Example1')
+return Policy

--- a/t/fixtures/policies_endpoint_test/policies/example1/1.0.0/init.lua
+++ b/t/fixtures/policies_endpoint_test/policies/example1/1.0.0/init.lua
@@ -1,0 +1,1 @@
+return require('example1')

--- a/t/fixtures/policies_endpoint_test/policies/example2/1.0.0/apicast-policy.json
+++ b/t/fixtures/policies_endpoint_test/policies/example2/1.0.0/apicast-policy.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "Example policy 2",
+  "description": "Just an example with a version mismatch.",
+  "version": "2.0.0",
+  "configuration": {
+    "type": "object",
+    "properties": {
+      "message": {
+        "type": "string",
+        "description": "A message."
+      }
+    }
+  }
+}

--- a/t/fixtures/policies_endpoint_test/policies/example2/1.0.0/example2.lua
+++ b/t/fixtures/policies_endpoint_test/policies/example2/1.0.0/example2.lua
@@ -1,0 +1,2 @@
+local Policy = require('apicast.policy').new('Example2')
+return Policy

--- a/t/fixtures/policies_endpoint_test/policies/example2/1.0.0/init.lua
+++ b/t/fixtures/policies_endpoint_test/policies/example2/1.0.0/init.lua
@@ -1,0 +1,1 @@
+return require('example2')

--- a/t/management-policies-endpoint-custom.t
+++ b/t/management-policies-endpoint-custom.t
@@ -1,0 +1,54 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+BEGIN {
+    $ENV{TEST_NGINX_MANAGEMENT_SERVER_NAME} = 'management';
+}
+
+env_to_apicast(
+    'APICAST_CONFIGURATION_LOADER' => 'test',
+    'APICAST_POLICY_LOAD_PATH' => "$ENV{PWD}/t/fixtures/policies_endpoint_test/policies"
+);
+
+# Converts what's in the 'expected_json' block and the body to JSON and
+# compares them. Raises and error when they do not match.
+add_response_body_check(sub {
+    my ($block, $body) = @_;
+
+    use JSON;
+    use Data::Compare;
+
+    my $h1 = JSON->new->utf8->decode($body);
+    my $h2 = JSON->new->utf8->decode($block->expected_json);
+    my $c = Data::Compare->new($h1, $h2);
+    if (!$c->Cmp) {
+        bail_out "JSON returned does not match the expected one.";
+    }
+
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: GET /policies
+Check that the endpoint returns the manifests of all the built-in policies plus
+the one in paths specified via config.
+We have a directory with policies in 't/fixtures'. There are 2 policies there,
+a valid one (example1), and one where the version specified in the manifest and
+the one in the policy directory do not match (example2). We need to check that
+the later is not returned.
+--- request
+GET /policies
+--- more_headers
+Host: management
+--- response_headers
+Content-Type: application/json; charset=utf-8
+--- expected_json eval
+use Cwd;
+my $dir = getcwd();
+my $cmd = "script/get_built_in_policy_manifests.sh $dir/t/fixtures/policies_endpoint_test/policies/example1";
+`$cmd`
+--- error_code: 200
+--- no_error_log
+[error]

--- a/t/management-policies-endpoint.t
+++ b/t/management-policies-endpoint.t
@@ -1,0 +1,45 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+BEGIN {
+    $ENV{TEST_NGINX_MANAGEMENT_SERVER_NAME} = 'management';
+}
+
+env_to_apicast(
+    'APICAST_CONFIGURATION_LOADER' => 'test'
+);
+
+# Converts what's in the 'expected_json' block and the body to JSON and
+# compares them. Raises and error when they do not match.
+add_response_body_check(sub {
+    my ($block, $body) = @_;
+
+    use JSON;
+    use Data::Compare;
+
+    my $h1 = JSON->new->utf8->decode($body);
+    my $h2 = JSON->new->utf8->decode($block->expected_json);
+    my $c = Data::Compare->new($h1, $h2);
+    if (!$c->Cmp) {
+        bail_out "JSON returned does not match the expected one.";
+    }
+
+});
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: GET /policies
+Check that the endpoint returns the manifests of all the built-in policies.
+--- request
+GET /policies
+--- more_headers
+Host: management
+--- response_headers
+Content-Type: application/json; charset=utf-8
+--- expected_json eval
+`script/get_built_in_policy_manifests.sh`
+--- error_code: 200
+--- no_error_log
+[error]


### PR DESCRIPTION
This PR introduces an endpoint in the management API to get all the schemas of the policies, both the built-in ones and the ones loaded using the `--policy-load-path` option.

/cc @3scale/system @macejmic the Policy API has now final shape.

This is the output with the policies we have:
```bash
curl "http://172.18.0.3:8090/policies/" | jq
{
  "policies": [
    {
      "description": [
        "This policy allows to modify the path of a request. ",
        "The operations supported are sub and gsub based on ngx.re.sub and ",
        "ngx.re.gsub provided by OpenResty. Please check ",
        "https://github.com/openresty/lua-nginx-module for more details on how ",
        "to define regular expressions and learn the options supported."
      ],
      "$schema": "http://apicast.io/policy-v1/schema#manifest#",
      "name": "URL rewriting policy",
      "configuration": {
        "properties": {
          "commands": {
            "items": {
              "properties": {
                "op": {
                  "oneOf": [
                    {
                      "const": "sub",
                      "description": "Substitutes the first match of the regex applied."
                    },
                    {
                      "const": "gsub",
                      "description": "Substitutes all the matches of the regex applied."
                    }
                  ],
                  "description": "Operation to be applied (sub or gsub)",
                  "type": "string"
                },
                "regex": {
                  "type": "string",
                  "description": "Regular expression to be matched"
                },
                "break": {
                  "type": "boolean",
                  "description": "when set to true, if the command rewrote the URL, it will be the last one applied"
                },
                "replace": {
                  "type": "string",
                  "description": "String that will replace what is matched by the regex"
                },
                "options": {
                  "type": "string",
                  "description": "Options that define how the regex matching is performed"
                }
              },
              "required": [
                "op",
                "regex",
                "replace"
              ],
              "type": "object"
            },
            "description": "List of rewriting commands to be applied",
            "type": "array"
          }
        },
        "type": "object"
      },
      "version": "0.1"
    },
    {
      "description": "This policy allows to modify the host of a request based on its path.",
      "$schema": "http://apicast.io/policy-v1/schema#manifest#",
      "name": "Upstream policy",
      "configuration": {
        "properties": {
          "rules": {
            "items": {
              "properties": {
                "url": {
                  "type": "string",
                  "description": "new URL in case of match"
                },
                "regex": {
                  "type": "string",
                  "description": "regular expression to be matched"
                }
              },
              "required": [
                "regex",
                "url"
              ],
              "type": "object"
            },
            "description": "list of rules to be applied",
            "type": "array"
          }
        },
        "type": "object"
      },
      "version": "0.1"
    },
    {
      "description": "This policy enables CORS (Cross Origin Resource Sharing) request handling.",
      "$schema": "http://apicast.io/policy-v1/schema#manifest#",
      "name": "CORS policy",
      "configuration": {
        "properties": {
          "allow_headers": {
            "items": {
              "type": "string"
            },
            "description": "Allowed headers",
            "type": "array"
          },
          "allow_credentials": {
            "type": "boolean",
            "description": "Whether the request can be made using credentials"
          },
          "allow_methods": {
            "items": {
              "enum": [
                "GET",
                "HEAD",
                "POST",
                "PUT",
                "DELETE",
                "PATCH",
                "OPTIONS",
                "TRACE",
                "CONNECT"
              ],
              "type": "string"
            },
            "description": "Allowed methods",
            "type": "array"
          },
          "allow_origin": {
            "type": "string",
            "description": "Origins for which the response can be shared with"
          }
        },
        "type": "object"
      },
      "version": "0.1"
    },
    {
      "description": [
        "This policy prints the request back to the client and optionally sets ",
        "a status code."
      ],
      "$schema": "http://apicast.io/policy-v1/schema#manifest#",
      "name": "Echo policy",
      "configuration": {
        "properties": {
          "status": {
            "type": "integer",
            "description": "HTTP status code to be returned"
          },
          "exit": {
            "oneOf": [
              {
                "const": "request",
                "description": "Interrupts the processing of the request."
              },
              {
                "const": "set",
                "description": "Only skips the rewrite phase."
              }
            ],
            "description": "Exit mode",
            "type": "string"
          }
        },
        "type": "object"
      },
      "version": "0.1"
    },
    {
      "description": [
        "This policy allows to include custom headers that will be sent to the ",
        "upstream as well as modify or delete the ones included in the original ",
        "request. Similarly, this policy also allows to add, modify, and delete ",
        "the headers included in the response."
      ],
      "$schema": "http://apicast.io/policy-v1/schema#manifest#",
      "name": "Headers policy",
      "configuration": {
        "definitions": {
          "commands": {
            "items": {
              "properties": {
                "op": {
                  "oneOf": [
                    {
                      "const": "add",
                      "description": "Adds a value to an existing header."
                    },
                    {
                      "const": "set",
                      "description": "Creates the header when not set, replaces its value when set."
                    },
                    {
                      "const": "push",
                      "description": "Creates the header when not set, adds the value when set."
                    }
                  ],
                  "description": "Operation to be applied",
                  "type": "string"
                },
                "header": {
                  "type": "string",
                  "description": "Header to be modified"
                },
                "value": {
                  "type": "string",
                  "description": "Value that will be added, set or pushed in the header"
                }
              },
              "required": [
                "op",
                "header",
                "value"
              ],
              "type": "object"
            },
            "description": "List of operations to apply to the headers",
            "type": "array"
          }
        },
        "properties": {
          "response": {
            "$ref": "#/definitions/commands"
          },
          "request": {
            "$ref": "#/definitions/commands"
          }
        },
        "type": "object"
      },
      "version": "0.1"
    },
    {
      "description": [
        "Configures a cache for the authentication calls against the 3scale ",
        "backend. This policy support three kinds of caching: \n",
        " - Strict: it only caches authorized calls. Denied and failed calls ",
        "invalidate the cache entry.\n",
        " - Resilient: caches authorized and denied calls. Failed calls do not ",
        "invalidate the cache. This allows us to authorize and deny calls ",
        "according to the result of the last request made even when backend is ",
        "down.\n",
        "- Allow: caches authorized and denied calls. When backend is ",
        "unavailable, it will cache an authorization. In practice, this means ",
        "that when backend is down _any_ request will be authorized unless last ",
        "call to backend for that request returned 'deny' (status code = 4xx). ",
        "Make sure to understand the implications of that before using this ",
        "mode. It makes sense only in very specific use cases.\n",
        "- None: disables caching."
      ],
      "$schema": "http://apicast.io/policy-v1/schema#manifest#",
      "name": "Caching policy",
      "configuration": {
        "properties": {
          "caching_type": {
            "oneOf": [
              {
                "const": "resilient",
                "description": "Authorize according to last request when backend is down."
              },
              {
                "const": "strict",
                "description": "It only caches authorized calls."
              },
              {
                "const": "allow",
                "description": "When backend is down, allow everything unless seen before and denied."
              },
              {
                "const": "none",
                "description": "Disables caching."
              }
            ],
            "description": "Caching mode",
            "type": "string"
          }
        },
        "type": "object"
      },
      "version": "0.1"
    },
    {
      "description": [
        "This policy adds support for a very small subset of SOAP. \n",
        "It expects a SOAP action URI in the SOAPAction header or the Content-Type ",
        "header. The SOAPAction header is used in v1.1 of the SOAP standard: ",
        "https://www.w3.org/TR/2000/NOTE-SOAP-20000508/#_Toc478383528 , whereas ",
        "the Content-Type header is used in v1.2 of the SOAP standard: ",
        "https://www.w3.org/TR/soap12-part2/#ActionFeature \n",
        "The SOAPAction URI is matched against the mapping rules defined in the ",
        "policy and calculates a usage based on that so it can be authorized and ",
        "reported against 3scale's backend."
      ],
      "$schema": "http://apicast.io/policy-v1/schema#manifest#",
      "name": "SOAP policy",
      "configuration": {
        "properties": {
          "mapping_rules": {
            "items": {
              "properties": {
                "delta": {
                  "type": "integer",
                  "description": "Value."
                },
                "metric_system_name": {
                  "type": "string",
                  "description": "Metric."
                },
                "pattern": {
                  "type": "string",
                  "description": "Pattern to match against the request."
                }
              },
              "required": [
                "pattern",
                "metric_system_name",
                "delta"
              ],
              "type": "object"
            },
            "description": "Mapping rules.",
            "type": "array"
          }
        },
        "type": "object"
      },
      "version": "0.1"
    }
  ]
}

```