### PR TITLE
[libexec] fix missing libexec when installed by luarocks

### DIFF
--- a/gateway/Makefile
+++ b/gateway/Makefile
@@ -5,4 +5,4 @@ install: $(INST_LUADIR)/apicast
 	@echo --- install
 	cp -R gateway/src/* $(INST_LUADIR)/
 	cp gateway/bin/apicast* $(INST_BINDIR)/
-	cp -r gateway/*.d gateway/conf{,ig} $(INST_CONFDIR)
+	cp -r gateway/*.d gateway/conf{,ig} gateway/libexec $(INST_CONFDIR)

--- a/gateway/libexec/run
+++ b/gateway/libexec/run
@@ -5,7 +5,7 @@ use File::Temp qw(tempfile);
 use File::Spec::Functions qw(catfile);
 
 my $libexec = abs_path(dirname(abs_path(__FILE__)));
-my $apicast = $ENV{APICAST_DIR} || catfile($libexec, '..');
+my $apicast = abs_path($ENV{APICAST_DIR} || catfile($libexec, '..'));
 
 my $ssl_cert_file = $ENV{SSL_CERT_FILE} || catfile($apicast, 'conf', 'ca-bundle.crt');
 my $lua_file = catfile($libexec, basename(__FILE__) . '.lua');


### PR DESCRIPTION
Also libexec should use only absolute directories because it runs nginx in different workdir.