### PR TITLE
[cli] properly configure policy load paths

### DIFF
--- a/gateway/src/apicast/cli/command/start.lua
+++ b/gateway/src/apicast/cli/command/start.lua
@@ -86,6 +86,8 @@ end
 local function build_environment_config(options)
     local config = Environment.new()
 
+    resty_env.set('APICAST_POLICY_LOAD_PATH', concat(options.policy_load_path,':'))
+
     for i=1, #options.environment do
         local ok, err = config:add(options.environment[i])
 
@@ -113,7 +115,7 @@ local function build_env(options, config, context)
         APICAST_CONFIGURATION_LOADER = tostring(options.configuration_loader or context.configuration_loader or 'lazy'),
         APICAST_CONFIGURATION_CACHE = tostring(options.cache or context.configuration_cache or 0),
         THREESCALE_DEPLOYMENT_ENV = context.configuration_channel or options.channel or config.name,
-        APICAST_POLICY_LOAD_PATH = options.policy_load_path or context.policy_load_path,
+        APICAST_POLICY_LOAD_PATH = concat(options.policy_load_path or context.policy_load_path, ':'),
     }
 end
 
@@ -229,7 +231,7 @@ local function configure(cmd)
     cmd:option("--policy-load-path",
         "Load path where to find policies. Entries separated by `:`.",
         resty_env.value('APICAST_POLICY_LOAD_PATH') or format('%s/policies', apicast_root())
-    )
+    ):init({}):count('*')
     cmd:mutex(
         cmd:flag('-v --verbose',
             "Increase logging verbosity (can be repeated).")

--- a/gateway/src/apicast/policy_loader.lua
+++ b/gateway/src/apicast/policy_loader.lua
@@ -215,23 +215,33 @@ local mt = {
 }
 
 do
-  local apicast_dir = resty_env.value('APICAST_DIR') or '.'
-  local policy_load_path = resty_env.value('APICAST_POLICY_LOAD_PATH') or
-      format('%s/policies', apicast_dir)
+  local function apicast_dir()
+    return resty_env.value('APICAST_DIR') or '.'
+  end
 
-  _M.policy_load_paths = re.split(policy_load_path, ':', 'oj')
-  _M.builtin_policy_load_path = resty_env.value('APICAST_BUILTIN_POLICY_LOAD_PATH') or format('%s/src/apicast/policy', apicast_dir)
+  local function policy_load_path()
+    return resty_env.value('APICAST_POLICY_LOAD_PATH') or
+      format('%s/policies', apicast_dir())
+  end
+
+  function _M.policy_load_paths()
+    return re.split(policy_load_path(), ':', 'oj')
+  end
+
+  function _M.builtin_policy_load_path()
+    return resty_env.value('APICAST_BUILTIN_POLICY_LOAD_PATH') or format('%s/src/apicast/policy', apicast_dir())
+  end
 end
 
 function _M.new(name, version, paths)
   local load_paths = {}
 
-  for _, path in ipairs(paths or _M.policy_load_paths) do
+  for _, path in ipairs(paths or _M.policy_load_paths()) do
     insert(load_paths, format('%s/%s/%s/?.lua', path, name, version))
   end
 
   if version == 'builtin' then
-    insert(load_paths, format('%s/%s/?.lua', _M.builtin_policy_load_path, name))
+    insert(load_paths, format('%s/%s/?.lua', _M.builtin_policy_load_path(), name))
   end
 
   -- need to create global variable package that mimics the native one


### PR DESCRIPTION
* policy load paths passed from the cli would not be recognized when
loading environment configuration
* policy loader now exposes functions instead of strings, so they are
refreshed
* cli now sets the policy load path to environment before loading
configurations


Given a command: `apicast --policy-load-path custom --environment custom.lua`
When `custom.lua` tries to load a policy that is only under the custom path.
Then CLI fails to load it because the policy path would not be set properly yet.

We are missing CLI tests, so this is not really tested.