### PR TITLE
Run each Test::Nginx test twice by default

### DIFF
--- a/t/apicast-blackbox.t
+++ b/t/apicast-blackbox.t
@@ -1,7 +1,10 @@
 use lib 't';
 use Test::APIcast::Blackbox 'no_plan';
 
+# Can't run twice because one of the test checks the contents of the cache, and
+# those change between runs (cache miss in first run, cache hit in second).
 repeat_each(1);
+
 run_tests();
 
 __DATA__

--- a/t/apicast-policy-caching.t
+++ b/t/apicast-policy-caching.t
@@ -1,7 +1,9 @@
 use lib 't';
 use Test::APIcast::Blackbox 'no_plan';
 
+# Can't run twice because of the setup of the cache for the tests.
 repeat_each(1);
+
 run_tests();
 
 __DATA__

--- a/t/apicast-policy-cors.t
+++ b/t/apicast-policy-cors.t
@@ -1,7 +1,6 @@
 use lib 't';
 use Test::APIcast::Blackbox 'no_plan';
 
-repeat_each(1);
 run_tests();
 
 __DATA__

--- a/t/apicast-policy-headers.t
+++ b/t/apicast-policy-headers.t
@@ -1,7 +1,6 @@
 use lib 't';
 use Test::APIcast::Blackbox 'no_plan';
 
-repeat_each(1);
 run_tests();
 
 __DATA__

--- a/t/apicast-policy-url-rewriting.t
+++ b/t/apicast-policy-url-rewriting.t
@@ -1,6 +1,5 @@
 use Test::APIcast::Blackbox 'no_plan';
 
-repeat_each(2);
 run_tests();
 
 __DATA__

--- a/t/balancer.t
+++ b/t/balancer.t
@@ -8,7 +8,6 @@ env_to_nginx(
     'RESOLVER'
 );
 master_on();
-repeat_each(1);
 run_tests();
 
 __DATA__

--- a/t/configuration-loading-lazy.t
+++ b/t/configuration-loading-lazy.t
@@ -12,7 +12,6 @@ env_to_nginx(
     'THREESCALE_PORTAL_ENDPOINT'
 );
 
-repeat_each(1);
 run_tests();
 
 __DATA__

--- a/t/deprecation-warnings.t
+++ b/t/deprecation-warnings.t
@@ -1,7 +1,9 @@
 use lib 't';
 use Test::APIcast::Blackbox 'no_plan';
 
+# Can't run twice because the deprecation msg shows only once per require.
 repeat_each(1);
+
 run_tests();
 
 __DATA__


### PR DESCRIPTION
Test::APIcast runs each test twice by default. Some of the tests were run just once for no reason. This PR makes sure that the default applies for those tests. Also, for the tests that can't run twice, this PR documents the reason.