### PR TITLE
[cli] detect number of available CPU shares from cgroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Allow configuration of the echo/management/fake backend ports [PR #506](https://github.com/3scale/apicast/pull/506)
 - Headers policy [PR #497](https://github.com/3scale/apicast/pull/497)
 - CORS policy [PR #487](https://github.com/3scale/apicast/pull/487)
+- Detect number of CPU shares when running on Kubernetes [PR #600](https://github.com/3scale/apicast/pull/600)
 
 ## Changed
 


### PR DESCRIPTION
Thanks @jmprusi 

Looks like kubernetes exposes number of available milicores as CPU shares. This value is used only when running on kubernetes to prevent misdetection as CPU shares can be any arbitrary number as it is just relative weight.

From https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-limits-are-run:
> The `spec.containers[].resources.requests.cpu` is converted to its core value, which is potentially fractional, and multiplied by 1024. The greater of this number or 2 is used as the value of the --cpu-shares flag in the docker run command.

BTW default value is 1024:
```shell
$ docker run alpine cat /sys/fs/cgroup/cpu/cpu.shares
1024
```