### PR TITLE
[THREESCALE-328] Allow to set a client SSL cert for upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Development environment (`--dev`) starts with Echo policy unless some configuration is passed [PR #593](https://github.com/3scale/apicast/pull/593)
 - Added support for passing whole configuration as Data URL [PR #593](https://github.com/3scale/apicast/pull/593)
 - More complete global environment when loading environment policies [PR #596](https://github.com/3scale/apicast/pull/596)
+- Support for Client Certificate authentication with upstream servers [PR #610](https://github.com/3scale/apicast/pull/596)
 
 ## Fixed
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -201,3 +201,39 @@ It can be used to first load policies from a development directory or to load ex
 Double colon (`:`) separated list of environments (or paths) APIcast should load.
 It can be used instead of `-e` or `---environment` parameter on the CLI and for example
 stored in the container image as default environment. Any value passed on the CLI overrides this variable.
+
+### `APICAST_PROXY_HTTPS_CERTIFICATE`
+
+**Default:**
+**Value:** string
+**Example:** /home/apicast/my_certificate.crt
+
+The path to the client SSL certificate that APIcast will use when connecting
+with the upstream. Notice that this certificate will be used for all the
+services in the configuration.
+
+
+### `APICAST_PROXY_HTTPS_CERTIFICATE_KEY`
+
+**Default:**
+**Value:** string
+**Example:** /home/apicast/my_certificate.key
+
+The path to the key of the client SSL certificate.
+
+### `APICAST_PROXY_HTTPS_SESSION_REUSE`
+
+**Default:** 'on'
+**Values:**
+- `on`: reuses SSL sessions.
+- `off`: does not reuse SSL sessions.
+
+
+### `APICAST_PROXY_HTTPS_PASSWORD_FILE`
+
+**Default:**
+**Value:** string
+**Example:** /home/apicast/passwords.txt
+
+Path to a file with passphrases for the SSL cert keys specified with
+`APICAST_PROXY_HTTPS_CERTIFICATE_KEY`.

--- a/examples/ssl-verification/badssl.json
+++ b/examples/ssl-verification/badssl.json
@@ -35,6 +35,28 @@
           }
         ]
       }
+    },
+    {
+      "id": "client-cert",
+      "backend_version": 1,
+      "proxy": {
+        "api_backend": "https://client.badssl.com",
+        "backend": {
+          "endpoint": "https://echo-api.3scale.net"
+        },
+        "hosts": [
+          "client.badssl.com",
+          "localhost"
+        ],
+        "proxy_rules": [
+          {
+            "http_method": "GET",
+            "pattern": "/",
+            "metric_system_name": "hits",
+            "delta": 1
+          }
+        ]
+      }
     }
   ]
 }

--- a/gateway/Roverfile.lock
+++ b/gateway/Roverfile.lock
@@ -3,7 +3,7 @@ busted 2.0.rc12-1||testing
 dkjson 2.5-2||testing
 inspect 3.1.1-0||production
 ldoc 1.4.6-2||development
-liquid scm-1||production
+liquid scm-1|87839313792423c9d726895d090153ab7efe7e0c|production
 lua-resty-env 0.4.0-1||production
 lua-resty-execvp 0.1.0-1||production
 lua-resty-http 0.12-0||production

--- a/gateway/conf.d/apicast.conf
+++ b/gateway/conf.d/apicast.conf
@@ -75,6 +75,34 @@ location @upstream {
   proxy_set_header X-3scale-debug "";
   proxy_set_header Connection "";
 
+  # This is a bit tricky. It uses liquid to set a SSL client certificate. In
+  # NGINX, all this is not executed as it is commented with '#'. However, in
+  # Liquid, all this will be evaluated. As a result, the following directives
+  # are set optionally: proxy_ssl_certificate, proxy_ssl_certificate_key,
+  # proxy_ssl_session_reuse, and proxy_ssl_password_file.
+
+  # {% if proxy_ssl_certificate != empty and proxy_ssl_certificate_key != empty %}
+  #   {% capture proxy_ssl %}
+  #{#}   proxy_ssl_certificate {{ proxy_ssl_certificate }};
+  #{#}   proxy_ssl_certificate_key {{ proxy_ssl_certificate_key }};
+  #   {% endcapture %}
+  #   {{ proxy_ssl | replace: "#{#}", "" }}
+  #
+  #   {% if proxy_ssl_password_file != empty %}
+  #     {% capture proxy_ssl %}
+  #{#}   proxy_ssl_password_file {{ proxy_ssl_password_file }}
+  #     {% endcapture %}
+  #   {{ proxy_ssl | replace: "#{#}", "" }}
+  #   {% endif %}
+  #
+  #   {% if proxy_ssl_session_reuse != empty %}
+  #     {% capture proxy_ssl %}
+  #{#}   proxy_ssl_session_reuse {{ proxy_ssl_session_reuse }}
+  #     {% endcapture %}
+  #   {{ proxy_ssl | replace: "#{#}", "" }}
+  #   {% endif %}
+  # {% endif %}
+
   # these are duplicated so when request is redirected here those phases are executed
   post_action @out_of_band_authrep_action;
   body_filter_by_lua_block { require('apicast.executor'):body_filter() }

--- a/gateway/cpanfile
+++ b/gateway/cpanfile
@@ -1,4 +1,4 @@
-requires 'Test::APIcast', '0.08';
+requires 'Test::APIcast', '0.09';
 requires 'Crypt::JWT';
 requires 'Test::Deep';
 requires 'File::Slurp';

--- a/gateway/src/apicast/cli/command/start.lua
+++ b/gateway/src/apicast/cli/command/start.lua
@@ -134,7 +134,7 @@ local function build_context(options, config)
 
 
     context.prefix = apicast_root()
-    context.ca_bundle = pl.path.abspath(context.ca_bundle or pl.path.join(context.prefix, 'conf', 'ca-bundle.crt'))
+    context.ca_bundle = pl.path.abspath(tostring(context.ca_bundle) or pl.path.join(context.prefix, 'conf', 'ca-bundle.crt'))
 
     return context
 end

--- a/gateway/src/apicast/cli/environment.lua
+++ b/gateway/src/apicast/cli/environment.lua
@@ -75,6 +75,13 @@ local function cpus()
     return tonumber(nproc)
 end
 
+local env_value_mt = {
+    __tostring = function(t) return resty_env.value(t.name) end
+}
+
+local function env_value_ref(name)
+    return setmetatable({ name = name }, env_value_mt)
+end
 
 local _M = {}
 ---
@@ -90,7 +97,8 @@ _M.default_environment = 'production'
 -- @tfield ?string package.cpath path to load libraries
 -- @table environment.default_config default configuration
 _M.default_config = {
-    ca_bundle = resty_env.value('SSL_CERT_FILE'),
+    ca_bundle = env_value_ref('SSL_CERT_FILE'),
+
     policy_chain = require('apicast.policy_chain').default(),
     nameservers = parse_nameservers(),
     worker_processes = cpus() or 'auto',

--- a/gateway/src/apicast/cli/environment.lua
+++ b/gateway/src/apicast/cli/environment.lua
@@ -91,13 +91,23 @@ _M.default_environment = 'production'
 
 --- Default configuration.
 -- @tfield ?string ca_bundle path to CA store file
+-- @tfield ?string proxy_ssl_certificate path to SSL certificate
+-- @tfield ?string proxy_ssl_certificate_key path to SSL certificate key
+-- @tfield ?string proxy_ssl_session_reuse whether SSL sessions can be reused
+-- @tfield ?string proxy_ssl_password_file path to a file with passphrases for the certificate keys
 -- @tfield ?policy_chain policy_chain @{policy_chain} instance
 -- @tfield ?{string,...} nameservers list of nameservers
 -- @tfield ?string package.path path to load Lua files
 -- @tfield ?string package.cpath path to load libraries
 -- @table environment.default_config default configuration
+
 _M.default_config = {
     ca_bundle = env_value_ref('SSL_CERT_FILE'),
+
+    proxy_ssl_certificate = env_value_ref('APICAST_PROXY_HTTPS_CERTIFICATE'),
+    proxy_ssl_certificate_key = env_value_ref('APICAST_PROXY_HTTPS_CERTIFICATE_KEY'),
+    proxy_ssl_session_reuse = env_value_ref('APICAST_PROXY_HTTPS_SESSION_REUSE'),
+    proxy_ssl_password_file = env_value_ref('APICAST_PROXY_HTTPS_PASSWORD_FILE'),
 
     policy_chain = require('apicast.policy_chain').default(),
     nameservers = parse_nameservers(),

--- a/gateway/src/apicast/cli/template.lua
+++ b/gateway/src/apicast/cli/template.lua
@@ -62,10 +62,17 @@ local function starts_with(string, match)
     return sub(string,1,len(match)) == match
 end
 
-function _M:interpret(str)
+local function build_interpreter(str)
     local lexer = Lexer:new(str)
     local parser = Parser:new(lexer)
     local interpreter = Interpreter:new(parser)
+
+    return interpreter
+end
+
+function _M:interpret(str)
+    local interpreter = build_interpreter(str)
+
     local context = self.context
     local filesystem = self.filesystem
     local filter_set = FilterSet:new()

--- a/gateway/src/resty/resolver.lua
+++ b/gateway/src/resty/resolver.lua
@@ -219,7 +219,7 @@ local function new_server(answer, port)
   return setmetatable({
     address = answer.address,
     ttl = answer.ttl,
-    port = answer.port or port
+    port = port or answer.port,
   }, server_mt)
 end
 

--- a/t/apicast-async-reporting.t
+++ b/t/apicast-async-reporting.t
@@ -196,7 +196,8 @@ GET /t?user_key=val
 --- response_body
 all ok
 --- error_code: 200
---- udp_listen random_port
+--- udp_listen random_port env chomp
+$TEST_NGINX_RANDOM_PORT
 --- udp_reply dns
 [ "localhost.example.com", "127.0.0.1", 60 ]
 --- no_error_log

--- a/t/apicast-policy-upstream.t
+++ b/t/apicast-policy-upstream.t
@@ -367,7 +367,7 @@ Upstream policy should work with internal echo API.
           { "name": "apicast.policy.upstream",
             "configuration":
               {
-                "rules": [ { "regex": "/", "url": "http://echo:$TEST_NGINX_SERVER_PORT" } ]
+                "rules": [ { "regex": "/", "url": "http://echo" } ]
               }
           }
         ]
@@ -388,3 +388,67 @@ HTTP
 --- error_code: 200
 --- no_error_log
 [error]
+
+
+
+=== TEST 8: TLS upstream
+--- configuration random_port env
+{
+  "services": [
+    {
+      "proxy": {
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/", "url": "https://test:$TEST_NGINX_RANDOM_PORT" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream random_port env
+  listen $TEST_NGINX_RANDOM_PORT ssl;
+
+  ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+  ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+  location / {
+     echo 'scheme: $scheme';
+     echo 'server_port: $server_port';
+     echo 'ssl_server_name: $ssl_server_name';
+  }
+--- request
+GET /?user_key=uk
+--- response_body random_port env
+scheme: https
+server_port: $TEST_NGINX_RANDOM_PORT
+ssl_server_name: test
+--- error_code: 200
+--- no_error_log
+[error]
+--- user_files
+>>> server.crt
+-----BEGIN CERTIFICATE-----
+MIIB0DCCAXegAwIBAgIJAISY+WDXX2w5MAoGCCqGSM49BAMCMEUxCzAJBgNVBAYT
+AkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRn
+aXRzIFB0eSBMdGQwHhcNMTYxMjIzMDg1MDExWhcNMjYxMjIxMDg1MDExWjBFMQsw
+CQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJu
+ZXQgV2lkZ2l0cyBQdHkgTHRkMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhkmo
+6Xp/9W9cGaoGFU7TaBFXOUkZxYbGXQfxyZZucIQPt89+4r1cbx0wVEzbYK5wRb7U
+iWhvvvYDltIzsD75vqNQME4wHQYDVR0OBBYEFOBBS7ZF8Km2wGuLNoXFAcj0Tz1D
+MB8GA1UdIwQYMBaAFOBBS7ZF8Km2wGuLNoXFAcj0Tz1DMAwGA1UdEwQFMAMBAf8w
+CgYIKoZIzj0EAwIDRwAwRAIgZ54vooA5Eb91XmhsIBbp12u7cg1qYXNuSh8zih2g
+QWUCIGTHhoBXUzsEbVh302fg7bfRKPCi/mcPfpFICwrmoooh
+-----END CERTIFICATE-----
+>>> server.key
+-----BEGIN EC PARAMETERS-----
+BggqhkjOPQMBBw==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIFCV3VwLEFKz9+yTR5vzonmLPYO/fUvZiMVU1Hb11nN8oAoGCCqGSM49
+AwEHoUQDQgAEhkmo6Xp/9W9cGaoGFU7TaBFXOUkZxYbGXQfxyZZucIQPt89+4r1c
+bx0wVEzbYK5wRb7UiWhvvvYDltIzsD75vg==
+-----END EC PRIVATE KEY-----

--- a/t/apicast-upstream-balancer.t
+++ b/t/apicast-upstream-balancer.t
@@ -31,7 +31,8 @@ location /t {
     ngx.say(require('cjson').encode(upstream))
   }
 }
---- udp_listen random_port
+--- udp_listen random_port env chomp
+$TEST_NGINX_RANDOM_PORT
 --- udp_reply dns
 [ "localhost", "127.0.0.1" ]
 --- request
@@ -124,7 +125,8 @@ location /t {
 
   proxy_pass http://upstream/api;
 }
---- udp_listen random_port
+--- udp_listen random_port env chomp
+$TEST_NGINX_RANDOM_PORT
 --- udp_reply dns
 [ "localhost", "127.0.0.1" ]
 --- request

--- a/t/apicast.t
+++ b/t/apicast.t
@@ -609,7 +609,8 @@ GET /t?user_key=val
 --- response_body
 all ok
 --- error_code: 200
---- udp_listen random_port
+--- udp_listen random_port env chomp
+$TEST_NGINX_RANDOM_PORT
 --- udp_reply dns
 [ "localhost.example.com", "127.0.0.1", 3600 ]
 --- no_error_log

--- a/t/management.t
+++ b/t/management.t
@@ -166,7 +166,8 @@ POST /boot
 --- response_body
 {"status":"ok","config":{"services":[{"id":42}]}}
 --- error_code: 200
---- udp_listen random_port
+--- udp_listen random_port env chomp
+$TEST_NGINX_RANDOM_PORT
 --- udp_reply dns
 [ "localhost.local", "127.0.0.1", 60 ]
 --- no_error_log
@@ -195,7 +196,8 @@ POST /test
 {"status":"ok","config":{"services":[{"id":42}]}}
 {"status":"ok","config":{"services":[{"id":42}]}}
 --- error_code: 200
---- udp_listen random_port
+--- udp_listen random_port env chomp
+$TEST_NGINX_RANDOM_PORT
 --- udp_reply dns
 [ "localhost.local", "127.0.0.1", 60 ]
 --- no_error_log

--- a/t/mutual-ssl.t
+++ b/t/mutual-ssl.t
@@ -1,0 +1,112 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+env_to_apicast(
+    'APICAST_PROXY_HTTPS_CERTIFICATE' => "$Test::Nginx::Util::ServRoot/html/client.crt",
+    'APICAST_PROXY_HTTPS_CERTIFICATE_KEY' => "$Test::Nginx::Util::ServRoot/html/client.key",
+);
+
+run_tests();
+
+__DATA__
+=== TEST 1: mutual SSL
+--- ssl random_port
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "https://test:$TEST_NGINX_RANDOM_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+        ngx.exit(200)
+    }
+  }
+--- upstream env
+  listen $TEST_NGINX_RANDOM_PORT ssl;
+
+  ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+  ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+  ssl_client_certificate $TEST_NGINX_SERVER_ROOT/html/client.crt;
+  ssl_verify_client on;
+
+  location / {
+     echo 'ssl_client_s_dn: $ssl_client_s_dn';
+     echo 'ssl_client_i_dn: $ssl_client_i_dn';
+  }
+--- request
+GET /?user_key=uk
+--- response_body
+ssl_client_s_dn: O=Internet Widgits Pty Ltd,ST=Some-State,C=AU
+ssl_client_i_dn: O=Internet Widgits Pty Ltd,ST=Some-State,C=AU
+--- error_code: 200
+--- no_error_log
+[error]
+--- user_files
+>>> server.crt
+-----BEGIN CERTIFICATE-----
+MIIB0DCCAXegAwIBAgIJAISY+WDXX2w5MAoGCCqGSM49BAMCMEUxCzAJBgNVBAYT
+AkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRn
+aXRzIFB0eSBMdGQwHhcNMTYxMjIzMDg1MDExWhcNMjYxMjIxMDg1MDExWjBFMQsw
+CQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJu
+ZXQgV2lkZ2l0cyBQdHkgTHRkMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhkmo
+6Xp/9W9cGaoGFU7TaBFXOUkZxYbGXQfxyZZucIQPt89+4r1cbx0wVEzbYK5wRb7U
+iWhvvvYDltIzsD75vqNQME4wHQYDVR0OBBYEFOBBS7ZF8Km2wGuLNoXFAcj0Tz1D
+MB8GA1UdIwQYMBaAFOBBS7ZF8Km2wGuLNoXFAcj0Tz1DMAwGA1UdEwQFMAMBAf8w
+CgYIKoZIzj0EAwIDRwAwRAIgZ54vooA5Eb91XmhsIBbp12u7cg1qYXNuSh8zih2g
+QWUCIGTHhoBXUzsEbVh302fg7bfRKPCi/mcPfpFICwrmoooh
+-----END CERTIFICATE-----
+>>> server.key
+-----BEGIN EC PARAMETERS-----
+BggqhkjOPQMBBw==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIFCV3VwLEFKz9+yTR5vzonmLPYO/fUvZiMVU1Hb11nN8oAoGCCqGSM49
+AwEHoUQDQgAEhkmo6Xp/9W9cGaoGFU7TaBFXOUkZxYbGXQfxyZZucIQPt89+4r1c
+bx0wVEzbYK5wRb7UiWhvvvYDltIzsD75vg==
+-----END EC PRIVATE KEY-----
+>>> client.crt
+-----BEGIN CERTIFICATE-----
+MIICWDCCAcGgAwIBAgIJAN52KeMKGGq9MA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
+BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
+aWRnaXRzIFB0eSBMdGQwHhcNMTgwMjE5MTQ0MzE4WhcNMTkwMjE5MTQ0MzE4WjBF
+MQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50
+ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKB
+gQC7b4gs1UsUI1akyeUdCF8RMHQhjf9XKMwGTc85RML+cLEl5MASYCOC5iE5/9Rv
+hLcgcRdJr1A/blLhK1NZOPVzI9fYFn5zTjxG94Pv11kIcvYLoJeZT1zlvCBsz2Ak
+tzK31QRXvkpn3ZikUQVflV5ArzFrIdxPNelVDMk1dwBejwIDAQABo1AwTjAdBgNV
+HQ4EFgQUoZwBPUe+E0r8/UTPJtJzntVvx44wHwYDVR0jBBgwFoAUoZwBPUe+E0r8
+/UTPJtJzntVvx44wDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOBgQBjVV6h
+fhZCNpzu9odus6uXiTGjAm2FJlpncxPw9lseKLljy2hm4dq94GYr1gFoMR7KmE+k
+Bp1RMO59vZd7TtrQ4d2t898mif04CCiQz1BeJ3cSvE+vhHJLmL+ImHh9uKFdmcg6
+MT5sX28flpZvErxsqjJ/bhKyd2R+WVuYWaoyfw==
+-----END CERTIFICATE-----
+>>> client.key
+-----BEGIN RSA PRIVATE KEY-----
+MIICXgIBAAKBgQC7b4gs1UsUI1akyeUdCF8RMHQhjf9XKMwGTc85RML+cLEl5MAS
+YCOC5iE5/9RvhLcgcRdJr1A/blLhK1NZOPVzI9fYFn5zTjxG94Pv11kIcvYLoJeZ
+T1zlvCBsz2AktzK31QRXvkpn3ZikUQVflV5ArzFrIdxPNelVDMk1dwBejwIDAQAB
+AoGBALZHctDW5NrCuyIqzct8NqfKzUVMiINEw5Vl2h7BhjhXc498dGXqZN6J2spC
+x19kW4sLMDCSc6IcMjGUJsxgHiGecloLHYnFz4faJpgNMjpu0vmz66qy/QnCy5Rf
+/g5mtQUhEkpivi9q4Thqxc2v8Y3g95D4boYYX7qNRq9jX52BAkEA6EMZOErUGIot
+vOAYSSOtkqE6di3gVqVaSk2kHjujO5AMcjhTiNv5bMrPUEOfR+JQE97XSqymfWdg
+TT7YvDt1bwJBAM6XmHA56qE7wpL9SwERlXOX/4fiTRzWDXEL+htoErMPYs/aPume
+NJBXLoTfgUghAKvhsUyMSCv/EHenGl+gWOECQQCII3xO4J19XND+WqQhisYcomBw
+EOfkIbvQvb2q8u305bRF5vofyEBlImNt+pUMP30MiJvM63ITI1rxLBtCCeAFAkA2
+Fk5co20gRUsNvK7UWswr9VF7O+5AbHIcdKxIXJj4tECEdnkeJMNSPuD4/KMWRT2t
+wmruxZNnoWGoUeF/w7VBAkEAz02rLKfeCShkbJd5f0qx0cubG/2lznrMvSBoI2ix
+itRV3G/wOHrsK9k06jx2L/+/YTUWcyzTm8B7Y34CTHGaHQ==
+-----END RSA PRIVATE KEY-----


### PR DESCRIPTION
This PR introduces 2 new ENVs (`APICAST_PROXY_HTTPS_CERTIFICATE_KEY ` and `APICAST_PROXY_HTTPS_CERTIFICATE`), they are used to set a client SSL certificate using the `proxy_ssl_certificate` and the `proxy_ssl_certificate_key` NGINX directives.

As a limitation, this certificate needs to be valid for all the services configured.