### PR TITLE
[THREESCALE-630] passthrough invalid HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix setting twice the headers in a pre-flight request in the CORS policy [PR #570](https://github.com/3scale/apicast/pull/570)
 - Fix case where debug headers are returned without enabling the option [PR #577](https://github.com/3scale/apicast/pull/577)
 - Fix errors loading openresty libraries when rover is active [PR #598](https://github.com/3scale/apicast/pull/598)
+- Passthrough "invalid" headers [PR #612](https://github.com/3scale/apicast/pull/612)
 
 ## Changed
 

--- a/gateway/conf.d/echo.conf
+++ b/gateway/conf.d/echo.conf
@@ -5,11 +5,15 @@ location / {
       end
     }
 
-    echo_duplicate 1 $echo_client_request_headers;
-    echo "\r";
+    echo_foreach_split '\r\n' $echo_client_request_headers;
+    echo $echo_it;
+    echo_end;
 
     echo_read_request_body;
-    echo $request_body;
+
+    if ($http_content_length) {
+      echo_after_body "\n$echo_request_body";
+    }
 
     access_by_lua_block {
       local delay = tonumber(ngx.var.arg_delay) or 0

--- a/gateway/conf/nginx.conf.liquid
+++ b/gateway/conf/nginx.conf.liquid
@@ -41,6 +41,8 @@ http {
   lua_package_path "{{ lua_path | default: package.path }}";
   lua_package_cpath "{{ lua_cpath | default: package.cpath }}";
 
+  ignore_invalid_headers off;
+
   {% if nameservers %}
     resolver {{ nameservers | join: " " }};
   {% endif %}
@@ -95,7 +97,6 @@ http {
     listen {{ port.apicast | default: 8080 }};
 
     server_name _;
-    underscores_in_headers on;
 
     {% include "http.d/ssl.conf" %}
 

--- a/t/apicast-policy-upstream.t
+++ b/t/apicast-policy-upstream.t
@@ -377,14 +377,10 @@ Upstream policy should work with internal echo API.
 }
 --- request
 GET /a_path?
---- response_body eval
-<<"HTTP"
-GET /a_path? HTTP/1.1\x{0d}
-X-Real-IP: 127.0.0.1\x{0d}
-Host: echo\x{0d}
-\x{0d}
-\x{0d}\x{0a}
-HTTP
+--- response_body
+GET /a_path? HTTP/1.1
+X-Real-IP: 127.0.0.1
+Host: echo
 --- error_code: 200
 --- no_error_log
 [error]

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1,0 +1,61 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: underscores in headers
+HTTP headers with underscores allowed and passed upstream.
+--- configuration
+{
+  "services": [{
+    "proxy": {
+      "policy_chain": [
+        { "name": "apicast.policy.upstream",
+          "configuration": { "rules": [ { "regex": "/", "url": "http://echo" } ] } }
+      ]
+    }
+  }]
+}
+--- request
+GET /test
+--- more_headers
+API_KEY: somekey
+--- response_body
+GET /test HTTP/1.1
+X-Real-IP: 127.0.0.1
+Host: echo
+API_KEY: somekey
+--- error_code: 200
+--- no_error_log
+[error]
+
+
+
+=== TEST 2 dots in headers
+Dots in headers are allowed and passed upstream.
+--- configuration
+{
+  "services": [{
+    "proxy": {
+      "policy_chain": [
+        { "name": "apicast.policy.upstream",
+          "configuration": { "rules": [ { "regex": "/", "url": "http://echo" } ] } }
+      ]
+    }
+  }]
+}
+--- request
+GET /test
+--- more_headers
+Client.ID: someid
+--- response_body
+GET /test HTTP/1.1
+X-Real-IP: 127.0.0.1
+Host: echo
+Client.ID: someid
+--- error_code: 200
+--- no_error_log
+[error]


### PR DESCRIPTION
APIcast should not drop any headers and just pass them to upstream. Fixes https://issues.jboss.org/browse/THREESCALE-630.