### PR TITLE
[t] use configuration fixtures

### DIFF
--- a/gateway/cpanfile
+++ b/gateway/cpanfile
@@ -1,4 +1,4 @@
-requires 'Test::APIcast', '0.09';
+requires 'Test::APIcast', '0.10';
 requires 'Crypt::JWT';
 requires 'Test::Deep';
 requires 'File::Slurp';

--- a/t/fixtures/echo.json
+++ b/t/fixtures/echo.json
@@ -1,0 +1,10 @@
+{
+  "services": [{
+    "proxy": {
+      "policy_chain": [
+        { "name": "apicast.policy.upstream",
+          "configuration": { "rules": [ { "regex": "/", "url": "http://echo" } ] } }
+      ]
+    }
+  }]
+}

--- a/t/fixtures/upstream.json
+++ b/t/fixtures/upstream.json
@@ -1,0 +1,10 @@
+{
+  "services": [{
+    "proxy": {
+      "policy_chain": [
+        { "name": "apicast.policy.upstream",
+          "configuration": { "rules": [ { "regex": "/", "url": "http://test" } ] } }
+      ]
+    }
+  }]
+}

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -1,6 +1,7 @@
 use lib 't';
 use Test::APIcast::Blackbox 'no_plan';
 
+filters { configuration => 'fixture=echo.json' };
 
 run_tests();
 
@@ -9,16 +10,6 @@ __DATA__
 === TEST 1: underscores in headers
 HTTP headers with underscores allowed and passed upstream.
 --- configuration
-{
-  "services": [{
-    "proxy": {
-      "policy_chain": [
-        { "name": "apicast.policy.upstream",
-          "configuration": { "rules": [ { "regex": "/", "url": "http://echo" } ] } }
-      ]
-    }
-  }]
-}
 --- request
 GET /test
 --- more_headers
@@ -37,16 +28,6 @@ API_KEY: somekey
 === TEST 2 dots in headers
 Dots in headers are allowed and passed upstream.
 --- configuration
-{
-  "services": [{
-    "proxy": {
-      "policy_chain": [
-        { "name": "apicast.policy.upstream",
-          "configuration": { "rules": [ { "regex": "/", "url": "http://echo" } ] } }
-      ]
-    }
-  }]
-}
 --- request
 GET /test
 --- more_headers


### PR DESCRIPTION
Simple way of having fixtures for common blackbox configurations.

depends on https://github.com/3scale/Test-APIcast/pull/5