### PR TITLE
Add token introspection feature as a policy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Added
+
+- OAuth2.0 Token Introspection policy [PR #619](https://github.com/3scale/apicast/pull/619)
+
 ## [3.2.0-beta1] - 2018-02-20
 
 ## Added

--- a/examples/policies/token_introspection_configuration.lua
+++ b/examples/policies/token_introspection_configuration.lua
@@ -1,0 +1,14 @@
+local policy_chain = require('apicast.policy_chain').default()
+
+local token_policy = require('apicast.policy.token_introspection').new({
+        introspection_url = "http://localhost:8080/auth/realms/3scale/protocol/openid-connect/token/introspect",
+        client_id = "YOUR_CLIENT_ID",
+        client_secret = "YOUR_CLIENT_SECRET"
+})
+
+policy_chain:insert(token_policy)
+
+return {
+        policy_chain = policy_chain
+}
+

--- a/gateway/src/apicast/policy/token_introspection/apicast-policy.json
+++ b/gateway/src/apicast/policy/token_introspection/apicast-policy.json
@@ -12,11 +12,11 @@
         "description": "Introspection Endpoint URL",
         "type": "string"
       },
-      "clientId": {
-        "description": "Clilent ID for the Token Introspection Endpoint",
+      "client_id": {
+        "description": "Client ID for the Token Introspection Endpoint",
         "type": "string"
       },
-      "clientSecret": {
+      "client_secret": {
         "description": "Client Secret for the Token Introspection Endpoint",
         "type": "string"
       }

--- a/gateway/src/apicast/policy/token_introspection/apicast-policy.json
+++ b/gateway/src/apicast/policy/token_introspection/apicast-policy.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://apicast.io/poolicy-v1/schema#manifest#",
+  "name": "oauth2 token introspection policy",
+  "description": 
+  ["This policy executes OAuth 2.0 Token Introspection",
+   "(https://tools.ietf.org/html/rfc7662) for every API calls."],
+  "version": "builtin",
+  "configuration": {
+    "type": "object",
+    "properties": {
+      "introspectionUrl": {
+        "description": "Introspection Endpoint URL",
+        "type": "string"
+      },
+      "clientId": {
+        "description": "Clilent ID for the Token Introspection Endpoint",
+        "type": "string"
+      },
+      "clientSecret": {
+        "description": "Client Secret for the Token Introspection Endpoint",
+        "type": "string"
+      }
+    }
+  }
+}

--- a/gateway/src/apicast/policy/token_introspection/apicast-policy.json
+++ b/gateway/src/apicast/policy/token_introspection/apicast-policy.json
@@ -8,7 +8,7 @@
   "configuration": {
     "type": "object",
     "properties": {
-      "introspectionUrl": {
+      "introspection_url": {
         "description": "Introspection Endpoint URL",
         "type": "string"
       },

--- a/gateway/src/apicast/policy/token_introspection/init.lua
+++ b/gateway/src/apicast/policy/token_introspection/init.lua
@@ -1,0 +1,1 @@
+return require('token_introspection')

--- a/gateway/src/apicast/policy/token_introspection/token_introspection.lua
+++ b/gateway/src/apicast/policy/token_introspection/token_introspection.lua
@@ -42,11 +42,12 @@ local function introspect_token(self, token)
 
   if res.status == 200 then
     local token_info, decode_err = cjson.decode(res.body)
-    if decode_err then
+    if type(token_info) == 'table' then
+      return token_info
+    else 
       ngx.log(ngx.ERR, 'failed to parse token introspection response:', decode_err)
       return { active = false }
     end
-    return token_info
   else
     ngx.log(ngx.WARN, 'failed to execute token introspection. status: ', res.status)
     return { active = false }
@@ -59,7 +60,7 @@ function _M:access(context)
     local access_token = authorization.token
     --- Introspection Response must have an "active" boolean value.
     -- https://tools.ietf.org/html/rfc7662#section-2.2
-    if not introspect_token(self, access_token).active then
+    if not introspect_token(self, access_token).active == true then
       ngx.status = context.service.auth_failed_status
       ngx.say(context.service.error_auth_failed)
       return ngx.exit(ngx.status)

--- a/gateway/src/apicast/policy/token_introspection/token_introspection.lua
+++ b/gateway/src/apicast/policy/token_introspection/token_introspection.lua
@@ -1,0 +1,68 @@
+local policy = require('apicast.policy')
+local _M = policy.new('Token Introspection Policy')
+
+local cjson = require('cjson')
+local http_authorization = require 'resty.http_authorization'
+local http_ng = require 'resty.http_ng'
+local user_agent = require 'apicast.user_agent'
+local resty_env = require('resty.env')
+
+local new = _M.new
+
+function _M.new(config)
+  local self = new()
+  self.config = config or {}
+  self.http_client = http_ng.new{
+    backend = config.client,
+    options = {
+      header = { ['User-Agent'] = user_agent() },
+      ssl = { verify = resty_env.enabled('OPENSSL_VERIFY') }
+    }
+  }
+  return self
+end
+
+local function introspect_token(self, token)
+  local config = self.config
+  if not config then
+    return false
+  end
+
+  local introspection_url = config.introspection_url
+  local client = config.client_id
+  local secret = config.client_secret
+  local credential = 'Basic ' .. ngx.encode_base64(table.concat({ client or '', secret or '' }, ':'))
+  local opts = {
+    headers = {
+      ['Authorization'] = credential
+    }
+  }
+
+  local res, err = self.http_client.post(introspection_url , { token = token, token_type_hint = 'access_token'}, opts)
+  if res and err then
+    ngx.log(ngx.WARN, 'token introspection error: ', err, ' url: ', introspection_url)
+    return false
+  end
+
+  if res.status == 200 then
+    local token_info = cjson.decode(res.body)
+    return token_info.active
+  else
+    ngx.log(ngx.WARN, 'failed to execute token introspection. status: ', res.status)
+    return false
+  end
+end
+
+function _M:access(context)
+  if self.config.introspection_url then
+    local authorization = http_authorization.new(ngx.var.http_authorization)
+    local access_token = authorization.token
+    if not introspect_token(self, access_token) then
+      ngx.status = context.service.auth_failed_status
+      ngx.say(context.service.error_auth_failed)
+      return ngx.exit(ngx.status)
+    end
+  end
+end
+
+return _M

--- a/gateway/src/apicast/policy/token_introspection/token_introspection.lua
+++ b/gateway/src/apicast/policy/token_introspection/token_introspection.lua
@@ -19,7 +19,7 @@ function _M.new(config)
   self.http_client = http_ng.new{
     backend = config.client,
     options = {
-      headers = { 
+      headers = {
         ['User-Agent'] = user_agent(),
         ['Authorization'] = credential
       },

--- a/spec/policy/token_introspection/token_introspection_spec.lua
+++ b/spec/policy/token_introspection/token_introspection_spec.lua
@@ -9,6 +9,12 @@ describe("token introspection policy", function()
     local test_client_secret = "secret"
     local test_basic_auth = 'Basic '..ngx.encode_base64(test_client_id..':'..test_client_secret)
 
+    local function assert_authentication_failed()
+      assert.same(ngx.status, 403)
+      assert.stub(ngx.say).was.called_with("auth failed")
+      assert.stub(ngx.exit).was.called_with(403)
+    end
+
     before_each(function()
       test_backend = test_backend_client.new()
       ngx.var = {}
@@ -140,12 +146,6 @@ describe("token introspection policy", function()
       token_policy:access(context)
       assert_authentication_failed()
     end)
-
-    function assert_authentication_failed()
-      assert.same(ngx.status, 403)
-      assert.stub(ngx.say).was.called_with("auth failed")
-      assert.stub(ngx.exit).was.called_with(403)
-    end
 
     after_each(function()
       test_backend.verify_no_outstanding_expectations()

--- a/spec/policy/token_introspection/token_introspection_spec.lua
+++ b/spec/policy/token_introspection/token_introspection_spec.lua
@@ -1,0 +1,94 @@
+local test_backend_client = require('resty.http_ng.backend.test')
+local cjson = require('cjson')
+describe("token introspection policy", function()
+  describe("execute introspection", function()
+    local context
+    local test_backend
+
+    before_each(function()
+      test_backend = test_backend_client.new()
+      ngx.var = {}
+      ngx.var.http_authorization = "Bearer test"
+      context = {
+        service = {
+          auth_failed_status = 403,
+          error_auth_failed = "auth failed"
+        }
+      }
+    end)
+
+    it('execute token introspection success', function()
+      local introspection_url = "http://example/token/introspection"
+      local policy_config = {
+        client = test_backend,
+        introspection_url = introspection_url,
+        client_id = "client",
+        client_secret = "secret"
+      }
+
+      test_backend.expect{ url = introspection_url }.
+        respond_with{
+          status = 200,
+          body = cjson.encode({
+              active = true
+          })
+        }
+      local token_policy = require('apicast.policy.token_introspection').new(policy_config)
+      token_policy:access(context)
+
+      test_backend.verify_no_outstanding_expectations()
+    end)
+
+    it('execute token introspection failed', function()
+      local introspection_url = "http://example/token/introspection"
+      local policy_config = {
+        client = test_backend,
+        introspection_url = introspection_url,
+        client_id = "client",
+        client_secret = "secret"
+      }
+
+      test_backend.expect{ url = introspection_url }.
+        respond_with{
+          status = 200,
+          body = cjson.encode({
+              active = false
+          })
+        }
+      stub(ngx, 'say')
+      stub(ngx, 'exit')
+
+      local token_policy = require('apicast.policy.token_introspection').new(policy_config)
+      token_policy:access(context)
+      assert.same(ngx.status, 403)
+      assert.stub(ngx.say).was.called_with("auth failed")
+      assert.stub(ngx.exit).was.called_with(403)
+      test_backend.verify_no_outstanding_expectations()
+    end)
+
+    it('execute token introspection request failed', function()
+      local introspection_url = "http://example/token/introspection"
+      local policy_config = {
+        client = test_backend,
+        introspection_url = introspection_url,
+        client_id = "client",
+        client_secret = "secret"
+      }
+
+      test_backend.expect{ url = introspection_url }.
+        respond_with{
+          status = 404,
+        }
+      stub(ngx, 'say')
+      stub(ngx, 'exit')
+
+      local token_policy = require('apicast.policy.token_introspection').new(policy_config)
+      token_policy:access(context)
+      assert.same(ngx.status, 403)
+      assert.stub(ngx.say).was.called_with("auth failed")
+      assert.stub(ngx.exit).was.called_with(403)
+      test_backend.verify_no_outstanding_expectations()
+    end)
+  end)
+end)
+

--- a/t/apicast-policy-token-introspection.t
+++ b/t/apicast-policy-token-introspection.t
@@ -154,3 +154,54 @@ Authorization: Bearer testaccesstoken
 --- error_code: 403
 --- no_error_log
 [error]
+=== TEST 4: Token introspection request is failed with bad response value
+Token introspection policy return "403 Unauthorized" if IdP response error status.
+--- backend
+  location /token/introspection {
+    content_by_lua_block {
+      ngx.req.read_body()
+      local args, err = ngx.req.get_post_args()
+      require('luassert').are.equal('testaccesstoken', args.token)
+      ngx.say('<html></html>')
+    }
+  }
+--- configuration
+
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oidc",
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.token_introspection",
+            "configuration": {
+              "client_id": "app",
+              "client_secret": "appsec",
+              "introspection_url": "http://test_backend:$TEST_NGINX_SERVER_PORT/token/introspection"
+            }
+          }
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /echo {
+    content_by_lua_block {
+      ngx.say('yay, api backend')
+      ngx.exit(200)
+    }
+  }
+
+--- request
+GET /echo
+--- more_headers
+Authorization: Bearer testaccesstoken
+--- error_code: 403
+--- error_log
+[error]

--- a/t/apicast-policy-token-introspection.t
+++ b/t/apicast-policy-token-introspection.t
@@ -1,0 +1,156 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: Token introspection request success
+Token introspection policy check access token.
+--- backend
+  location /token/introspection {
+    content_by_lua_block {
+      ngx.req.read_body()
+      local args, err = ngx.req.get_post_args()
+      require('luassert').are.equal('testaccesstoken', args.token)
+      ngx.say('{"active": true}')
+    }
+  }
+--- configuration
+
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oidc",
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.token_introspection", 
+            "configuration": {
+              "client_id": "app",
+              "client_secret": "appsec",
+              "introspection_url": "http://test_backend:$TEST_NGINX_SERVER_PORT/token/introspection"
+            }
+          }
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /echo {
+    content_by_lua_block {
+      ngx.say('yay, api backend')
+      ngx.exit(200)
+    }
+  }
+
+--- request
+GET /echo
+--- more_headers
+Authorization: Bearer testaccesstoken
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 2: Token already revoked.
+Token introspection policy return "403 Unauthorized" if access token is already revoked on IdP.
+--- backend
+  location /token/introspection {
+    content_by_lua_block {
+      ngx.say('{"active": false}')
+    }
+  }
+--- configuration
+
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oidc",
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.token_introspection", 
+            "configuration": {
+              "client_id": "app",
+              "client_secret": "appsec",
+              "introspection_url": "http://test_backend:$TEST_NGINX_SERVER_PORT/token/introspection"
+            }
+          }
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /echo {
+    content_by_lua_block {
+      ngx.say('yay, api backend')
+      ngx.exit(200)
+    }
+  }
+
+--- request
+GET /echo
+--- more_headers
+Authorization: Bearer testaccesstoken
+--- error_code: 403
+--- no_error_log
+[error]
+
+=== TEST 3: Token introspection request is failed due to IdP error
+Token introspection policy return "403 Unauthorized" if IdP response error status.
+--- backend
+  location /token/introspection {
+    content_by_lua_block {
+      ngx.exit(500)
+    }
+  }
+--- configuration
+
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oidc",
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.token_introspection", 
+            "configuration": {
+              "client_id": "app",
+              "client_secret": "appsec",
+              "introspection_url": "http://test_backend:$TEST_NGINX_SERVER_PORT/token/introspection"
+            }
+          }
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /echo {
+    content_by_lua_block {
+      ngx.say('yay, api backend')
+      ngx.exit(200)
+    }
+  }
+
+--- request
+GET /echo
+--- more_headers
+Authorization: Bearer testaccesstoken
+--- error_code: 403
+--- no_error_log
+[error]


### PR DESCRIPTION
Hi team,

I created a new policy to enable [RFC7662 OAuth2.0 Token Introspection](https://tools.ietf.org/html/rfc7662).
This PR is a rework of the previous request (https://github.com/3scale/apicast/pull/435) as a policy.

And Also added sample configuration in the `examples/policies` directory.