### PR TITLE
[t] cleanup integration tests with luassert

### DIFF
--- a/t/apicast-async-reporting.t
+++ b/t/apicast-async-reporting.t
@@ -39,14 +39,7 @@ include $TEST_NGINX_APICAST_CONFIG;
 location /transactions/authrep.xml {
   content_by_lua_block {
     local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-    local args = ngx.var.args
-    ngx.log(ngx.INFO, 'backend got ', args, ' expected ', expected)
-    if args == expected then
-      ngx.exit(200)
-    else
-      ngx.log(ngx.ERR, expected, ' did not match: ', args)
-      ngx.exit(403)
-    end
+    require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
   }
 }
 
@@ -58,8 +51,6 @@ GET /?user_key=value
 --- response_body
 yay, api backend: 127.0.0.1
 --- error_code: 200
---- error_log
-backend got service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value
 --- no_error_log
 [error]
 
@@ -106,7 +97,6 @@ location /api/ {
 
 location /transactions/authrep.xml {
   content_by_lua_block {
-    ngx.log(ngx.INFO, 'backend got: ', ngx.var.args)
     ngx.exit(200)
   }
 }

--- a/t/apicast-blackbox.t
+++ b/t/apicast-blackbox.t
@@ -52,13 +52,7 @@ It asks backend and then forwards the request to the api.
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- upstream

--- a/t/apicast-oauth.t
+++ b/t/apicast-oauth.t
@@ -68,13 +68,8 @@ called oauth_authorize.xml
   location = /backend/transactions/oauth_authorize.xml {
     content_by_lua_block {
       local expected = "provider_key=fookey&service_id=42&app_id=id&redirect_uri=otheruri"
-      if ngx.var.args == expected then
-        ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized></status>')
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' does not match ', ngx.var.args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+      ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized></status>')
     }
   }
 --- request
@@ -108,13 +103,9 @@ Location: http://example.com/redirect\?response_type=code&client_id=id&state=[a-
 
   location = /backend/transactions/oauth_authorize.xml {
     content_by_lua_block {
-      if ngx.var.args == "provider_key=fookey&service_id=42&app_id=id&redirect_uri=otheruri" then
-        ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized></status>')
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' does not match ', ngx.var.args)
-        ngx.exit(403)
-      end
+      local expected = "provider_key=fookey&service_id=42&app_id=id&redirect_uri=otheruri"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+      ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized></status>')
     }
   }
 --- request
@@ -339,13 +330,8 @@ Location: http://example.com/redirect\?code=\w+&state=clientstate
     location = /backend/transactions/oauth_authorize.xml {
       content_by_lua_block {
         local expected = "provider_key=fookey&service_id=42&app_key=client_secret&app_id=client_id&redirect_uri=redirect_uri"
-        if ngx.var.args == expected then
-          ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized><application><key>client_secret</key></application></status>')
-          ngx.exit(200)
-        else
-          ngx.log(ngx.ERR, 'expected: ' .. expected .. ' got: ' .. ngx.var.args)
-          ngx.exit(403)
-        end
+        require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+        ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized><application><key>client_secret</key></application></status>')
       }
     }
 
@@ -610,13 +596,8 @@ Regression test for CVE-2017-7512
     location = /backend/transactions/oauth_authorize.xml {
       content_by_lua_block {
         expected = "provider_key=fookey&service_id=42&app_key=&app_id=client_id&redirect_uri=redirect_uri"
-        if ngx.var.args == expected then
+        require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
         ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized><application><key>client_secret</key></application></status>')
-          ngx.exit(200)
-        else
-          ngx.log(ngx.ERR, 'expected: ' .. expected .. ' got: ' .. ngx.var.args)
-          ngx.exit(403)
-        end
       }
     }
 
@@ -677,13 +658,8 @@ GET /t
     location = /backend/transactions/oauth_authorize.xml {
       content_by_lua_block {
         expected = "provider_key=fookey&service_id=42&app_key=bar&app_id=foo&redirect_uri=redirect"
-        if ngx.var.args == expected then
-          ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized><application><key>bar</key></application></status>')
-          ngx.exit(200)
-        else
-          ngx.log(ngx.ERR, 'expected: ' .. expected .. ' got: ' .. ngx.var.args)
-          ngx.exit(403)
-        end
+        require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+        ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized><application><key>bar</key></application></status>')
       }
     }
 
@@ -747,13 +723,8 @@ GET /t
     location = /backend/transactions/oauth_authorize.xml {
       content_by_lua_block {
         expected = "provider_key=fookey&service_id=42&app_key=bar&app_id=foo&redirect_uri=redirect"
-        if ngx.var.args == expected then
-          ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized><application><key>bar</key></application></status>')
-          ngx.exit(200)
-        else
-          ngx.log(ngx.ERR, 'expected: ' .. expected .. ' got: ' .. ngx.var.args)
-          ngx.exit(403)
-        end
+        require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+        ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized><application><key>bar</key></application></status>')
       }
     }
 
@@ -769,9 +740,6 @@ GET /t
           ngx.log(ngx.ERR, 'Invalid Content-Type: ', ngx.var.http_content_type)
           ngx.status = 400
           ngx.print('invalid content-type')
-          ngx.exit(400)
-        else
-          ngx.exit(200)
         end
       }
     }
@@ -835,13 +803,9 @@ When a token TTL is not specified, it applies a default of 7 days (604800 s)
   location = /backend/transactions/oauth_authorize.xml {
     content_by_lua_block {
       expected = "provider_key=fookey&service_id=42&app_key=bar&app_id=foo&redirect_uri=redirect"
-      if ngx.var.args == expected and ngx.var.host == ngx.var.backend_host then
-        ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized><application><key>bar</key></application></status>')
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, 'expected: ' .. expected .. ' got: ' .. ngx.var.args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+      require('luassert').same(ngx.var.backend_host, ngx.var.host)
+      ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized><application><key>bar</key></application></status>')
     }
   }
 
@@ -917,13 +881,9 @@ When an empty token TTL is received, Apicast applies a default of 7 days (604800
   location = /backend/transactions/oauth_authorize.xml {
     content_by_lua_block {
       expected = "provider_key=fookey&service_id=42&app_key=bar&app_id=foo&redirect_uri=redirect"
-      if ngx.var.args == expected and ngx.var.host == ngx.var.backend_host then
-        ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized><application><key>bar</key></application></status>')
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, 'expected: ' .. expected .. ' got: ' .. ngx.var.args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+      require('luassert').same(ngx.var.backend_host, ngx.var.host)
+      ngx.say('<?xml version="1.0" encoding="UTF-8"?><status><authorized>true</authorized><application><key>bar</key></application></status>')
     }
   }
 

--- a/t/apicast-oidc.t
+++ b/t/apicast-oidc.t
@@ -54,12 +54,7 @@ __DATA__
   location = /backend/transactions/oauth_authrep.xml {
     content_by_lua_block {
       local expected = "provider_key=fookey&service_id=42&usage%5Bhits%5D=1&app_id=appid"
-      if ngx.var.args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, 'expected: ' .. expected .. ' got: ' .. ngx.var.args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- request

--- a/t/apicast-policy-cors.t
+++ b/t/apicast-policy-cors.t
@@ -71,13 +71,7 @@ the request. So for example, if the request sets the 'Origin' header to
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- upstream
@@ -133,13 +127,7 @@ the CORS headers in the response.
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- upstream

--- a/t/apicast-policy-headers.t
+++ b/t/apicast-policy-headers.t
@@ -16,13 +16,7 @@ We test 4 things:
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -94,13 +88,7 @@ We test 3 things:
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -170,13 +158,7 @@ We test 3 things:
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -243,13 +225,7 @@ We test 3 things:
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -313,13 +289,7 @@ We test 2 things:
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -383,13 +353,7 @@ We test 3 things:
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -448,13 +412,7 @@ configuration.
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration

--- a/t/apicast-policy-soap.t
+++ b/t/apicast-policy-soap.t
@@ -14,13 +14,7 @@ Test that the usage reported to backend is the sum of:
     content_by_lua_block {
       -- Notice that hits is 3 (1 in service rules + 2 in the policy rules)
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=3&user_key=uk"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -85,13 +79,7 @@ Test that the usage reported to backend is the sum of:
     content_by_lua_block {
       -- Notice that hits is 3 (1 in service rules + 2 in the policy rules)
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=3&user_key=uk"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -158,13 +146,7 @@ because it takes precedence over the one in the SOAPAction header.
     content_by_lua_block {
       -- Notice that hits is 3 (1 in service rules + 2 in the policy rules)
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=3&user_key=uk"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -234,13 +216,7 @@ mapping rules.
     content_by_lua_block {
       -- Notice that hits is 1 (comes from the service mapping rules).
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=1&user_key=uk"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration

--- a/t/apicast-policy-upstream.t
+++ b/t/apicast-policy-upstream.t
@@ -13,13 +13,7 @@ to the one we have set up. If this was not working we would notice, because
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=uk"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -72,13 +66,7 @@ upstream we have set up.
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=uk"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -135,13 +123,7 @@ upstream in 'api_backend'.
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=uk"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -196,13 +178,7 @@ yay, api backend
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=uk"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -258,13 +234,7 @@ yay, api backend
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=uk"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration

--- a/t/apicast-policy-url-rewriting.t
+++ b/t/apicast-policy-url-rewriting.t
@@ -9,13 +9,7 @@ __DATA__
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -64,13 +58,7 @@ yay, api backend
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -120,13 +108,7 @@ Substitutions are applied in the order specified.
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -180,13 +162,7 @@ We need to test 2 things:
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration
@@ -241,13 +217,7 @@ rules.
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 --- configuration

--- a/t/apicast.t
+++ b/t/apicast.t
@@ -239,13 +239,7 @@ It asks backend and then forwards the request to the api.
   location /transactions/authrep.xml {
     content_by_lua_block {
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(403)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 
@@ -760,13 +754,7 @@ taken into account.
     content_by_lua_block {
       -- Notice that the user_key sent in the body does not appear here.
       local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2"
-      local args = ngx.var.args
-      if args == expected then
-        ngx.exit(403)
-      else
-        ngx.log(ngx.ERR, expected, ' did not match: ', args)
-        ngx.exit(500)
-      end
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
     }
   }
 


### PR DESCRIPTION
luassert version is not only way shorter, but also:

* writes proper error message on failure
* ignores order of elements (that can happen when openresty was compiled differently)


I also wanted to expose it as `assert` by the environment configuration generated by Test::APIcast::Blackbox, but can't due to the sandbox. 


Travis fails to check links because JIRA is down.
