### PR TITLE
Reset ngx state on every test

### DIFF
--- a/spec/policy/cors/cors_spec.lua
+++ b/spec/policy/cors/cors_spec.lua
@@ -40,8 +40,9 @@ describe('CORS policy', function()
 
   describe('.header_filter', function()
     before_each(function()
-      local headers = {}
-      stub(ngx.header, function() return headers end)
+      -- Replace original ngx.header. Openresty does not allow to modify it when
+      -- running busted tests.
+      ngx.header = {}
     end)
 
     describe('when the policy configuration defines CORS headers', function()

--- a/spec/policy/headers/headers_spec.lua
+++ b/spec/policy/headers/headers_spec.lua
@@ -111,8 +111,9 @@ describe('Headers policy', function()
     local response_headers = 'response' -- header_filter() only modifies resp headers
 
     before_each(function()
-      local headers = {}
-      stub(ngx.header, function() return headers end)
+      -- Replace original ngx.header. Openresty does not allow to modify it when
+      -- running busted tests.
+      ngx.header = {}
     end)
 
     describe('the push operation', function()

--- a/spec/proxy_spec.lua
+++ b/spec/proxy_spec.lua
@@ -21,6 +21,10 @@ describe('Proxy', function()
   describe(':rewrite', function()
     local service
     before_each(function()
+      -- Replace original ngx.header. Openresty does not allow to modify it when
+      -- running busted tests.
+      ngx.header = {}
+
       ngx.var = { backend_endpoint = 'http://localhost:1853', uri = '/a/uri' }
       ngx.req = { get_method = function () return 'GET' end}
       service = Service.new({ extract_usage = function() end })


### PR DESCRIPTION
This PR modifies the `after_each` in the busted helpers to make sure that we start with a clean ngx state on every test.
