### PR TITLE
[rover] update liquid version

### DIFF
--- a/gateway/Roverfile.lock
+++ b/gateway/Roverfile.lock
@@ -3,7 +3,7 @@ busted 2.0.rc12-1||testing
 dkjson 2.5-2||testing
 inspect 3.1.1-0||production
 ldoc 1.4.6-2||development
-liquid scm-1|87839313792423c9d726895d090153ab7efe7e0c|production
+liquid 0.1.0-1||production
 lua-resty-env 0.4.0-1||production
 lua-resty-execvp 0.1.0-1||production
 lua-resty-http 0.12-0||production


### PR DESCRIPTION
* scm-1 was marked as development again so we can use normal versioning
* fixes a failure to install dependencies because there is no liquid scm-1