### PR TITLE
Fix busted lib broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ For developing and testing APIcast the following tools are needed:
  brew install apitools/openresty/luarocks
 ```
 
-- [busted](http://olivinelabs.com/busted/) - unit testing framework, used for unit testing.
+- [busted](https://github.com/Olivine-Labs/busted) - unit testing framework, used for unit testing.
 ```shell
  luarocks install busted
 ```

--- a/doc/why.md
+++ b/doc/why.md
@@ -18,7 +18,7 @@ Splitting code and configuration allows thorough testing of each component indiv
 
 Using wonderful [Test::Nginx](http://search.cpan.org/~agent/Test-Nginx/lib/Test/Nginx/Socket.pm) framework for high level integration tests allows us to run every test several times in random order to ensure there are no random failures.
 
-Low level unit testing is done in Lua testing framework [busted](https://olivinelabs.com/busted/). That allows us to run low level tests for edge cases easily and run them in isolation.
+Low level unit testing is done in Lua testing framework [busted](https://github.com/Olivine-Labs/busted). That allows us to run low level tests for edge cases easily and run them in isolation.
 
 ## Modules
 


### PR DESCRIPTION
The website has been down for days and our builds are failing in Travis because of the linter that checks for broken links. Point to the GitHub repo instead.