### PR TITLE
Fix resolv.conf search parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Splitted `resolv.conf` in lines,to avoid commented lines  [PR #618](https://github.com/3scale/apicast/pull/618)
 - Avoid `nameserver` repetion from `RESOLVER` variable and `resolv.conf` file [PR #636](https://github.com/3scale/apicast/pull/636)
 - Bug in URL rewriting policy that ignored the `commands` attribute in the policy manifest [PR #641](https://github.com/3scale/apicast/pull/641)
+- Skip comentaries after `search` values in resolv.conf [PR #635](https://github.com/3scale/apicast/pull/635)
 
 ## Added
 

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,9 @@ apicast-source: ## Create Docker Volume container with APIcast source code
 	docker create --rm -v /opt/app-root/src --name $(COMPOSE_PROJECT_NAME)-source $(IMAGE_NAME) /bin/true
 	docker cp . $(COMPOSE_PROJECT_NAME)-source:/opt/app-root/src
 
-
+BUSTED_FILES ?=
 busted: dependencies $(ROVER) ## Test Lua.
-	@$(ROVER) exec bin/busted
+	@$(ROVER) exec bin/busted $(BUSTED_FILES)
 	@- luacov
 
 nginx:

--- a/gateway/src/resty/resolver.lua
+++ b/gateway/src/resty/resolver.lua
@@ -124,15 +124,16 @@ function _M.parse_nameservers(path)
     -- see https://github.com/3scale/apicast/issues/321 for more details
     insert(nameservers, resolver)
   end
-  
+
   for _,line in ipairs(re.split(resolv_conf, "\n+")) do
-    
+
     local domains = match(line, '^search%s+([^\n]+)')
-    
+
     if domains then
       ngx.log(ngx.DEBUG, 'search ', domains)
 
       for domain in gmatch(domains or '', '([^%s]+)') do
+        if match(domain, '^%#') then break end
         ngx.log(ngx.DEBUG, 'search domain: ', domain)
         insert(search, domain)
       end

--- a/t/resolver.t
+++ b/t/resolver.t
@@ -44,9 +44,9 @@ nameservers: 3 127.0.1.15353 1.2.3.453 4.5.6.753
 #search updated  in comentary
 #search nameserver 1.2.3.4
 #search nameserver
-search localdomain.example.com local
-nameserver 1.2.3.4
-nameserver 4.5.6.7
+search localdomain.example.com local #search nameserver
+nameserver 1.2.3.4  #search nameserver
+nameserver 4.5.6.7  #nameserver search
 
 
 === TEST 2: uses upstream peers


### PR DESCRIPTION
Corrects parsing `search local.domain #foobar` in #630 