### PR TITLE
Adding .cache dir and .bash_history files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ apicast/logs/
 *.rock
 lua_modules/
 tmp/benchmark/
+.bash_history
+.cache/


### PR DESCRIPTION
 `make dev` causes the creation of `.bash_history` and `.cache/`. No need for them in repo. 