### PR TITLE
Make sure all the policy configs used in specs are valid

### DIFF
--- a/spec/policy/cors/cors_spec.lua
+++ b/spec/policy/cors/cors_spec.lua
@@ -52,7 +52,7 @@ describe('CORS policy', function()
 
       it('sets those headers', function()
         local policy_config = {
-          allow_headers = 'Content-Type',
+          allow_headers = { 'Content-Type' },
           allow_methods = { 'GET', 'POST' },
           allow_origin = '*',
           allow_credentials = true

--- a/spec/policy/url_rewriting/url_rewriting_spec.lua
+++ b/spec/policy/url_rewriting/url_rewriting_spec.lua
@@ -55,7 +55,7 @@ describe('URL rewriting policy', function()
     it('when there is a break, stops at the first match', function()
       local config_with_break = {
         commands = {
-          { op = 'gsub', regex = 'to_be_replaced', replace = 'abc', ['break'] = '1' },
+          { op = 'gsub', regex = 'to_be_replaced', replace = 'abc', ['break'] = true },
           { op = 'gsub', regex = 'abc', replace = 'def' } -- Not applied
         }
       }


### PR DESCRIPTION
This PR fixes a couple of policy configs in the specs that are not valid according to the configuration schema of the policy.

I found those errors using this WIP branch: https://github.com/3scale/apicast/tree/validate-policy-configs