### PR TITLE
Validation for policy configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - New property `summary` in the policy manifests [PR #633](https://github.com/3scale/apicast/pull/633)
 - OAuth2.0 Token Introspection policy [PR #619](https://github.com/3scale/apicast/pull/619)
+- New `metrics` phase that runs when prometheus is collecting metrics [PR #629](https://github.com/3scale/apicast/pull/629)
+- Validation of policy configs both in integration and unit tests [PR #646](https://github.com/3scale/apicast/pull/646)
 
 ## Fixed
 
@@ -17,10 +19,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Splitted `resolv.conf` in lines,to avoid commented lines  [PR #618](https://github.com/3scale/apicast/pull/618)
 - Avoid `nameserver` repetion from `RESOLVER` variable and `resolv.conf` file [PR #636](https://github.com/3scale/apicast/pull/636)
 - Bug in URL rewriting policy that ignored the `commands` attribute in the policy manifest [PR #641](https://github.com/3scale/apicast/pull/641)
-
-## Added
-
-- New `metrics` phase that runs when prometheus is collecting metrics [PR #629](https://github.com/3scale/apicast/pull/629)
 
 ## [3.2.0-beta1] - 2018-02-20
 

--- a/gateway/Roverfile
+++ b/gateway/Roverfile
@@ -4,6 +4,7 @@ luarocks {
 
     group 'testing' {
         module { 'busted' },
+        module { 'ljsonschema' },
     },
 
     group 'development' {

--- a/gateway/Roverfile.lock
+++ b/gateway/Roverfile.lock
@@ -4,6 +4,7 @@ dkjson 2.5-2||testing
 inspect 3.1.1-0||production
 ldoc 1.4.6-2||development
 liquid 0.1.0-1||production
+ljsonschema 0.1.0-1||testing
 lua-resty-env 0.4.0-1||production
 lua-resty-execvp 0.1.0-1||production
 lua-resty-http 0.12-0||production
@@ -18,6 +19,7 @@ luassert 1.7.10-0||testing
 luasystem 0.2.1-0||testing
 markdown 0.33-1||development
 mediator_lua 1.1.2-0||testing
+net-url 0.9-1||testing
 nginx-lua-prometheus 0.20171117-4||production
 penlight 1.5.4-1||production,development,testing
 router 2.1-0||production

--- a/gateway/src/apicast/policy/caching/apicast-policy.json
+++ b/gateway/src/apicast/policy/caching/apicast-policy.json
@@ -27,19 +27,19 @@
         "type": "string",
         "oneOf": [
           {
-            "const": "resilient",
+            "enum": ["resilient"],
             "description": "Authorize according to last request when backend is down."
           },
           {
-            "const": "strict",
+            "enum": ["strict"],
             "description": "It only caches authorized calls."
           },
           {
-            "const": "allow",
+            "enum": ["allow"],
             "description": "When backend is down, allow everything unless seen before and denied."
           },
           {
-            "const": "none",
+            "enum": ["none"],
             "description": "Disables caching."
           }
         ]

--- a/gateway/src/apicast/policy/caching/caching.lua
+++ b/gateway/src/apicast/policy/caching/caching.lua
@@ -98,7 +98,7 @@ end
 -- @tparam[opt] table config
 -- @field caching_type Caching type (strict, resilient, allow, none)
 function _M.new(config)
-  local self = new()
+  local self = new(config)
   self.cache_handler = handler(config or {})
   return self
 end

--- a/gateway/src/apicast/policy/cors/cors.lua
+++ b/gateway/src/apicast/policy/cors/cors.lua
@@ -25,7 +25,7 @@ local new = _M.new
 -- @field[opt] allow_origin Allowed origins (e.g. 'http://example.com', '*')
 -- @field[opt] allow_credentials Boolean
 function _M.new(config)
-  local self = new()
+  local self = new(config)
   self.config = config or {}
   return self
 end

--- a/gateway/src/apicast/policy/echo/apicast-policy.json
+++ b/gateway/src/apicast/policy/echo/apicast-policy.json
@@ -18,11 +18,11 @@
         "type": "string",
         "oneOf": [
           {
-            "const": "request",
+            "enum": ["request"],
             "description": "Interrupts the processing of the request."
           },
           {
-            "const": "set",
+            "enum": ["set"],
             "description": "Only skips the rewrite phase."
           }
         ]

--- a/gateway/src/apicast/policy/headers/apicast-policy.json
+++ b/gateway/src/apicast/policy/headers/apicast-policy.json
@@ -22,15 +22,15 @@
               "type": "string",
               "oneOf": [
                 {
-                  "const": "add",
+                  "enum": ["add"],
                   "description": "Adds a value to an existing header."
                 },
                 {
-                  "const": "set",
+                  "enum": ["set"],
                   "description": "Creates the header when not set, replaces its value when set."
                 },
                 {
-                  "const": "push",
+                  "enum": ["push"],
                   "description": "Creates the header when not set, adds the value when set."
                 }
               ]

--- a/gateway/src/apicast/policy/headers/headers.lua
+++ b/gateway/src/apicast/policy/headers/headers.lua
@@ -106,7 +106,7 @@ end
 --   2) When the header is set, it creates a new header with the same name and
 --      the given value.
 function _M.new(config)
-  local self = new()
+  local self = new(config)
   self.config = init_config(config)
   return self
 end

--- a/gateway/src/apicast/policy/token_introspection/token_introspection.lua
+++ b/gateway/src/apicast/policy/token_introspection/token_introspection.lua
@@ -10,7 +10,7 @@ local resty_env = require('resty.env')
 local new = _M.new
 
 function _M.new(config)
-  local self = new()
+  local self = new(config)
   self.config = config or {}
   --- authorization for the token introspection endpoint.
   -- https://tools.ietf.org/html/rfc7662#section-2.2

--- a/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
+++ b/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
@@ -23,11 +23,11 @@
               "type": "string",
               "oneOf": [
                 {
-                  "const": "sub",
+                  "enum": ["sub"],
                   "description": "Substitutes the first match of the regex applied."
                 },
                 {
-                  "const": "gsub",
+                  "enum": ["gsub"],
                   "description": "Substitutes all the matches of the regex applied."
                 }
               ]

--- a/gateway/src/apicast/policy/url_rewriting/url_rewriting.lua
+++ b/gateway/src/apicast/policy/url_rewriting/url_rewriting.lua
@@ -57,7 +57,7 @@ end
 --   - break[opt]: defaults to false. When set to true, if the command rewrote
 --     the URL, it will be the last command applied.
 function _M.new(config)
-  local self = new()
+  local self = new(config)
   self.commands = (config and config.commands) or {}
   return self
 end

--- a/gateway/src/apicast/policy_config_validator.lua
+++ b/gateway/src/apicast/policy_config_validator.lua
@@ -1,0 +1,20 @@
+--- Policy Config Validator
+-- @module policy_config_validator
+-- Validates a policy configuration against a policy config JSON schema.
+
+local jsonschema = require('jsonschema')
+
+local _M = { }
+
+--- Validate a policy configuration
+-- Checks if a policy configuration is valid according to the given schema.
+-- @tparam table config Policy configuration
+-- @tparam table config_schema Policy configuration schema
+-- @treturn boolean True if the policy configuration is valid. False otherwise.
+-- @treturn string Error message only when the policy config is invalid.
+function _M.validate_config(config, config_schema)
+  local validator = jsonschema.generate_validator(config_schema or {})
+  return validator(config or {})
+end
+
+return _M

--- a/spec/policy/caching/caching_spec.lua
+++ b/spec/policy/caching/caching_spec.lua
@@ -24,16 +24,6 @@ describe('Caching policy', function()
       ctx.cache_handler(cache, 'a_key', { status = 200 }, nil)
       assert.is_nil(cache:get('a_key'))
     end)
-
-    it('disables caching when invalid caching type is specified', function()
-      local config = { caching_type = 'invalid_caching_type' }
-      local caching_policy = require('apicast.policy.caching').new(config)
-      local ctx = {}
-      caching_policy:rewrite(ctx)
-
-      ctx.cache_handler(cache, 'a_key', { status = 200 }, nil)
-      assert.is_nil(cache:get('a_key'))
-    end)
   end)
 
   describe('.access', function()

--- a/spec/policy_config_validator_spec.lua
+++ b/spec/policy_config_validator_spec.lua
@@ -1,0 +1,58 @@
+local cjson = require('cjson')
+local policy_config_validator = require('apicast.policy_config_validator')
+
+describe('policy_config_validator', function()
+  -- We use the echo policy schema as an example for the tests.
+  local test_config_schema = cjson.decode([[
+    {
+      "type": "object",
+      "properties": {
+        "status": {
+          "description": "HTTP status code to be returned",
+          "type": "integer"
+        },
+        "exit": {
+          "description": "Exit mode",
+          "type": "string",
+          "oneOf": [{
+              "enum": ["request"],
+              "description": "Interrupts the processing of the request."
+            },
+            {
+              "enum": ["set"],
+              "description": "Only skips the rewrite phase."
+            }
+          ]
+        }
+      }
+    }
+  ]])
+
+  it('returns true with a config that conforms with the schema', function()
+    local valid_config = { status = 200, exit = "request" }
+
+    local is_valid, err = policy_config_validator.validate_config(
+      valid_config, test_config_schema)
+
+    assert.is_true(is_valid)
+    assert.is_nil(err)
+  end)
+
+  it('returns false with a config that does not conform with the schema', function()
+    local invalid_config = { status = "not_an_integer" }
+
+    local is_valid, err = policy_config_validator.validate_config(
+      invalid_config, test_config_schema)
+
+    assert.is_false(is_valid)
+    assert.is_not_nil(err)
+  end)
+
+  it('returns true when the schema is empty', function()
+    assert.is_true(policy_config_validator.validate_config({ a_param = 1 }, {}))
+  end)
+
+  it('returns true when the schema is nil', function()
+    assert.is_true(policy_config_validator.validate_config({ a_param = 1 }, nil))
+  end)
+end)

--- a/spec/spec_helper.lua
+++ b/spec/spec_helper.lua
@@ -38,6 +38,9 @@ local function reset()
 
   previous_env = {}
 
+  -- To make sure that we are using valid policy configs in the tests.
+  set('APICAST_VALIDATE_POLICY_CONFIGS', true)
+
   env.reset()
 end
 

--- a/t/apicast-policy-invalid-config.t
+++ b/t/apicast-policy-invalid-config.t
@@ -1,0 +1,44 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+use Cwd qw(abs_path);
+
+BEGIN {
+    $ENV{TEST_NGINX_APICAST_POLICY_LOAD_PATH} = 't/fixtures/policies';
+}
+
+env_to_apicast(
+    'APICAST_POLICY_LOAD_PATH' => abs_path($ENV{TEST_NGINX_APICAST_POLICY_LOAD_PATH}),
+);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: policy with invalid configuration
+In this test, we use an example policy that requires a 'message' param in the
+configuration. We are going to initialize the policy with an empty
+configuration and check that Apicast exits.
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "policy_chain": [
+          { "name": "example_policy", "version": "1.0.0", "configuration": { } }
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- request
+GET /?user_key=value
+--- must_die

--- a/t/fixtures/policies/example_policy/1.0.0/apicast-policy.json
+++ b/t/fixtures/policies/example_policy/1.0.0/apicast-policy.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "Example policy",
+  "description": "An example policy to be used in integration tests.",
+  "version": "1.0.0",
+  "configuration": {
+    "type": "object",
+    "properties": {
+      "message": {
+        "type": "string",
+        "description": "A message."
+      }
+    },
+    "required": ["message"]
+  }
+}

--- a/t/fixtures/policies/example_policy/1.0.0/example_policy.lua
+++ b/t/fixtures/policies/example_policy/1.0.0/example_policy.lua
@@ -1,0 +1,21 @@
+local _M = require('apicast.policy').new('example_policy', '1.0.0')
+
+local new = _M.new
+
+function _M.new(configuration)
+  local policy = new(configuration)
+
+  policy.message = ''
+
+  if configuration then
+    policy.message = configuration.message
+  end
+
+  return policy
+end
+
+function _M:content()
+  ngx.say(self.message)
+end
+
+return _M

--- a/t/fixtures/policies/example_policy/1.0.0/init.lua
+++ b/t/fixtures/policies/example_policy/1.0.0/init.lua
@@ -1,0 +1,1 @@
+return require('example_policy')


### PR DESCRIPTION
This PR introduces a way to validate a policy's configuration against the JSON schema defined for its configuration.

This is what I used to detect the problems in our tests fixed in previous PRs: #641 , #644 , #645 

We need to define and agree on a few things before this becomes mergeable. That's why I tagged it as WIP:
* I used `rapidjson` to perform the validation, and it needs cmake. This means that it should be installed on the base image.
* `rapidjson` uses the draft04 version of the JSON schema. I needed to replace the `const`s in our schemas so it works correctly as `const` was introduced in newer versions.
* I needed to instantiate policies using the same name and version used by the policy loaded to find the manifests easily.
* I think this feature should be opt-in via ENV and always enabled in the tests. (I didn't implement this part yet).