### PR TITLE
[upstream policy] use the default port (by scheme) for the upstream url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Added
 
 - New property `summary` in the policy manifests [PR #633](https://github.com/3scale/apicast/pull/633)
-- OAuth2.0 Token Introspection policy [PR #619](https://github.com/3scale/apicast/pull/619)
+- OAuth 2.0 Token Introspection policy [PR #619](https://github.com/3scale/apicast/pull/619)
 - New `metrics` phase that runs when prometheus is collecting metrics [PR #629](https://github.com/3scale/apicast/pull/629)
 - Validation of policy configs both in integration and unit tests [PR #646](https://github.com/3scale/apicast/pull/646)
 
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Avoid `nameserver` repetion from `RESOLVER` variable and `resolv.conf` file [PR #636](https://github.com/3scale/apicast/pull/636)
 - Bug in URL rewriting policy that ignored the `commands` attribute in the policy manifest [PR #641](https://github.com/3scale/apicast/pull/641)
 - Skip comentaries after `search` values in resolv.conf [PR #635](https://github.com/3scale/apicast/pull/635)
+- Add the default port based on scheme in the `upstream` policy if it is missing in the policy configuration [PR #647](https://github.com/3scale/apicast/pull/647)
 
 ## [3.2.0-beta1] - 2018-02-20
 

--- a/gateway/src/apicast/policy/upstream/upstream.lua
+++ b/gateway/src/apicast/policy/upstream/upstream.lua
@@ -27,7 +27,7 @@ end
 
 local function change_upstream(url)
   ngx.ctx.upstream = resty_resolver:instance():get_servers(
-    url.host, { port = url.port })
+    url.host, { port = url.port or resty_url.default_port(url.scheme) })
 
   ngx.var.proxy_pass = proxy_pass(url)
   ngx.req.set_header('Host', url.host)

--- a/spec/policy/upstream/upstream_spec.lua
+++ b/spec/policy/upstream/upstream_spec.lua
@@ -21,6 +21,7 @@ describe('Upstream policy', function()
 
       -- ngx functions and vars
       ngx.var = { uri = test_req_uri }
+      ngx.ctx = {}
       stub(ngx.req, 'set_header')
       stub(ngx, 'exec')
     end)
@@ -97,6 +98,25 @@ describe('Upstream policy', function()
         upstream:content(context)
         assert.is_falsy(context.upstream_changed)
       end)
+    end)
+
+    describe('when the port is not specified for the url', function()
+      local url_without_port = 'https://127.0.0.1/a_path'
+      local config_with_a_matching_rule = {
+        rules = {
+          { regex = '/', url = url_without_port }
+        }
+      }
+
+      local upstream = UpstreamPolicy.new(config_with_a_matching_rule)
+
+      it('sets a default port by scheme', function()
+        upstream:content(context)
+
+        assert.is_truthy(context.upstream_changed)
+        assert.equals(443, ngx.ctx.upstream[1].port)
+      end)
+
     end)
   end)
 


### PR DESCRIPTION
This fixes the following issue:

when the URL in the `upstream` policy is set to `https://something`, the port is `nil`, and so https://github.com/3scale/apicast/blob/2affe4e40e268841b489cf06c229a66ac9aa9749/gateway/src/resty/balancer.lua#L33 will set it to `80`. As a result APIcast will try to reach `https://something:80` and fail.

Couldn't figure out how to test this yet... some help would be appreciated @davidor @mikz 🙏 