### PR TITLE
Dockerized dev env: ensure correct dependencies are used

### DIFF
--- a/Dockerfile-development
+++ b/Dockerfile-development
@@ -25,6 +25,8 @@ COPY Makefile ${USER_HOME}
 WORKDIR ${USER_HOME}
 
 RUN make dependencies
+RUN mv lua_modules /tmp/lua_modules
+
 RUN cpanm --installdeps ./gateway
 
 COPY . ${USER_HOME}

--- a/README.md
+++ b/README.md
@@ -161,6 +161,26 @@ To see additional test targets (such as testing produced Docker images) use:
 make help
 ```
 
+## Development using Docker
+
+This option requires a single step:
+
+```shell
+make development
+```
+
+That will create a Docker container and run bash inside it. This command will
+take care of installing all dependencies.
+
+The project's source code will be available in the container and sync'ed with
+your local `apicast` directory, so you can edit files in your preferred
+environment and still be able to run whatever you need inside the Docker container.
+
+To run the tests inside the container, just run:
+```shell
+script/test
+```
+
 # Contributing
 For details on how to contribute to this repo see [CONTRIBUTING](.github/CONTRIBUTING.md)
 

--- a/script/test
+++ b/script/test
@@ -5,11 +5,15 @@ PROJECT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 ROVER="/usr/local/openresty/luajit/bin/rover"
 
 function run_busted_tests {
+    sudo cp -R /tmp/lua_modules .
+
     cd "${PROJECT_PATH}" || exit; ${ROVER} exec ./bin/busted
 }
 
 function run_nginx_unit_tests {
     cd "${PROJECT_PATH}" || exit
+
+    sudo cp -R /tmp/lua_modules .
 
     sudo TEST_NGINX_APICAST_PATH="${PROJECT_PATH}/gateway" \
          TEST_NGINX_BINARY=openresty \


### PR DESCRIPTION
The problem was that when mounting the volume, ./lua_modules was used instead of the one generated inside the container.

To solve the issue, lua_modules is moved to a tmp directory when building the container and we make sure to use it when running the tests in `script/test`.