### PR TITLE
Allow setting cache loader = boot on staging and never reload the config [THREESCALE-756] 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Avoid `nameserver` repetion from `RESOLVER` variable and `resolv.conf` file [PR #636](https://github.com/3scale/apicast/pull/636)
 - Bug in URL rewriting policy that ignored the `commands` attribute in the policy manifest [PR #641](https://github.com/3scale/apicast/pull/641)
 - Skip comentaries after `search` values in resolv.conf [PR #635](https://github.com/3scale/apicast/pull/635)
+- Bug that prevented using `CONFIGURATION_CACHE_LOADER=boot` without specifying `APICAST_CONFIGURATION_CACHE` in staging [PR #651](https://github.com/3scale/apicast/pull/651).
 
 ## [3.2.0-beta1] - 2018-02-20
 

--- a/gateway/Roverfile.lock
+++ b/gateway/Roverfile.lock
@@ -6,7 +6,7 @@ ldoc 1.4.6-2||development
 liquid 0.1.0-1||production
 ljsonschema 0.1.0-1||testing
 lua-resty-env 0.4.0-1||production
-lua-resty-execvp 0.1.0-1||production
+lua-resty-execvp 0.1.1-1||production
 lua-resty-http 0.12-0||production
 lua-resty-iputils 0.3.0-1||development
 lua-resty-jwt 0.1.11-0||production

--- a/gateway/config/staging.lua
+++ b/gateway/config/staging.lua
@@ -2,5 +2,5 @@ return {
     master_process = 'on',
     lua_code_cache = 'on',
     configuration_loader = 'lazy',
-    configuration_cache = 0,
+    configuration_cache = os.getenv('APICAST_CONFIGURATION_CACHE'),
 }

--- a/gateway/src/apicast/cli/command/start.lua
+++ b/gateway/src/apicast/cli/command/start.lua
@@ -110,15 +110,10 @@ local function openresty_binary(candidates)
 end
 
 local function build_env(options, config, context)
-    local configuration_cache = options.cache or context.configuration_cache
-    if configuration_cache then -- Avoid calling tostring() on nil, would return "nil".
-        configuration_cache = tostring(configuration_cache)
-    end
-
     return {
         APICAST_CONFIGURATION = options.configuration or context.configuration,
-        APICAST_CONFIGURATION_LOADER = tostring(options.configuration_loader or context.configuration_loader or 'lazy'),
-        APICAST_CONFIGURATION_CACHE = configuration_cache,
+        APICAST_CONFIGURATION_LOADER = options.configuration_loader or context.configuration_loader or 'lazy',
+        APICAST_CONFIGURATION_CACHE = options.cache or context.configuration_cache,
         THREESCALE_DEPLOYMENT_ENV = context.configuration_channel or options.channel or config.name,
         APICAST_POLICY_LOAD_PATH = concat(options.policy_load_path or context.policy_load_path, ':'),
     }

--- a/gateway/src/apicast/cli/command/start.lua
+++ b/gateway/src/apicast/cli/command/start.lua
@@ -110,10 +110,15 @@ local function openresty_binary(candidates)
 end
 
 local function build_env(options, config, context)
+    local configuration_cache = options.cache or context.configuration_cache
+    if configuration_cache then -- Avoid calling tostring() on nil, would return "nil".
+        configuration_cache = tostring(configuration_cache)
+    end
+
     return {
         APICAST_CONFIGURATION = options.configuration or context.configuration,
         APICAST_CONFIGURATION_LOADER = tostring(options.configuration_loader or context.configuration_loader or 'lazy'),
-        APICAST_CONFIGURATION_CACHE = tostring(options.cache or context.configuration_cache or 0),
+        APICAST_CONFIGURATION_CACHE = configuration_cache,
         THREESCALE_DEPLOYMENT_ENV = context.configuration_channel or options.channel or config.name,
         APICAST_POLICY_LOAD_PATH = concat(options.policy_load_path or context.policy_load_path, ':'),
     }

--- a/gateway/src/apicast/configuration_loader.lua
+++ b/gateway/src/apicast/configuration_loader.lua
@@ -60,7 +60,7 @@ end
 _M.mock = mock_loader.save
 
 local function ttl()
-  return tonumber(env.get('APICAST_CONFIGURATION_CACHE'), 10)
+  return tonumber(env.value('APICAST_CONFIGURATION_CACHE') or 0, 10)
 end
 
 function _M.global(contents)
@@ -121,7 +121,7 @@ end
 
 local boot = {
   rewrite = noop,
-  ttl = function() return tonumber(env.get('APICAST_CONFIGURATION_CACHE'), 10) end
+  ttl = function() return tonumber(env.value('APICAST_CONFIGURATION_CACHE'), 10) end
 }
 
 function boot.init(configuration)
@@ -135,7 +135,7 @@ function boot.init(configuration)
     os.exit(1)
   end
 
-  if ttl() == 0 then
+  if boot.ttl() == 0 then
     ngx.log(ngx.EMERG, 'cache is off, cannot store configuration, exiting')
     os.exit(0)
   end
@@ -153,7 +153,7 @@ local function refresh_configuration(configuration)
 end
 
 function boot.init_worker(configuration)
-  local interval = ttl() or 0
+  local interval = boot.ttl() or 0
 
   local function schedule(...)
     local ok, err = ngx.timer.at(...)

--- a/spec/configuration_loader_spec.lua
+++ b/spec/configuration_loader_spec.lua
@@ -1,3 +1,5 @@
+local env = require 'resty.env'
+
 insulate('Configuration object', function()
 
   insulate('.mock', function()
@@ -92,7 +94,14 @@ insulate('Configuration object', function()
     local configuration_store = require('apicast.configuration_store')
     local loader
 
-    before_each(function() loader = _M.new('lazy') end)
+    before_each(function()
+      loader = _M.new('lazy')
+
+      -- By default, the config is reloaded on every rewrite(), because
+      -- APICAST_CONFIGURATION_CACHE is set to 0. To be sure that it does not
+      -- change and we can compare it, we need to set the env.
+      env.set('APICAST_CONFIGURATION_CACHE', 120)
+    end)
 
     it('does not crash on rewrite', function()
       local configuration = configuration_store.new()

--- a/t/configuration-loading-boot-staging.t
+++ b/t/configuration-loading-boot-staging.t
@@ -1,0 +1,29 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+$ENV{THREESCALE_DEPLOYMENT_ENV} = 'staging';
+$ENV{APICAST_CONFIGURATION_LOADER} = 'boot';
+$ENV{APICAST_CONFIGURATION_CACHE} = '';
+
+filters { configuration => 'fixture=echo.json' };
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: 'boot' config loader in staging deployment env without config cache
+Test that APIcast does not crash when using the 'boot' config loader and the
+'staging' deployment env without a config cache value.
+This is a regression test. APIcast was setting a 0 as the default value for the
+config cache which is incompatible with the 'boot' loader method, and it
+crashed as a result.
+--- configuration
+--- request
+GET /test
+--- response_body
+GET /test HTTP/1.1
+X-Real-IP: 127.0.0.1
+Host: echo
+--- error_code: 200
+--- no_error_log
+[error]


### PR DESCRIPTION
APIcast crashes when it starts with:

```
THREESCALE_DEPLOYMENT_ENV: staging
APICAST_CONFIGURATION_LOADER: boot
APICAST_CONFIGURATION_CACHE: ''
```

Error msg:

```
[lua] configuration_loader.lua:139: init(): cache is off, cannot store configuration, exiting
```

This is because by default, the staging deployment env sets `configuration_cache` to 0, which is incompatible with the 'boot' mode. This PR solves the issue by avoiding setting that default.

Ref: https://issues.jboss.org/browse/THREESCALE-756