### PR TITLE
Require summary in policy manifests and add it to the ones that do not have one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bug in URL rewriting policy that ignored the `commands` attribute in the policy manifest [PR #641](https://github.com/3scale/apicast/pull/641)
 - Skip comentaries after `search` values in resolv.conf [PR #635](https://github.com/3scale/apicast/pull/635)
 
+
+## Changed
+
+- `summary` is now required in policy manifests [PR #655](https://github.com/3scale/apicast/pull/655)
+
 ## [3.2.0-beta1] - 2018-02-20
 
 ## Added

--- a/examples/policies/ngx-example/1.0.0/apicast-policy.json
+++ b/examples/policies/ngx-example/1.0.0/apicast-policy.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
   "name": "Ngx example policy",
+  "summary": "Sets request headers",
   "description":
   ["This policy is meant to be just an example.",
     "It sets request headers based on the configuration.",

--- a/gateway/src/apicast/policy/manifest-schema.json
+++ b/gateway/src/apicast/policy/manifest-schema.json
@@ -64,5 +64,5 @@
       "$ref": "#/definitions/schema"
     }
   },
-  "required": ["name", "version", "configuration"]
+  "required": ["name", "version", "configuration", "summary"]
 }

--- a/gateway/src/apicast/policy/token_introspection/apicast-policy.json
+++ b/gateway/src/apicast/policy/token_introspection/apicast-policy.json
@@ -1,9 +1,10 @@
 {
   "$schema": "http://apicast.io/poolicy-v1/schema#manifest#",
   "name": "oauth2 token introspection policy",
+  "summary": "Configures OAuth 2.0 Token Introspection.",
   "description": 
-  ["This policy executes OAuth 2.0 Token Introspection",
-   "(https://tools.ietf.org/html/rfc7662) for every API calls."],
+  ["This policy executes OAuth 2.0 Token Introspection ",
+   "(https://tools.ietf.org/html/rfc7662) for every API call."],
   "version": "builtin",
   "configuration": {
     "type": "object",

--- a/t/fixtures/policies/example_policy/1.0.0/apicast-policy.json
+++ b/t/fixtures/policies/example_policy/1.0.0/apicast-policy.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
   "name": "Example policy",
-  "description": "An example policy to be used in integration tests.",
+  "summary": "An example policy to be used in integration tests.",
   "version": "1.0.0",
   "configuration": {
     "type": "object",

--- a/t/fixtures/policies_endpoint_test/policies/example1/1.0.0/apicast-policy.json
+++ b/t/fixtures/policies_endpoint_test/policies/example1/1.0.0/apicast-policy.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
   "name": "Example policy 1",
-  "description": "Just an example.",
+  "summary": "Just an example.",
   "version": "1.0.0",
   "configuration": {
     "type": "object",

--- a/t/fixtures/policies_endpoint_test/policies/example2/1.0.0/apicast-policy.json
+++ b/t/fixtures/policies_endpoint_test/policies/example2/1.0.0/apicast-policy.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
   "name": "Example policy 2",
-  "description": "Just an example with a version mismatch.",
+  "summary": "Just an example with a version mismatch.",
   "version": "2.0.0",
   "configuration": {
     "type": "object",


### PR DESCRIPTION
This PR makes summary mandatory in the policy manifests.
The reason is that users of the UI might be confused if they see a blank space in the list of policies instead of a summary.