### PR TITLE
Add option to never reload configuration when configuration loader is lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - OAuth2.0 Token Introspection policy [PR #619](https://github.com/3scale/apicast/pull/619)
 - New `metrics` phase that runs when prometheus is collecting metrics [PR #629](https://github.com/3scale/apicast/pull/629)
 - Validation of policy configs both in integration and unit tests [PR #646](https://github.com/3scale/apicast/pull/646)
+- Option to avoid refreshing the config when using the lazy loader with `APICAST_CONFIGURATION_CACHE` < 0 [PR #657](https://github.com/3scale/apicast/pull/657)
 
 ## Fixed
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -17,10 +17,11 @@ Resilient will do so only on getting authorization denied from backend.
 
 ### `APICAST_CONFIGURATION_CACHE`
 
-**Values:** _a number > 60_  
+**Values:** _a number_
 **Default:** 0
 
 Specifies the interval (in seconds) that the configuration will be stored for. The value should be set to 0 (not compatible with boot value of `APICAST_CONFIGURATION_LOADER`) or more than 60. For example, if `APICAST_CONFIGURATION_CACHE` is set to 120, the gateway will reload the configuration from the API manager every 2 minutes (120 seconds).
+A value < 0 disables reloading.
 
 ### `APICAST_CONFIGURATION_LOADER`
 

--- a/gateway/src/apicast/configuration_store.lua
+++ b/gateway/src/apicast/configuration_store.lua
@@ -133,8 +133,15 @@ function _M.store(self, config, ttl)
 
   local cache = self.cache
 
+  local cache_ttl = config.ttl or ttl or _M.ttl
+
+  -- In lrucache a value < 0 expires, but we use configs and ENVs for
+  -- setting the ttl where < 0 means 'never expire'. When ttl < 0,
+  -- we need to set it to nil (never expire in lrucache).
+  if cache_ttl and cache_ttl < 0 then cache_ttl = nil end
+
   for host, services_for_host in pairs(by_host) do
-    cache:set(host, services_for_host, config.ttl or ttl or _M.ttl)
+    cache:set(host, services_for_host, cache_ttl)
   end
 
   return config

--- a/spec/configuration_loader_spec.lua
+++ b/spec/configuration_loader_spec.lua
@@ -57,7 +57,10 @@ insulate('Configuration object', function()
 
     it('returns false when configuration is stale', function()
       local config = configuration_store.new()
-      config:add({ id = 42, hosts = { 'example.com' } }, -1)
+
+      -- Can't add stale info with config.add. Need to do it through the
+      -- internals of the object.
+      config.cache:set('example.com', { { id = 42, hosts = { 'example.com' } } }, -1)
 
       assert.falsy(_M.configured(config, 'example.com'))
     end)

--- a/spec/configuration_store_spec.lua
+++ b/spec/configuration_store_spec.lua
@@ -151,20 +151,24 @@ describe('Configuration Store', function()
 
     it('returns stale records by default', function()
       local store = configuration.new()
-      local service =  { id = '21', hosts = { 'example.com', 'localhost' } }
+      local service =  { id = '21', hosts = { 'example.com' } }
 
-      store:add(service, -1)
+      -- Can't add stale info with config.add. Need to do it through the
+      -- internals of the object.
+      store.cache:set('example.com', { service }, -1)
 
       assert.same({ service }, store:find_by_host('example.com'))
     end)
 
     it('does not return stale records when disabled', function()
       local store = configuration.new()
-      local service =  { id = '21', hosts = { 'example.com', 'localhost' } }
+      local service =  { id = '21', hosts = { 'example.com' } }
 
-      store:add(service, -1)
+      -- Can't add stale info with config.add. Need to do it through the
+      -- internals of the object.
+      store.cache:set('example.com', { service }, -1)
 
-      assert.same({ }, store:find_by_host('example.com', false))
+      assert.same({}, store:find_by_host('example.com', false))
     end)
 
     it('normalizes hosts to lowercase', function()


### PR DESCRIPTION
It's not possible to use `APICAST_CONFIGURATION_LOADER=lazy` and never refresh the configuration. This PR solves the issue by allowing setting negatives values in `APICAST_CONFIGURATION_CACHE`.