### PR TITLE
OIDC: verify typ is Bearer when included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bug in URL rewriting policy that ignored the `commands` attribute in the policy manifest [PR #641](https://github.com/3scale/apicast/pull/641)
 - Skip comentaries after `search` values in resolv.conf [PR #635](https://github.com/3scale/apicast/pull/635)
 - Bug that prevented using `CONFIGURATION_CACHE_LOADER=boot` without specifying `APICAST_CONFIGURATION_CACHE` in staging [PR #651](https://github.com/3scale/apicast/pull/651).
-
+- `typ` is verified when it's present in keycloak tokens [PR #658](https://github.com/3scale/apicast/pull/658)
 
 ## Changed
 

--- a/gateway/src/apicast/oauth/oidc.lua
+++ b/gateway/src/apicast/oauth/oidc.lua
@@ -99,6 +99,13 @@ local function parse_and_verify_token(self, jwt_token)
   -- TODO: this should be able to use DER format instead of PEM
   local pubkey = format_public_key(self.config.public_key)
 
+  -- This is keycloak-specific. Its tokens have a 'typ' and we need to verify
+  -- it's Bearer.
+  local claims = self.jwt_claims
+  if jwt_obj.payload and jwt_obj.payload.typ then
+    claims.typ = jwt_validators.equals('Bearer')
+  end
+
   jwt_obj = jwt:verify_jwt_obj(pubkey, jwt_obj, self.jwt_claims)
 
   if not jwt_obj.verified then

--- a/spec/oauth/oidc_spec.lua
+++ b/spec/oauth/oidc_spec.lua
@@ -135,6 +135,43 @@ describe('OIDC', function()
       assert.match('invalid alg', err, nil, true)
       assert.falsy(credentials, err)
     end)
+
+    it('validation fails when typ is invalid', function()
+      local oidc = _M.new(service)
+      local access_token = jwt:sign(rsa.private, {
+        header = { typ = 'JWT', alg = 'RS256' },
+        payload = {
+          iss = service.oidc.issuer,
+          aud = 'notused',
+          azp = 'ce3b2e5e',
+          nbf = 0,
+          exp = ngx.now() + 10,
+          typ = 'Not-Bearer'
+        },
+      })
+
+      local credentials, _, err = oidc:transform_credentials({ access_token = access_token })
+      assert.same("Claim 'typ' ('Not-Bearer') returned failure", err)
+      assert.falsy(credentials, err)
+    end)
+
+    it('validation is successful when typ is included and is Bearer', function()
+      local oidc = _M.new(service)
+      local access_token = jwt:sign(rsa.private, {
+        header = { typ = 'JWT', alg = 'RS256' },
+        payload = {
+          iss = service.oidc.issuer,
+          aud = 'notused',
+          azp = 'ce3b2e5e',
+          nbf = 0,
+          exp = ngx.now() + 10,
+          typ = 'Bearer'
+        },
+      })
+
+      local credentials, _, err = oidc:transform_credentials({ access_token = access_token })
+      assert(credentials, err)
+    end)
   end)
 
 end)


### PR DESCRIPTION
This is Keycloak specific. It verifies 'typ' included in the token payload only when it's present.

Closes https://github.com/3scale/apicast/issues/643