### PR TITLE
Require 'ljsonschema' only when the validation of schemas is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `ljsonschema` is only used in testing but was required in production also [PR #660](https://github.com/3scale/apicast/pull/660)
+
 ## [3.2.0-beta2] - 2018-03-19
 
 ### Added

--- a/gateway/src/apicast/policy_loader.lua
+++ b/gateway/src/apicast/policy_loader.lua
@@ -14,8 +14,6 @@ local insert = table.insert
 local setmetatable = setmetatable
 local pcall = pcall
 
-local policy_config_validator = require('apicast.policy_config_validator')
-
 local _M = {}
 
 local resty_env = require('resty.env')
@@ -47,6 +45,11 @@ end
 local function policy_config_validation_is_enabled()
   return resty_env.enabled('APICAST_VALIDATE_POLICY_CONFIGS')
     or resty_env.value('TEST_NGINX_BINARY')
+end
+
+local policy_config_validator = { validate_config = function() return true end }
+if policy_config_validation_is_enabled() then
+  policy_config_validator = require('apicast.policy_config_validator')
 end
 
 local function read_manifest(path)


### PR DESCRIPTION
The validation is enabled only in testing and the validator relies on a rock that is marked as a 'testing' dependency. That means we need to require the validator only when the option is enabled, otherwise, it will
crash because of a missing dependency.