### PR TITLE
policy manifests: replace descriptions with titles in OneOfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- descriptions in `oneOf`s in policy manifests have been replaced with titles [PR #663](https://github.com/3scale/apicast/pull/663)
+
 ## [3.2.0-beta3] - 2018-03-20
 
 ### Fixed

--- a/gateway/src/apicast/policy/caching/apicast-policy.json
+++ b/gateway/src/apicast/policy/caching/apicast-policy.json
@@ -28,19 +28,19 @@
         "oneOf": [
           {
             "enum": ["resilient"],
-            "description": "Authorize according to last request when backend is down."
+            "title": "Authorize according to last request when backend is down."
           },
           {
             "enum": ["strict"],
-            "description": "It only caches authorized calls."
+            "title": "Cache only authorized calls."
           },
           {
             "enum": ["allow"],
-            "description": "When backend is down, allow everything unless seen before and denied."
+            "title": "When backend is down, allow everything unless seen before and denied."
           },
           {
             "enum": ["none"],
-            "description": "Disables caching."
+            "title": "Disable caching."
           }
         ]
       }

--- a/gateway/src/apicast/policy/echo/apicast-policy.json
+++ b/gateway/src/apicast/policy/echo/apicast-policy.json
@@ -19,11 +19,11 @@
         "oneOf": [
           {
             "enum": ["request"],
-            "description": "Interrupts the processing of the request."
+            "title": "Interrupt the processing of the request."
           },
           {
             "enum": ["set"],
-            "description": "Only skips the rewrite phase."
+            "title": "Skip only the rewrite phase."
           }
         ]
       }

--- a/gateway/src/apicast/policy/headers/apicast-policy.json
+++ b/gateway/src/apicast/policy/headers/apicast-policy.json
@@ -23,15 +23,15 @@
               "oneOf": [
                 {
                   "enum": ["add"],
-                  "description": "Adds a value to an existing header."
+                  "title": "Add a value to an existing header."
                 },
                 {
                   "enum": ["set"],
-                  "description": "Creates the header when not set, replaces its value when set."
+                  "title": "Create the header when not set, replace its value when set."
                 },
                 {
                   "enum": ["push"],
-                  "description": "Creates the header when not set, adds the value when set."
+                  "title": "Create the header when not set, add the value when set."
                 }
               ]
             },

--- a/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
+++ b/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
@@ -24,11 +24,11 @@
               "oneOf": [
                 {
                   "enum": ["sub"],
-                  "description": "Substitutes the first match of the regex applied."
+                  "title": "Substitute the first match of the regex applied."
                 },
                 {
                   "enum": ["gsub"],
-                  "description": "Substitutes all the matches of the regex applied."
+                  "title": "Substitute all the matches of the regex applied."
                 }
               ]
             },


### PR DESCRIPTION
This is a change proposed by @ddcesare 

The reason is that the library used in the UI to render policy configs does not show descriptions, but it shows titles.

From an APIcast point of view I don't see a difference, so I think this should be OK.