### PR TITLE
script/test: set redis host when running busted tests

### DIFF
--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -7,5 +7,11 @@ services:
     entrypoint: "bash"
     volumes:
       - .:/home/centos/
+    environment:
+      TEST_NGINX_REDIS_HOST: redis
+      TEST_NGINX_BINARY: openresty
+      PROJECT_PATH: /home/centos
+      TEST_NGINX_APICAST_PATH: /home/centos/gateway
+      ROVER: /usr/local/openresty/luajit/bin/rover
   redis:
     image: redis

--- a/script/test
+++ b/script/test
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 COMMAND=$1
-PROJECT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
-ROVER="/usr/local/openresty/luajit/bin/rover"
+PROJECT_PATH=${PROJECT_PATH-$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )}
+ROVER=${ROVER-/usr/local/openresty/luajit/bin/rover}
 
 function run_busted_tests {
     sudo cp -R /tmp/lua_modules .
-
-    cd "${PROJECT_PATH}" || exit; ${ROVER} exec ./bin/busted
+    cd "${PROJECT_PATH}" || exit
+    ${ROVER} exec ./bin/busted
 }
 
 function run_nginx_unit_tests {
@@ -15,10 +15,7 @@ function run_nginx_unit_tests {
 
     sudo cp -R /tmp/lua_modules .
 
-    sudo TEST_NGINX_APICAST_PATH="${PROJECT_PATH}/gateway" \
-         TEST_NGINX_BINARY=openresty \
-         TEST_NGINX_REDIS_HOST=redis \
-         ${ROVER} exec prove
+    sudo -E "${ROVER}" exec prove
 
     # Text::Nginx runs nginx in the t/servroot dir. Clean it.
     sudo rm -rf "${PROJECT_PATH}/t/servroot"


### PR DESCRIPTION
Busted tests are failing in the dockerized development environment.

The reason is that the unit tests of the rate limit policy use `TEST_NGINX_REDIS_HOST`, which was only set in `script/test` when running the `Test::Nginx` tests.

This PR simply sets that env when running busted tests.
