### PR TITLE
[dev] start development from any s2i-openresty version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+node_modules
+lua_modules
+.DS_Store
+t/servroot*
+log
+.idea
+*.swp
+tmp
+.vagrant

--- a/Dockerfile-development
+++ b/Dockerfile-development
@@ -18,16 +18,19 @@ RUN mkdir -p ${USER_HOME}/gateway \
  && echo "${USER_NAME} ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/${USER_NAME} \
  && chmod 0440 /etc/sudoers.d/${USER_NAME}
 
+COPY gateway/cpanfile ${USER_HOME}/gateway
+RUN cpanm --installdeps ${USER_HOME}/gateway
+
 COPY gateway/Roverfile ${USER_HOME}/gateway
 COPY gateway/Roverfile.lock ${USER_HOME}/gateway
-COPY gateway/cpanfile ${USER_HOME}/gateway
-COPY Makefile ${USER_HOME}
 
 WORKDIR ${USER_HOME}
 
-RUN make dependencies
+RUN rover install --roverfile=gateway/Roverfile
 
-RUN cpanm --installdeps ./gateway
+COPY Makefile ${USER_HOME}
+
+RUN make dependencies
 
 COPY . ${USER_HOME}
 

--- a/Dockerfile-development
+++ b/Dockerfile-development
@@ -1,4 +1,5 @@
-FROM quay.io/3scale/s2i-openresty-centos7:1.13.6.1-rover6
+ARG BUILDER_IMAGE
+FROM ${BUILDER_IMAGE}
 LABEL maintainer="dortiz@redhat.com"
 
 USER root
@@ -25,7 +26,6 @@ COPY Makefile ${USER_HOME}
 WORKDIR ${USER_HOME}
 
 RUN make dependencies
-RUN mv lua_modules /tmp/lua_modules
 
 RUN cpanm --installdeps ./gateway
 

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ clean-containers: apicast-source
 clean: clean-containers ## Remove all running docker containers and images
 	- docker rmi apicast-test apicast-runtime-test --force
 
-doc/lua/index.html: $(shell find gateway/src -name '*.lua') | dependencies $(ROVER)
+doc/lua/index.html: $(shell find gateway/src -name '*.lua' 2>/dev/null) | dependencies $(ROVER)
 	$(ROVER) exec ldoc -c doc/config.ld .
 
 doc: doc/lua/index.html ## Generate documentation

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ test-runtime-image: runtime-image clean-containers ## Smoke test the runtime ima
 	$(DOCKER_COMPOSE) run --rm test sh -c 'sleep 5 && curl --fail http://gateway:8090/status/live'
 
 build-development:
-	docker build -f $(DEVEL_DOCKERFILE) -t $(DEVEL_IMAGE) .
+	docker build -f $(DEVEL_DOCKERFILE) -t $(DEVEL_IMAGE) --build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) .
 
 development: build-development ## Run bash inside the development image
 	$(DOCKER_COMPOSE) -f $(DEVEL_DOCKER_COMPOSE_FILE) run --rm development


### PR DESCRIPTION
```shell
make development OPENRESTY_VERSION=tag
```

* automatically pull latest s2i-openresty version
* few performance enhancements of building the docker image

# TODO

- [x] ~~~`make dependencies` inside `make development` fails, looks like rover points to wrong luajit bin~~~
  This seems to be an issue with my local folder, but `git clean -f -x -d` fixed it.