### PR TITLE
Fix title of the token introspection and the rate limit policies in their manifests

### DIFF
--- a/gateway/src/apicast/policy/rate_limit/apicast-policy.json
+++ b/gateway/src/apicast/policy/rate_limit/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
-  "name": "rate limit policy",
+  "name": "Rate Limit",
   "summary": "Adds rate limit.",
   "description": ["This policy adds rate limit."],
   "version": "builtin",

--- a/gateway/src/apicast/policy/token_introspection/apicast-policy.json
+++ b/gateway/src/apicast/policy/token_introspection/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/poolicy-v1/schema#manifest#",
-  "name": "oauth2 token introspection policy",
+  "name": "OAuth 2.0 Token Introspection",
   "summary": "Configures OAuth 2.0 Token Introspection.",
   "description": 
   ["This policy executes OAuth 2.0 Token Introspection ",


### PR DESCRIPTION
A minor change proposed by @thomasmaas

This makes the title of the policy look nicer in the UI and more consistent with the rest of policies.