### PR TITLE
[cli] generate command to create scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - OpenTracing support [PR #669](https://github.com/3scale/apicast/pull/669)
 - Default value for the `caching_type` attribute of the caching policy config schema [#691](https://github.com/3scale/apicast/pull/691), [THREESCALE-845](https://issues.jboss.org/browse/THREESCALE-845)
+- Generate new policy scaffold from the CLI [PR #682](https://github.com/3scale/apicast/pull/682)
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,10 @@ ifeq ($(CPANM),)
 endif
 	$(CPANM) --notest --installdeps ./gateway
 
+find-file = $(shell find $(2) -type f -name $(1))
+
 prove: HARNESS ?= TAP::Harness
-prove: PROVE_FILES ?= $(shell find t examples  -type f -name "*.t")
+prove: PROVE_FILES ?= $(filter-out $(call find-file, "*.t", examples/scaffold),$(call find-file, *.t, t examples))
 prove: export TEST_NGINX_RANDOMIZE=1
 prove: $(ROVER) nginx cpan ## Test nginx
 	$(ROVER) exec prove -j$(NPROC) --harness=$(HARNESS) $(PROVE_FILES) 2>&1 | awk '/found ONLY/ { print "FAIL: because found ONLY in test"; print; exit 1 }; { print }'

--- a/doc/policies.md
+++ b/doc/policies.md
@@ -193,6 +193,12 @@ own:
 - [CORS](../gateway/src/apicast/policy/cors)
 - [Headers](../gateway/src/apicast/policy/headers)
 
+### Policy scaffolding
+
+We provide a policy generator to make this process easier and create basic structure for you.
+Policy scaffolding generator will provide you with structure for your code,
+policy manifest, unit tests and integration tests.
+Invoke `bin/apicast generate policy --help` and follow the documentation.
 
 ## Integrate your policies
 

--- a/examples/scaffold/policy/gateway/src/apicast/policy/{{policy.file}}/apicast-policy.json
+++ b/examples/scaffold/policy/gateway/src/apicast/policy/{{policy.file}}/apicast-policy.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "{{ policy.name }}",
+  "summary": "{{ policy.summary }}",
+  "description": [
+      "TODO: Write policy description"
+  ],
+  "version": "{{policy.version}}",
+  "configuration": {
+    "type": "object",
+    "properties": { }
+  }
+}

--- a/examples/scaffold/policy/gateway/src/apicast/policy/{{policy.file}}/init.lua
+++ b/examples/scaffold/policy/gateway/src/apicast/policy/{{policy.file}}/init.lua
@@ -1,0 +1,1 @@
+return require('{{ policy.file }}')

--- a/examples/scaffold/policy/gateway/src/apicast/policy/{{policy.file}}/{{policy.file}}.lua
+++ b/examples/scaffold/policy/gateway/src/apicast/policy/{{policy.file}}/{{policy.file}}.lua
@@ -1,0 +1,14 @@
+-- This is a {{ policy.name }} description.
+
+local policy = require('apicast.policy')
+local _M = policy.new('{{ policy.name }}')
+
+local new = _M.new
+--- Initialize a {{ policy.name }}
+-- @tparam[opt] table config Policy configuration.
+function _M.new(config)
+  local self = new(config)
+  return self
+end
+
+return _M

--- a/examples/scaffold/policy/spec/policy/{{policy.name}}/{{policy.name}}_spec.lua
+++ b/examples/scaffold/policy/spec/policy/{{policy.name}}/{{policy.name}}_spec.lua
@@ -1,0 +1,13 @@
+local _M = require('apicast.policy.{{ policy.file }}')
+
+describe('{{ policy.name }} policy', function()
+  describe('.new', function()
+    it('works without configuration', function()
+      assert(_M.new())
+    end)
+
+    it('accepts configuration', function()
+        assert(_M.new({ }))
+    end)
+  end)
+end)

--- a/examples/scaffold/policy/t/apicast-policy-{{policy.file}}.t
+++ b/examples/scaffold/policy/t/apicast-policy-{{policy.file}}.t
@@ -1,0 +1,29 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: {{ policy.name}} accepts configuration
+--- configuration
+{
+  "services": [
+    {
+      "proxy": {
+        "policy_chain": [
+          { "name": "apicast.policy.{{ policy.file }}",
+            "configuration": { } },
+          { "name": "apicast.policy.echo" }
+        ]
+      }
+    }
+  ]
+}
+--- request
+GET /t
+--- response_body
+GET /t HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]

--- a/gateway/bin/apicast
+++ b/gateway/bin/apicast
@@ -74,6 +74,7 @@ $ENV{LUA_PATH} = sprintf('%1$s/?.lua;', $apicast_src) . $lua_path;
 $ENV{LUA_CPATH} = sprintf('%1$s/?.so;', $apicast_lib) . $lua_lib;
 
 $ENV{PWD} = $cwd;
+$ENV{ARGV0} = $0;
 
 sub lua_file {
     my ($lua, $lua_file) = tempfile();

--- a/gateway/src/apicast/cli.lua
+++ b/gateway/src/apicast/cli.lua
@@ -2,7 +2,7 @@ require('apicast.loader')
 
 local command_target = '_cmd'
 local parser = require('argparse')() {
-    name = "APIcast",
+    name = os.getenv('ARGV0') or 'apicast',
     description = "APIcast - 3scale API Management Platform Gateway."
 }
 :command_target(command_target)

--- a/gateway/src/apicast/cli.lua
+++ b/gateway/src/apicast/cli.lua
@@ -20,7 +20,10 @@ local function load_commands(commands, argparse)
     return commands
 end
 
-_M.commands = load_commands({ 'start' }, parser)
+_M.commands = load_commands({
+  'start',
+  'generate',
+}, parser)
 
 function mt.__call(self, arg)
     -- now we parse the options like usual:

--- a/gateway/src/apicast/cli/command/generate.lua
+++ b/gateway/src/apicast/cli/command/generate.lua
@@ -1,0 +1,51 @@
+local setmetatable = setmetatable
+
+local filesystem = require('apicast.cli.filesystem')
+local pl = require'pl.import_into'()
+local Template = require('apicast.cli.template')
+
+local _M = { }
+local mt = { __index = _M }
+
+function mt.__call(_) end
+
+local function configure(cmd)
+  cmd:command_target("_command")
+
+  require('apicast.cli.command.generate.policy')(cmd)
+
+  return cmd
+end
+
+function _M.new(parser)
+  local cmd = configure(parser:command('generate', 'Generate scaffolding'))
+
+  return setmetatable({ parser = parser, cmd = cmd }, mt)
+end
+
+function _M.copy(source, destination, env, force)
+  print('source: ', source)
+  print('destination: ', destination)
+  print('')
+
+  local template = Template:new(env, source, true)
+
+  for filename in filesystem(source) do
+    local path = template:interpret(pl.path.relpath(filename, source))
+
+    local fullpath = pl.path.join(destination, path)
+
+    if pl.path.exists(fullpath) and not force then
+      print('exists: ', path)
+    elseif pl.path.isdir(filename) then
+      assert(pl.dir.makepath(fullpath))
+      print('created: ', path)
+    else
+      assert(pl.file.write(fullpath, template:render(filename)))
+      print('created: ', path)
+    end
+  end
+end
+
+
+return setmetatable(_M, mt)

--- a/gateway/src/apicast/cli/command/generate/policy.lua
+++ b/gateway/src/apicast/cli/command/generate/policy.lua
@@ -1,0 +1,41 @@
+local generate = require('apicast.cli.command.generate')
+local pl = require'pl.import_into'()
+
+local function call(options)
+  generate.copy(options.template, options.apicast, {
+    _brackets = '{}',
+    policy = {
+      file = options.name,
+      name = options.name,
+      version = options.version,
+      summary = options.summary,
+    }
+  }, options.force)
+end
+
+local directory = function(dir) if pl.path.dir(dir) then return pl.path.abspath(dir) end end
+
+return function(parser)
+  local cmd = parser:command('policy', 'create new policy')
+
+  cmd:argument('name', 'a name of the new policy')
+
+  cmd:option('--summary', 'Policy summary')
+    :default('TODO: write policy summary')
+
+  cmd:option('--apicast', 'APIcast directory')
+    :convert(directory):default('.')
+
+  cmd:option('--template', 'path to a policy template')
+    :convert(directory):default('examples/scaffold/policy')
+
+  cmd:option('--version', 'policy version')
+    :default('builtin')
+
+  cmd:flag('-f --force', 'override existing files'):default(false)
+  cmd:flag('-n --dry-run', 'do not create anything')
+    :default(false)
+    :action(function() error('dry run does not work yet') end)
+
+  cmd:action(call)
+end

--- a/gateway/src/apicast/cli/command/start.lua
+++ b/gateway/src/apicast/cli/command/start.lua
@@ -178,7 +178,6 @@ end
 local load_env = split_by(':')
 
 local function configure(cmd)
-    cmd:usage("Usage: apicast-cli start [OPTIONS]")
     cmd:option("--template", "Nginx config template.", 'conf/nginx.conf.liquid')
 
     local channel = resty_env.value('THREESCALE_DEPLOYMENT_ENV') or 'production'

--- a/gateway/src/apicast/cli/command/start.lua
+++ b/gateway/src/apicast/cli/command/start.lua
@@ -15,11 +15,7 @@ local re = require('ngx.re')
 local Template = require('apicast.cli.template')
 local Environment = require('apicast.cli.environment')
 
-local pl = {
-    path = require('pl.path'),
-    file = require('pl.file'),
-    dir = require('pl.dir'),
-}
+local pl = require'pl.import_into'()
 
 local _M = {
     openresty = { 'openresty-debug', 'openresty', 'nginx' },


### PR DESCRIPTION
The idea is to replace the need to copy-paste with scaffolding.

```shell
$ bin/apicast generate policy somename -f
source: /Users/mikz/Developer/3scale/apicast/examples/scaffold/policy
destination: /Users/mikz/Developer/3scale/apicast

created: spec
created: spec/policy
created: spec/policy/somename
created: spec/policy/somename/somename_spec.lua
created: t
created: t/apicast-policy-somename.t
created: gateway
created: gateway/src
created: gateway/src/apicast
created: gateway/src/apicast/policy
created: gateway/src/apicast/policy/somename
created: gateway/src/apicast/policy/somename/apicast-policy.json
created: gateway/src/apicast/policy/somename/init.lua
created: gateway/src/apicast/policy/somename/somename.lua
```