### PR TITLE
Fix validation of policy configs in busted tests

### DIFF
--- a/spec/spec_helper.lua
+++ b/spec/spec_helper.lua
@@ -38,10 +38,10 @@ local function reset()
 
   previous_env = {}
 
+  env.reset()
+
   -- To make sure that we are using valid policy configs in the tests.
   set('APICAST_VALIDATE_POLICY_CONFIGS', true)
-
-  env.reset()
 end
 
 busted.before_each(reset)


### PR DESCRIPTION
Validation of policy config schemas in busted tests was not working correctly because the ENV that controls that was not set correctly.

Even though the validation was not working correctly, there were not any invalid configs. Not sure when this broke.