### PR TITLE
Fix incorrect param value in the Echo policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed set of valid values for the exit param of the Echo policy [PR #684](https://github.com/3scale/apicast/pull/684/)
+
 ## [3.2.0-rc1] - 2018-04-24
 
 ### Added

--- a/gateway/src/apicast/policy/echo/apicast-policy.json
+++ b/gateway/src/apicast/policy/echo/apicast-policy.json
@@ -22,7 +22,7 @@
             "title": "Interrupt the processing of the request."
           },
           {
-            "enum": ["set"],
+            "enum": ["phase"],
             "title": "Skip only the rewrite phase."
           }
         ]

--- a/spec/policy/echo/echo_spec.lua
+++ b/spec/policy/echo/echo_spec.lua
@@ -1,0 +1,28 @@
+local EchoPolicy = require('apicast.policy.echo')
+
+describe('Echo policy', function()
+  describe('.rewrite', function()
+    describe('when configured with exit=request', function()
+      it('stops processing the request and returns with the configured status', function()
+        local ngx_exit_spy = spy.on(ngx, 'exit')
+        local status = 200
+        local echo = EchoPolicy.new({ status = status, exit = 'request' })
+
+        echo:rewrite()
+
+        assert.spy(ngx_exit_spy).was_called_with(status)
+      end)
+    end)
+
+    describe('when configured with exit=phase', function()
+      it('skips the current phase', function()
+        local ngx_exit_spy = spy.on(ngx, 'exit')
+        local echo = EchoPolicy.new({ status = 200, exit = 'phase' })
+
+        echo:rewrite()
+
+        assert.spy(ngx_exit_spy).was_called_with(0)
+      end)
+    end)
+  end)
+end)


### PR DESCRIPTION
The code was assuming that valid values for `exit` were `request` and `set`. However, valid values according to the schema are `request` and `set`. The latter was changed in the schema by mistake.