### PR TITLE
3scale batcher policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - OpenTracing support [PR #669](https://github.com/3scale/apicast/pull/669)
 - Default value for the `caching_type` attribute of the caching policy config schema [#691](https://github.com/3scale/apicast/pull/691), [THREESCALE-845](https://issues.jboss.org/browse/THREESCALE-845)
 - Generate new policy scaffold from the CLI [PR #682](https://github.com/3scale/apicast/pull/682)
+- 3scale batcher policy [PR #685](https://github.com/3scale/apicast/pull/685)
 
 ### Fixed
 

--- a/gateway/conf/nginx.conf.liquid
+++ b/gateway/conf/nginx.conf.liquid
@@ -159,6 +159,13 @@ http {
 
   lua_shared_dict limiter 1m;
 
+  # This shared dictionaries are only used in the 3scale batcher policy.
+  # This is not ideal, but they'll need to be here until we allow policies to
+  # modify this template.
+  lua_shared_dict cached_auths 1m;
+  lua_shared_dict batched_reports 1m;
+  lua_shared_dict batched_reports_locks 1m;
+
   {% for file in "sites.d/*.conf" | filesystem %}
     {% include file %}
   {% endfor %}

--- a/gateway/src/apicast/errors.lua
+++ b/gateway/src/apicast/errors.lua
@@ -1,0 +1,47 @@
+local _M = { }
+
+function _M.no_credentials(service)
+  ngx.log(ngx.INFO, 'no credentials provided for service ', service.id)
+  ngx.var.cached_key = nil
+  ngx.status = service.auth_missing_status
+  ngx.header.content_type = service.auth_missing_headers
+  ngx.print(service.error_auth_missing)
+  return ngx.exit(ngx.HTTP_OK)
+end
+
+function _M.authorization_failed(service)
+  ngx.log(ngx.INFO, 'authorization failed for service ', service.id)
+  ngx.var.cached_key = nil
+  ngx.status = service.auth_failed_status
+  ngx.header.content_type = service.auth_failed_headers
+  ngx.print(service.error_auth_failed)
+  return ngx.exit(ngx.HTTP_OK)
+end
+
+function _M.limits_exceeded(service)
+  ngx.log(ngx.INFO, 'limits exceeded for service ', service.id)
+  ngx.var.cached_key = nil
+  ngx.status = service.limits_exceeded_status
+  ngx.header.content_type = service.limits_exceeded_headers
+  ngx.print(service.error_limits_exceeded)
+  return ngx.exit(ngx.HTTP_OK)
+end
+
+function _M.no_match(service)
+  ngx.header.x_3scale_matched_rules = ''
+  ngx.log(ngx.INFO, 'no rules matched for service ', service.id)
+  ngx.var.cached_key = nil
+  ngx.status = service.no_match_status
+  ngx.header.content_type = service.no_match_headers
+  ngx.print(service.error_no_match)
+  return ngx.exit(ngx.HTTP_OK)
+end
+
+function _M.service_not_found(host)
+  ngx.status = 404
+  ngx.print('')
+  ngx.log(ngx.WARN, 'could not find service for host: ', host or ngx.var.host)
+  return ngx.exit(ngx.status)
+end
+
+return _M

--- a/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
@@ -1,0 +1,150 @@
+local backend_client = require('apicast.backend_client')
+local AuthsCache = require('auths_cache')
+local ReportsBatcher = require('reports_batcher')
+local policy = require('apicast.policy')
+local errors = require('apicast.errors')
+local reporter = require('reporter')
+local http_ng_resty = require('resty.http_ng.backend.resty')
+local semaphore = require('ngx.semaphore')
+
+local ipairs = ipairs
+
+local default_auths_ttl = 10
+local default_batch_reports_seconds = 10
+
+local _M = policy.new('Caching policy')
+
+local new = _M.new
+
+function _M.new(config)
+  local self = new(config)
+
+  local auths_ttl = config.auths_ttl or default_auths_ttl
+  self.auths_cache = AuthsCache.new(ngx.shared.cached_auths, auths_ttl)
+
+  self.reports_batcher = ReportsBatcher.new(
+    ngx.shared.batched_reports, 'batched_reports_locks')
+
+  self.batch_reports_seconds = config.batch_reports_seconds or
+                               default_batch_reports_seconds
+
+  self.report_timer_on = false
+
+  -- Semaphore used to ensure that only one timer is started per worker.
+  local semaphore_report_timer, err = semaphore.new(1)
+  if not semaphore_report_timer then
+    ngx.log(ngx.ERR, "Create semaphore failed: ", err)
+  end
+  self.semaphore_report_timer = semaphore_report_timer
+
+  return self
+end
+
+-- TODO: More policies are using this method. Move it to backend_client to
+-- avoid duplicating code.
+-- Converts a usage to the format expected by the 3scale backend client.
+local function format_usage(usage)
+  local res = {}
+
+  local usage_metrics = usage.metrics
+  local usage_deltas = usage.deltas
+
+  for _, metric in ipairs(usage_metrics) do
+    local delta = usage_deltas[metric]
+    res['usage[' .. metric .. ']'] = delta
+  end
+
+  return res
+end
+
+local function set_flags_to_avoid_auths_in_apicast(context)
+  context.skip_apicast_access = true
+  context.skip_apicast_post_action = true
+end
+
+local function report(_, service_id, backend, reports_batcher)
+  local reports = reports_batcher:get_all(service_id)
+
+  -- TODO: verify if we should limit the number of reports sent in a sigle req
+  reporter.report(reports, service_id, backend, reports_batcher)
+end
+
+-- This starts a timer on each worker.
+-- Starting a timer on each worker means that there will be more calls to
+-- 3scale backend, and the config param 'batch_report_seconds' becomes
+-- more confusing because the reporting frequency will be affected by the
+-- number of APIcast workers.
+-- If we started a timer just on one of the workers, it could die, and then,
+-- there would not be any reporting.
+local function ensure_report_timer_on(self, service_id, backend)
+  local check_timer = self.semaphore_report_timer:wait(0)
+
+  if check_timer then
+    if not self.report_timer_on then
+      ngx.timer.every(self.batch_reports_seconds, report,
+        service_id, backend, self.reports_batcher)
+
+      self.report_timer_on = true
+    end
+
+    self.semaphore_report_timer:post()
+  end
+end
+
+local function rejection_reason_from_headers(response_headers)
+  return response_headers and response_headers['3scale-rejection-reason']
+end
+
+local function error(service, rejection_reason)
+  if rejection_reason == 'limits_exceeded' then
+    return errors.limits_exceeded(service)
+  else
+    return errors.authorization_failed(service)
+  end
+end
+
+-- Note: when an entry in the cache expires, there might be several requests
+-- with those credentials and all of them will call auth() on backend with the
+-- same parameters until the auth status is cached again. In the future, we
+-- might want to introduce a mechanism to avoid this and reduce the number of
+-- calls to backend.
+function _M:access(context)
+  local backend = backend_client:new(context.service, http_ng_resty)
+  local usage = context.usage
+  local service = context.service
+  local service_id = service.id
+  local credentials = context.credentials
+
+  ensure_report_timer_on(self, service_id, backend)
+
+  local cached_auth = self.auths_cache:get(service_id, credentials, usage)
+
+  if not cached_auth then
+    local formatted_usage = format_usage(usage)
+    local backend_res = backend:authorize(formatted_usage, credentials)
+    local backend_status = backend_res.status
+
+    if backend_status == 200 then
+      self.auths_cache:set(service_id, credentials, usage, 200)
+      local to_batch = { service_id = service_id, credentials = credentials, usage = usage }
+      self.reports_batcher:add(to_batch.service_id, to_batch.credentials, to_batch.usage)
+    elseif backend_status >= 400 and backend_status < 500 then
+      local rejection_reason = rejection_reason_from_headers(backend_res.headers)
+      self.auths_cache:set(service_id, credentials, usage, backend_status, rejection_reason)
+      return error(service, rejection_reason)
+    else
+      return error(service)
+    end
+  else
+    if cached_auth.status == 200 then
+      local to_batch = { service_id = service_id, credentials = credentials, usage = usage }
+      self.reports_batcher:add(to_batch.service_id, to_batch.credentials, to_batch.usage)
+    else
+      return error(service, cached_auth.rejection_reason)
+    end
+  end
+
+  set_flags_to_avoid_auths_in_apicast(context)
+end
+
+return _M

--- a/gateway/src/apicast/policy/3scale_batcher/README.md
+++ b/gateway/src/apicast/policy/3scale_batcher/README.md
@@ -1,0 +1,65 @@
+# 3scale Batcher Policy
+
+## Description
+
+The APIcast policy performs one call to the 3scale backend for each request that
+it receives. The goal of this policy is to reduce latency and increase
+throughput by significantly reducing the number of requests made to the 3scale
+backend. In order to achieve that, this policy caches authorization statuses and
+batches reports.
+
+## Technical details
+
+When the APIcast policy receives a request, it makes an 'authrep' call to
+backend. This call checks the credentials sent by APIcast, and also applies rate
+limiting over the metrics sent by APIcast. If the credentials are correct and
+rate limits not violated, backend also increases the counters of the metrics
+reported by APIcast. This counters are used both to show statistics in the
+3scale UI and also to apply the rate limits. This means that the rate limiting
+applied will not be accurate until the counter is updated. For limits defined
+for long windows of time (hour, day, etc.) this update lag if often irrelevant.
+However, it might be important to take it into account for limits defined for a
+small window of time (a per-minute limit, for example).
+
+This policy uses a cache for authorizations and batches reports. Also, it makes
+'authorize' and 'report' calls to backend instead of 'authrep' calls. On each
+request, the flow is as follows:
+
+1. The policy checks whether the credentials are cached. If they are, the policy
+uses the cached authorization status instead of calling 3scale's backend. When
+the credentials are not cached, it calls backend and caches the authorization
+status with a configurable TTL.
+
+2. Instead of reporting to 3scale's backend the metrics associated with the
+request, the policy accumulates their usages to report to backend in batches.
+
+Apart from that, there's a separate thread that reports to backend periodically.
+The time is configurable. This thread fetches all the batched reports and sends
+them to backend in a single call.
+
+This approach increases throughput for two reasons. First, it caches
+authorizations. This reduces the number of calls to the 3scale backend. Second,
+it batches the reports. This also helps reducing the number of calls made to the
+3scale backend, but more importantly, it also reduces the amount of work it
+needs to do because the policy already aggregated the metrics to report. Suppose
+that we define a mapping rule that increases the metric 'hits' by one on each
+request. Suppose also that we have 1000 requests per second. If we define a
+batching period of 10 seconds, this policy will report to 3scale backend just a
+'hits +10000' instead of 10000 separated 'hits +1'. This is very important,
+because from the 3scale backend perspective reporting a +10000 or a +1 to its
+database it's the same amount of work.
+
+Of course, reporting to 3scale in batches has a trade-off. Rate limiting loses
+accuracy. The reason is that while reports are accumulated, they're not being
+sent to backend and rate limits only take into account reports that have been
+stored in the 3scale backend database. In summary, going over the defined usage
+limits is easier. The APIcast policy reports to 3scale backend every time it
+receives a request. Reports are asynchronous and that means that we can go over
+the limits for a brief window of time. On the other hand, this policy reports
+every X seconds (configurable) to 3scale backend. The window of time in which we
+can get over the limits is wider in this case.
+
+The effectiveness of this policy will depend on the cache hit ratio. For use
+cases where the variety of services, apps, metrics, etc. is relatively low,
+caching and batching will be very effective and will increase the throughput of
+the system significantly.

--- a/gateway/src/apicast/policy/3scale_batcher/apicast-policy.json
+++ b/gateway/src/apicast/policy/3scale_batcher/apicast-policy.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "3scale batcher",
+  "summary": "Caches auths from 3scale backend and batches reports.",
+  "description":
+    ["This policy caches authorizations from the 3scale backend ",
+     "and also reports in batches. Doing this is more efficient than ",
+     "authorizing and reporting on each request at the expense of losing ",
+     "accuracy in the rate limits."],
+  "version": "builtin",
+  "configuration": {
+    "type": "object",
+    "properties": {
+      "auths_ttl": {
+        "description": "TTL for cached auths in seconds",
+        "type": "integer"
+      },
+      "batch_report_seconds": {
+        "description": "Duration (in seconds) for batching reports",
+        "type": "integer"
+      }
+    }
+  }
+}

--- a/gateway/src/apicast/policy/3scale_batcher/auths_cache.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/auths_cache.lua
@@ -1,0 +1,67 @@
+local keys_helper = require('apicast.policy.3scale_batcher.keys_helper')
+
+local re = require('ngx.re')
+local re_split = re.split
+
+local setmetatable = setmetatable
+local format = string.format
+local tonumber = tonumber
+
+local _M = {}
+
+local mt = { __index = _M }
+
+--- Initialize a cache for authorizations.
+-- @tparam storage ngx.shared.dict Shared dict to store the authorizations
+-- @tparam ttl integer TTL for the cached authorizations
+-- @treturn AuthsCache New cache for authorizations
+function _M.new(storage, ttl)
+  local self = setmetatable({}, mt)
+  self.storage = storage
+  self.ttl = ttl
+  return self
+end
+
+local function value_to_cache(auth_status, rejection_reason)
+  if rejection_reason then
+    return format("%s:%s", auth_status, rejection_reason)
+  else
+    return auth_status
+  end
+end
+
+--- Get a cached authorization.
+-- @tparam service_id string Service ID
+-- @tparam credentials table The keys of the table are the credential type
+--   (user_key, app_id or access_token) and the values are the credentials
+-- @tparam usage Usage The usage to authorize
+-- @treturn table The table has a "status" and a "rejection_reason"
+function _M:get(service_id, credentials, usage)
+  local key = keys_helper.key_for_cached_auth(service_id, credentials, usage)
+  local cached_value = self.storage:get(key)
+
+  if not cached_value then return nil end
+
+  local split_val = re_split(cached_value, ':', 'oj', nil, 2)
+  return { status = tonumber(split_val[1]), rejection_reason = split_val[2] }
+end
+
+--- Store an authorization in the cache.
+-- @tparam service_id string Service ID
+-- @tparam credentials table The keys of the table are the credential type
+--   (user_key, app_id or access_token) and the values are the credentials
+-- @tparam usage Usage Usage of the authorization
+-- @tparam auth_status integer Status returned by backend (200, 409, etc.)
+-- @tparam[opt] rejection_reason string Rejection reason given by backend
+--   when it denies an authorization
+function _M:set(service_id, credentials, usage, auth_status, rejection_reason)
+  local key = keys_helper.key_for_cached_auth(service_id, credentials, usage)
+  local val_to_cache = value_to_cache(auth_status, rejection_reason)
+
+  local ok, err = self.storage:set(key, val_to_cache, self.ttl)
+  if not ok then
+    ngx.log(ngx.ERR, 'Failed to set value in storage: ', err)
+  end
+end
+
+return _M

--- a/gateway/src/apicast/policy/3scale_batcher/init.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/init.lua
@@ -1,0 +1,1 @@
+return require('3scale_batcher')

--- a/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
@@ -1,0 +1,79 @@
+local ipairs = ipairs
+local format = string.format
+local insert = table.insert
+local concat = table.concat
+local sort = table.sort
+local unpack = table.unpack
+local ngx_re = ngx.re
+local table = table
+
+local _M = {}
+
+local function creds_part_in_key(creds)
+  if creds.app_id and creds.app_key then
+    return format("app_id:%s,app_key:%s", creds.app_id, creds.app_key)
+  elseif creds.user_key then
+    return format("user_key:%s", creds.user_key)
+  elseif creds.access_token then
+    return format("access_token:%s", creds.access_token)
+  end
+end
+
+local function metrics_part_in_key(usage)
+  local usages = table.new(#usage.metrics, 0)
+
+  local deltas = usage.deltas
+
+  -- Need to sort the metrics. Otherwise, same metrics but in different order,
+  -- would end up in a different key.
+  local metrics = { unpack(usage.metrics) } -- Does not modify the original.
+  sort(metrics)
+
+  for _, metric in ipairs(metrics) do
+    insert(usages, format("%s=%s", metric, deltas[metric]))
+  end
+
+  return format("metrics:%s", concat(usages, ';'))
+end
+
+local regexes_report_key = {
+  "service_id:(?<service_id>[\\w-]+),user_key:(?<user_key>[\\w-]+),metric:(?<metric>[\\w-]+)",
+  "service_id:(?<service_id>[\\w-]+),access_token:(?<access_token>[\\w-]+),metric:(?<metric>[\\w-]+)",
+  "service_id:(?<service_id>[\\w-]+),app_id:(?<app_id>[\\w-]+),app_key:(?<app_key>[\\w-]+),metric:(?<metric>[\\w-]+)"
+}
+
+function _M.key_for_cached_auth(service_id, credentials, usage)
+  local service_part = format("service_id:%s", service_id)
+  local creds_part = creds_part_in_key(credentials)
+  local metrics_part = metrics_part_in_key(usage)
+
+  return format("%s,%s,%s", service_part, creds_part, metrics_part)
+end
+
+function _M.key_for_batched_report(service_id, credentials, metric_name)
+  local creds_part = creds_part_in_key(credentials)
+
+  return format("service_id:%s,%s,metric:%s",
+                service_id, creds_part, metric_name)
+end
+
+function _M.report_from_key_batched_report(key, value)
+  for _, regex in ipairs(regexes_report_key) do
+    local match = ngx_re.match(key, regex, 'oj')
+
+    if match then
+      -- some credentials will be nil.
+      return {
+        service_id = match.service_id,
+        metric = match.metric,
+        user_key = match.user_key,
+        access_token = match.access_token,
+        app_id = match.app_id,
+        app_key = match.app_key,
+        value = value
+      }
+    end
+  end
+end
+
+return _M

--- a/gateway/src/apicast/policy/3scale_batcher/reporter.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/reporter.lua
@@ -1,0 +1,38 @@
+local ReportsBatch = require('apicast.policy.3scale_batcher.reports_batch')
+local Usage = require('apicast.usage')
+
+local pairs = pairs
+
+local _M = {}
+
+local function return_reports(service_id, batch, reports_batcher)
+  local credentials_type = batch.credentials_type
+
+  for credential, metrics in pairs(batch.reports) do
+    local usage = Usage.new()
+    for metric, value in pairs(metrics) do
+      usage:add(metric, value)
+    end
+
+    reports_batcher:add(
+      service_id,
+      { [credentials_type] = credential },
+      usage
+    )
+  end
+end
+
+function _M.report(reports, service_id, backend_client, reports_batcher)
+  if #reports > 0 then
+    local batch = ReportsBatch.new(service_id, reports)
+
+    local res_report = backend_client:report(batch)
+
+    if not res_report.ok then
+      ngx.log(ngx.WARN, "Returning reports to the batcher because couldn't report to backend")
+      return_reports(service_id, batch, reports_batcher)
+    end
+  end
+end
+
+return _M

--- a/gateway/src/apicast/policy/3scale_batcher/reports_batch.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/reports_batch.lua
@@ -1,0 +1,35 @@
+local setmetatable = setmetatable
+local ipairs = ipairs
+
+local _M = {}
+
+local mt = { __index = _M }
+
+local function add_value(reports, credential, metric, value)
+  reports[credential] = reports[credential] or {}
+  reports[credential][metric] = reports[credential][metric] or 0
+  reports[credential][metric] = reports[credential][metric] + value
+end
+
+function _M.new(service_id, reports)
+  local self = setmetatable({}, mt)
+
+  self.service_id = service_id
+
+  if reports[1] then
+    -- A service only works with a type of credentials. We know that all the
+    -- reports will have the same type so checking the first one is enough.
+    self.credentials_type = (reports[1].user_key and 'user_key') or
+                            (reports[1].app_id and 'app_id') or
+                            (reports[1].access_token and 'access_token')
+  end
+
+  self.reports = {}
+  for _, report in ipairs(reports) do
+    add_value(self.reports, report[self.credentials_type], report.metric, report.value)
+  end
+
+  return self
+end
+
+return _M

--- a/gateway/src/apicast/policy/3scale_batcher/reports_batcher.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/reports_batcher.lua
@@ -1,0 +1,91 @@
+local keys_helper = require('apicast.policy.3scale_batcher.keys_helper')
+
+local setmetatable = setmetatable
+local ipairs = ipairs
+local insert = table.insert
+local resty_lock = require 'resty.lock'
+
+local _M = {}
+
+local mt = { __index = _M }
+
+local lock_timeout = 10
+local lock_options = { timeout = lock_timeout }
+
+-- Note: storage needs to implement shdict interface.
+function _M.new(storage, lock_shdict_name)
+  local self = setmetatable({}, mt)
+  self.storage = storage
+  self.lock_shdict_name = lock_shdict_name
+  return self
+end
+
+-- Note: When the lock cannot be acquired, the report will be lost.
+-- The timeout is high, that means that if it could not be acquired, there's
+-- probably a problem in the system.
+-- TODO: Find a solution for this.
+function _M:add(service_id, credentials, usage)
+  local deltas = usage.deltas
+
+  local lock, new_lock_err = resty_lock:new(self.lock_shdict_name, lock_options)
+  if not lock then
+    ngx.log(ngx.ERR, 'failed to create lock: ', new_lock_err)
+    return
+  end
+
+  local elapsed, lock_err = lock:lock(service_id)
+  if not elapsed then
+    ngx.log("failed to acquire the lock: ", lock_err)
+    return
+  end
+
+  for _, metric in ipairs(usage.metrics) do
+    local key = keys_helper.key_for_batched_report(service_id, credentials, metric)
+    self.storage:incr(key, deltas[metric], 0)
+  end
+
+  local ok, unlock_err = lock:unlock()
+  if not ok then
+    ngx.log(ngx.ERR, 'failed to unlock: ', unlock_err)
+    return
+  end
+end
+
+function _M:get_all(service_id)
+  local cached_reports = {}
+
+  local cached_report_keys = self.storage:get_keys()
+
+  local lock, new_lock_err = resty_lock:new(self.lock_shdict_name, lock_options)
+  if not lock then
+    ngx.log(ngx.ERR, 'failed to create lock: ', new_lock_err)
+    return {}
+  end
+
+  local elapsed, lock_err = lock:lock(service_id)
+  if not elapsed then
+    ngx.log(ngx.ERR, "failed to acquire the lock: ", lock_err)
+    return {}
+  end
+
+  for _, key in ipairs(cached_report_keys) do
+    local value = self.storage:get(key)
+
+    local report = keys_helper.report_from_key_batched_report(key, value)
+
+    if value and value > 0 and report.service_id == service_id then
+      insert(cached_reports, report)
+      self.storage:delete(key)
+    end
+  end
+
+  local ok, unlock_err = lock:unlock()
+  if not ok then
+    ngx.log(ngx.ERR, 'failed to unlock: ', unlock_err)
+    return
+  end
+
+  return cached_reports
+end
+
+return _M

--- a/gateway/src/apicast/policy/apicast/apicast.lua
+++ b/gateway/src/apicast/policy/apicast/apicast.lua
@@ -57,6 +57,8 @@ function _M:rewrite(context)
 end
 
 function _M:post_action(context)
+  if context.skip_apicast_post_action then return end
+
   local p = context and context.proxy or ngx.ctx.proxy or self.proxy
 
   if p then
@@ -68,6 +70,8 @@ function _M:post_action(context)
 end
 
 function _M:access(context)
+  if context.skip_apicast_access then return end
+
   local ctx = ngx.ctx
   local p = context and context.proxy or ctx.proxy or self.proxy
 

--- a/gateway/src/apicast/proxy.lua
+++ b/gateway/src/apicast/proxy.lua
@@ -321,6 +321,8 @@ function _M:rewrite(service, context)
     ctx.credentials = credentials
     ctx.ttl = ttl
   end
+
+  context.credentials = ctx.credentials
 end
 
 function _M:access(service, usage, credentials, ttl)

--- a/spec/policy/3scale_batcher/3scale_batcher_spec.lua
+++ b/spec/policy/3scale_batcher/3scale_batcher_spec.lua
@@ -1,0 +1,67 @@
+local ThreescaleBatcher = require('apicast.policy.3scale_batcher')
+local AuthsCache = require('apicast.policy.3scale_batcher.auths_cache')
+local Usage = require('apicast.usage')
+local configuration = require('apicast.configuration')
+local lrucache = require('resty.lrucache')
+
+describe('3scale batcher policy', function()
+  describe('.access', function()
+    local service = configuration.parse_service({ id = 42 })
+    local service_id = service.id
+    local credentials = { user_key = 'uk' }
+    local usage = Usage.new()
+    usage:add('m1', 1)
+
+    local context
+    local batcher_policy
+
+    before_each(function()
+      ngx.var = {}
+      ngx.header = {}
+      ngx.print = function() end
+
+      batcher_policy = ThreescaleBatcher.new({})
+      batcher_policy.auths_cache = AuthsCache.new(lrucache.new(10), 10)
+      stub(batcher_policy.reports_batcher, 'add')
+
+      context = {
+        service = service,
+        usage = usage,
+        credentials = credentials
+      }
+    end)
+
+    describe('when the request is cached', function()
+      describe('and it is authorized', function()
+        it('adds the report to the batcher', function()
+          batcher_policy.auths_cache:set(service_id, credentials, usage, 200)
+
+          batcher_policy:access(context)
+
+          assert.stub(batcher_policy.reports_batcher.add).was_called_with(
+            batcher_policy.reports_batcher, service_id, credentials, usage)
+        end)
+      end)
+
+      describe('and it is not authorized', function()
+        it('does not add the report to the batcher', function()
+          batcher_policy.auths_cache:set(
+            service_id, credentials, usage, 409, 'limits_exceeded')
+
+          batcher_policy:access(context)
+
+          assert.stub(batcher_policy.reports_batcher.add).was_not_called()
+        end)
+
+        it('returns an error', function()
+          batcher_policy.auths_cache:set(
+            service_id, credentials, usage, 409, 'limits_exceeded')
+
+          batcher_policy:access(context)
+
+          assert.is_true(ngx.status >= 400 and ngx.status < 500)
+        end)
+      end)
+    end)
+  end)
+end)

--- a/spec/policy/3scale_batcher/auths_cache_spec.lua
+++ b/spec/policy/3scale_batcher/auths_cache_spec.lua
@@ -1,0 +1,82 @@
+local AuthsCache = require 'apicast.policy.3scale_batcher.auths_cache'
+local Usage = require 'apicast.usage'
+local lrucache =require 'resty.lrucache'
+
+local storage
+local cache
+local usage
+
+local service_id = 's1'
+local auth_status = 200
+
+describe('Auths cache', function()
+  before_each(function()
+    storage = lrucache.new(100)
+    cache = AuthsCache.new(storage)
+
+    usage = Usage.new()
+    usage:add('m1', 1)
+  end)
+
+  it('caches auth with user key', function()
+    local user_key = { user_key = 'uk' }
+
+    cache:set(service_id, user_key, usage, auth_status)
+
+    local cached = cache:get(service_id, user_key, usage)
+    assert.equals(auth_status, cached.status)
+  end)
+
+  it('caches auth with app id + app key', function()
+    local app_id_and_key = { app_id = 'an_id', app_key = 'a_key' }
+
+    cache:set(service_id, app_id_and_key, usage, auth_status)
+
+    local cached = cache:get(service_id, app_id_and_key, usage)
+    assert.equals(auth_status, cached.status)
+  end)
+
+  it('caches auth with access token', function()
+    local access_token = { access_token = 'a_token' }
+
+    cache:set(service_id, access_token, usage, auth_status)
+
+    local cached = cache:get(service_id, access_token, usage)
+    assert.equals(auth_status, cached.status)
+  end)
+
+  it('caches auths with same usages but different order in the same key', function()
+    local usage_order_1 = Usage.new()
+    usage_order_1:add('m1', 1)
+    usage_order_1:add('m2', 1)
+
+    local usage_order_2 = Usage.new()
+    usage_order_2:add('m2', 1)
+    usage_order_2:add('m1', 1)
+
+    local user_key = { user_key = 'uk' }
+
+    cache:set(service_id, user_key, usage_order_1, auth_status)
+
+    local cached = cache:get(service_id, user_key, usage_order_2)
+    assert.equals(auth_status, cached.status)
+  end)
+
+  it('caches a rejection reason when given', function()
+    local rejection_reason = 'limits_exceeded'
+    local app_id_and_key = { app_id = 'an_id', app_key = 'a_key' }
+    local not_authorized_status = 409
+
+    cache:set(service_id, app_id_and_key, usage, not_authorized_status, rejection_reason)
+
+    local cached = cache:get(service_id, app_id_and_key, usage)
+    assert.equals(not_authorized_status, cached.status)
+    assert.equals(rejection_reason, cached.rejection_reason)
+  end)
+
+  it('returns nil when something is not cached', function()
+    local user_key = { user_key = 'uk' }
+
+    assert.is_nil(cache:get(service_id, user_key, usage))
+  end)
+end)

--- a/spec/policy/3scale_batcher/keys_helper_spec.lua
+++ b/spec/policy/3scale_batcher/keys_helper_spec.lua
@@ -1,0 +1,51 @@
+local keys_helper = require 'apicast.policy.3scale_batcher.keys_helper'
+local Usage = require 'apicast.usage'
+
+describe('Keys Helper', function()
+  describe('.key_for_cached_auth', function()
+    it('returns a key with the expected format', function()
+      local service_id = 's1'
+      local credentials = { app_id = 'ai', app_key = 'ak' }
+      local usage = Usage.new()
+      usage:add('m1', 1)
+      usage:add('m2', 2)
+
+      local key = keys_helper.key_for_cached_auth(service_id, credentials, usage)
+      assert.equals('service_id:s1,app_id:ai,app_key:ak,metrics:m1=1;m2=2', key)
+    end)
+  end)
+
+  describe('.key_for_batched_report', function()
+    it('returns a key with the expected format', function()
+      local service_id = 's1'
+      local credentials = { app_id = 'ai', app_key = 'ak' }
+      local metric = 'm1'
+
+      local key = keys_helper.key_for_batched_report(service_id, credentials, metric)
+      assert.equals('service_id:s1,app_id:ai,app_key:ak,metric:m1', key)
+    end)
+  end)
+
+  describe('.report_from_key_batched_report', function()
+    it('returns a report given a key of a batched report with app ID', function()
+      local key = 'service_id:s1,app_id:ai,app_key:ak,metric:m1'
+
+      local report = keys_helper.report_from_key_batched_report(key)
+      assert.same({ service_id = 's1', app_id = 'ai', app_key = 'ak', metric = 'm1' }, report)
+    end)
+
+    it('returns a report given a key of a batched report with user key', function()
+      local key = 'service_id:s1,user_key:uk,metric:m1'
+
+      local report = keys_helper.report_from_key_batched_report(key)
+      assert.same({ service_id = 's1', user_key = 'uk', metric = 'm1' }, report)
+    end)
+
+    it('returns a report given a key of a batched report with access token', function()
+      local key = 'service_id:s1,access_token:at,metric:m1'
+
+      local report = keys_helper.report_from_key_batched_report(key)
+      assert.same({ service_id = 's1', access_token = 'at', metric = 'm1' }, report)
+    end)
+  end)
+end)

--- a/spec/policy/3scale_batcher/reporter_spec.lua
+++ b/spec/policy/3scale_batcher/reporter_spec.lua
@@ -1,0 +1,65 @@
+local reporter = require('apicast.policy.3scale_batcher.reporter')
+local keys_helper = require('apicast.policy.3scale_batcher.keys_helper')
+local ipairs = ipairs
+local pairs = pairs
+local insert = table.insert
+
+describe('reporter', function()
+  local test_service_id = 's1'
+
+  local test_backend_client
+  local spy_report_backend_client
+
+  before_each(function()
+    test_backend_client = { report = function() return { ok = false } end }
+    spy_report_backend_client = spy.on(test_backend_client, 'report')
+  end)
+
+  -- Testing using the real ReportsBatcher is a bit difficult because it uses
+  -- shared dicts and locks. To simplify we define this table with the same
+  -- interface.
+  local reports_batcher = {
+    reports = {},
+
+    add = function(self, service_id, credentials, usage)
+      local deltas = usage.deltas
+      for _, metric in ipairs(usage.metrics) do
+        local key = keys_helper.key_for_batched_report(service_id, credentials, metric)
+        self.reports[key] = (self.reports[key] or 0) + deltas[metric]
+      end
+    end,
+
+    get_all = function(self, service_id)
+      local cached_reports = {}
+
+      for key, value in pairs(self.reports) do
+        local report = keys_helper.report_from_key_batched_report(key, value)
+
+        if value and value > 0 and report.service_id == service_id then
+          insert(cached_reports, report)
+          self.reports[key] = nil
+        end
+      end
+
+      return cached_reports
+    end
+  }
+
+  it('returns reports to the batcher when sending reports to backend fails', function()
+    local test_reports = {
+      { service_id = test_service_id, user_key = 'uk', metric = 'm1', value = 1 }
+    }
+
+    reporter.report(test_reports, test_service_id, test_backend_client, reports_batcher)
+
+    assert.same(test_reports, reports_batcher:get_all(test_service_id))
+  end)
+
+  it('does not report call report on the backend client when there are no reports', function()
+    local no_reports = {}
+
+    reporter.report(no_reports, test_service_id, test_backend_client, reports_batcher)
+
+    assert.spy(spy_report_backend_client).was_not_called()
+  end)
+end)

--- a/spec/policy/3scale_batcher/reports_batch_spec.lua
+++ b/spec/policy/3scale_batcher/reports_batch_spec.lua
@@ -1,0 +1,51 @@
+local ReportsBatch = require 'apicast.policy.3scale_batcher.reports_batch'
+
+describe('reports batch', function()
+  local reports_with_user_key = {
+    { user_key = 'uk1', metric = 'm1', value = 1 },
+    { user_key = 'uk1', metric = 'm2', value = 1 },
+    { user_key = 'uk2', metric = 'm2', value = 2 }
+  }
+
+  local reports_with_app_id = {
+    { app_id = 'id1', metric = 'm1', value = 1 },
+    { app_id = 'id1', metric = 'm2', value = 1 },
+    { app_id = 'id2', metric = 'm2', value = 2 }
+  }
+
+  local reports_with_access_token = {
+    { access_token = 't1', metric = 'm1', value = 1 },
+    { access_token = 't1', metric = 'm2', value = 1 },
+    { access_token = 't2', metric = 'm2', value = 2 }
+  }
+
+  describe('with reports with user keys', function()
+    it('groups them correctly', function()
+      local batch = ReportsBatch.new('s1', reports_with_user_key)
+
+      assert.equals('s1', batch.service_id)
+      assert.equals('user_key', batch.credentials_type)
+      assert.same({ uk1 = { m1 = 1, m2 = 1 }, uk2 = { m2 = 2 } }, batch.reports)
+    end)
+  end)
+
+  describe('with reports with app IDs', function()
+    it('groups them correctly', function()
+      local batch = ReportsBatch.new('s1', reports_with_app_id)
+
+      assert.equals('s1', batch.service_id)
+      assert.equals('app_id', batch.credentials_type)
+      assert.same({ id1 = { m1 = 1, m2 = 1 }, id2 = { m2 = 2 } }, batch.reports)
+    end)
+  end)
+
+  describe('with reports with access tokens', function()
+    it('groups them correctly', function()
+      local batch = ReportsBatch.new('s1', reports_with_access_token)
+
+      assert.equals('s1', batch.service_id)
+      assert.equals('access_token', batch.credentials_type)
+      assert.same({ t1 = { m1 = 1, m2 = 1 }, t2 = { m2 = 2 } }, batch.reports)
+    end)
+  end)
+end)

--- a/spec/policy/3scale_batcher/reports_batcher_spec.lua
+++ b/spec/policy/3scale_batcher/reports_batcher_spec.lua
@@ -1,0 +1,76 @@
+local ReportsBatcher = require 'apicast.policy.3scale_batcher.reports_batcher'
+local Usage = require 'apicast.usage'
+local keys_helper = require 'apicast.policy.3scale_batcher.keys_helper'
+local resty_lock = require 'resty.lock'
+
+describe('reports batcher', function()
+  describe('.add', function()
+    before_each(function()
+      -- Stub locks. Not relevant for these tests.
+      stub(resty_lock, 'new').returns({
+        lock = function() return true end,
+        unlock = function() return true end
+      })
+    end)
+
+    local service_id = 's1'
+    local credentials = { user_key = 'uk' }
+
+    local usage = Usage.new()
+    local metric = 'm1'
+    usage:add(metric, 1)
+
+    local report_key = keys_helper.key_for_batched_report(service_id, credentials, metric)
+
+    -- Note: all these tests use a mocked instance of ngx.shared.dict.
+    -- 'safe_add()' returns 'no memory' when the dict ran out of memory and
+    -- 'exists' when the key already exists in the dict.
+
+    describe('when a report cannot be batched because the dict ran out of mem', function()
+      it('does not try to increase the value of the batched report', function()
+        local test_dict = {
+          safe_add = function(_, _, _) return nil, 'no memory' end,
+          incr = function(_, _, _) end
+        }
+        local spy_incr_dict = spy.on(test_dict, 'incr')
+        local reports_batcher = ReportsBatcher.new(test_dict, 'batched_reports_locks')
+
+        reports_batcher:add(service_id, credentials, usage)
+
+        assert.spy(spy_incr_dict).was_not_called()
+      end)
+    end)
+
+    describe('when a report already exists in the dict', function()
+      it('increases its usage', function()
+        local test_dict = {
+          safe_add = function(_, _, _) return nil, 'exists' end,
+          incr = function(_, _, _) end
+        }
+        local spy_incr_dict = spy.on(test_dict, 'incr')
+        local reports_batcher = ReportsBatcher.new(test_dict, 'batched_reports_locks')
+
+        reports_batcher:add(service_id, credentials, usage)
+
+        assert.spy(spy_incr_dict).was_called_with(test_dict, report_key, 1)
+      end)
+    end)
+
+    describe('when a report is not in the dict', function()
+      it('adds it with the given usage', function()
+        local test_dict = {
+          safe_add = function(_, _, _) return true end,
+          incr = function(_, _, _) end
+        }
+        local spy_add_dict = spy.on(test_dict, 'safe_add')
+        local spy_incr_dict = spy.on(test_dict, 'incr')
+        local reports_batcher = ReportsBatcher.new(test_dict, 'batched_reports_locks')
+
+        reports_batcher:add(service_id, credentials, usage)
+
+        assert.spy(spy_add_dict).was_called.with(test_dict, report_key, 1)
+        assert.spy(spy_incr_dict).was_not_called()
+      end)
+    end)
+  end)
+end)

--- a/t/apicast-policy-3scale-batcher.t
+++ b/t/apicast-policy-3scale-batcher.t
@@ -1,0 +1,373 @@
+use lib 't';
+use Test::APIcast 'no_plan';
+
+# Can't run twice because of the report batches
+repeat_each(1);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: caches successful authorizations
+This test checks that the policy caches successful authorizations. To do that,
+we define a backend that makes sure that it's called only once.
+--- http_config
+include $TEST_NGINX_UPSTREAM_CONFIG;
+lua_shared_dict cached_auths 1m;
+lua_shared_dict batched_reports 1m;
+lua_shared_dict batched_reports_locks 1m;
+lua_package_path "$TEST_NGINX_LUA_PATH";
+
+init_by_lua_block {
+  require('apicast.configuration_loader').mock({
+    services = {
+      {
+        id = 42,
+        backend_version = 1,
+        backend_authentication_type = 'service_token',
+        backend_authentication_value = 'token-value',
+        proxy = {
+          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" },
+          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
+          proxy_rules = {
+            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
+          },
+          policy_chain = {
+            { name = 'apicast.policy.3scale_batcher', configuration = {} },
+            { name = 'apicast.policy.apicast' }
+          }
+        }
+      }
+    }
+  })
+}
+--- config
+  include $TEST_NGINX_APICAST_CONFIG;
+
+  location /transactions/authorize.xml {
+    content_by_lua_block {
+      local test_counter = ngx.shared.test_counter or 0
+      if test_counter == 0 then
+        ngx.shared.test_counter = test_counter + 1
+        ngx.exit(200)
+      else
+        ngx.log(ngx.ERR, 'auth should be cached but called backend anyway')
+        ngx.exit(502)
+      end
+    }
+  }
+
+  location /api-backend {
+     echo 'yay, api backend';
+  }
+--- request eval
+["GET /test?user_key=foo", "GET /foo?user_key=foo"]
+--- response_body eval
+["yay, api backend\x{0a}", "yay, api backend\x{0a}"]
+--- error_code eval
+[ 200, 200 ]
+--- no_error_log
+[error]
+
+=== TEST 2: caches unsuccessful authorizations
+This test checks that the policy caches successful authorizations. To do that,
+we define a backend that makes sure that it's called only once.
+--- http_config
+include $TEST_NGINX_UPSTREAM_CONFIG;
+lua_shared_dict cached_auths 1m;
+lua_shared_dict batched_reports 1m;
+lua_shared_dict batched_reports_locks 1m;
+lua_package_path "$TEST_NGINX_LUA_PATH";
+
+init_by_lua_block {
+  require('apicast.configuration_loader').mock({
+    services = {
+      {
+        id = 42,
+        backend_version = 1,
+        backend_authentication_type = 'service_token',
+        backend_authentication_value = 'token-value',
+        proxy = {
+          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" },
+          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
+          proxy_rules = {
+            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
+          },
+          policy_chain = {
+            { name = 'apicast.policy.3scale_batcher', configuration = {} },
+            { name = 'apicast.policy.apicast' }
+          }
+        }
+      }
+    }
+  })
+}
+--- config
+  include $TEST_NGINX_APICAST_CONFIG;
+
+  location /transactions/authorize.xml {
+    content_by_lua_block {
+      local test_counter = ngx.shared.test_counter or 0
+      if test_counter == 0 then
+        ngx.shared.test_counter = test_counter + 1
+        ngx.header['3scale-rejection-reason'] = 'limits_exceeded'
+        ngx.status = 409
+        ngx.exit(ngx.HTTP_OK)
+      else
+        ngx.log(ngx.ERR, 'auth should be cached but called backend anyway')
+        ngx.exit(502)
+      end
+    }
+  }
+
+  location /api-backend {
+     echo 'yay, api backend';
+  }
+--- request eval
+["GET /test?user_key=foo", "GET /foo?user_key=foo"]
+--- response_body eval
+["Limits exceeded", "Limits exceeded"]
+--- error_code eval
+[ 429, 429 ]
+--- no_error_log
+[error]
+
+=== TEST 3: batched reports
+This test checks that reports are batched correctly. In order to do that, we
+make 100 requests using 5 different user keys (20 requests for each of them).
+We define 2 services and make each of them receive the same number of calls.
+This is to test that reports are correctly classified by service.
+At the end, we make another request that is redirected to a location we defined
+in this test that checks the counters of the batched reports.
+To make sure that the policy does not report the batched reports during the
+test, we define a high 'batch_report_seconds' in the policy config.
+--- http_config
+include $TEST_NGINX_UPSTREAM_CONFIG;
+lua_shared_dict cached_auths 1m;
+lua_shared_dict batched_reports 1m;
+lua_shared_dict batched_reports_locks 1m;
+lua_package_path "$TEST_NGINX_LUA_PATH";
+init_by_lua_block {
+  require('apicast.configuration_loader').mock({
+    services = {
+      {
+        id = 1,
+        backend_version = 1,
+        backend_authentication_type = 'service_token',
+        backend_authentication_value = 'token-value',
+        proxy = {
+          hosts = { 'one' },
+          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" },
+          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
+          proxy_rules = {
+            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
+          },
+          policy_chain = {
+            {
+              name = 'apicast.policy.3scale_batcher',
+              configuration = { batch_report_seconds = 60 }
+            },
+            { name = 'apicast.policy.apicast' }
+          }
+        }
+      },
+      {
+        id = 2,
+        backend_version = 1,
+        backend_authentication_type = 'service_token',
+        backend_authentication_value = 'token-value',
+        proxy = {
+          hosts = { 'two' },
+          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" },
+          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
+          proxy_rules = {
+            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
+          },
+          policy_chain = {
+            {
+              name = 'apicast.policy.3scale_batcher',
+              configuration = { batch_report_seconds = 60 }
+            },
+            { name = 'apicast.policy.apicast' }
+          }
+        }
+      }
+    }
+  })
+}
+--- config
+  include $TEST_NGINX_APICAST_CONFIG;
+
+  location /check_batched_reports {
+    content_by_lua_block {
+      local keys_helper = require('apicast.policy.3scale_batcher.keys_helper')
+      local luassert = require('luassert')
+
+      for service = 1,2 do
+        for user_key = 1,5 do
+          local key = keys_helper.key_for_batched_report(service, {user_key = user_key }, 'hits')
+          -- The mapping rule defines a delta of 2 for hits, and we made 10
+          -- requests for each {service, user_key}, so all the counters should
+          -- be 20.
+          luassert.equals(20, ngx.shared.batched_reports:get(key))
+        end
+      end
+    }
+  }
+
+  location /transactions/authorize.xml {
+    content_by_lua_block {
+      ngx.exit(200)
+    }
+  }
+
+  location /api-backend {
+     echo 'yay, api backend';
+  }
+
+--- request eval
+my $res = [];
+
+for(my $i = 0; $i < 20; $i = $i + 1 ) {
+  push $res, "GET /test?user_key=1";
+  push $res, "GET /test?user_key=2";
+  push $res, "GET /test?user_key=3";
+  push $res, "GET /test?user_key=4";
+  push $res, "GET /test?user_key=5";
+}
+
+push $res, "GET /check_batched_reports";
+
+$res
+--- more_headers eval
+my $res = [];
+
+for(my $i = 0; $i < 50; $i = $i + 1 ) {
+  push $res, "Host: one";
+}
+
+for(my $i = 0; $i < 50; $i = $i + 1 ) {
+  push $res, "Host:two";
+}
+
+push $res, "Host: one";
+
+$res
+--- no_error_log
+[error]
+
+=== TEST 4: report batched reports to backend
+This test checks that reports are sent correctly to backend. To do that, it performs
+some requests, then it forces a report request to backend, and finally, checks that
+the POST body that backend receives is correct.
+--- http_config
+include $TEST_NGINX_UPSTREAM_CONFIG;
+lua_shared_dict cached_auths 1m;
+lua_shared_dict batched_reports 1m;
+lua_shared_dict batched_reports_locks 1m;
+lua_package_path "$TEST_NGINX_LUA_PATH";
+init_by_lua_block {
+  require('apicast.configuration_loader').mock({
+    services = {
+      {
+        id = 1,
+        backend_version = 1,
+        backend_authentication_type = 'service_token',
+        backend_authentication_value = 'token-value',
+        proxy = {
+          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" },
+          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
+          proxy_rules = {
+            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
+          },
+          policy_chain = {
+            {
+              name = 'apicast.policy.3scale_batcher',
+              configuration = { batch_report_seconds = 60 }
+            },
+            { name = 'apicast.policy.apicast' }
+          }
+        }
+      }
+    }
+  })
+}
+--- config
+  include $TEST_NGINX_APICAST_CONFIG;
+
+  location /force_report_to_backend {
+    content_by_lua_block {
+      local ReportsBatcher = require ('apicast.policy.3scale_batcher.reports_batcher')
+      local reporter = require ('apicast.policy.3scale_batcher.reporter')
+      local http_ng_resty = require('resty.http_ng.backend.resty')
+      local backend_client = require('apicast.backend_client')
+
+      local service_id = '1'
+
+      local reports_batcher = ReportsBatcher.new(
+        ngx.shared.batched_reports, 'batched_reports_locks')
+
+      local reports = reports_batcher:get_all(service_id)
+
+      local backend = backend_client:new(
+        {
+          id = '1',
+          backend_authentication_type = 'service_token',
+          backend_authentication_value = 'token-value',
+          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" }
+        }, http_ng_resty)
+
+      reporter.report(reports, service_id, backend, reports_batcher)
+    }
+  }
+
+  location /transactions/authorize.xml {
+    content_by_lua_block {
+      ngx.exit(200)
+    }
+  }
+
+  location /transactions.xml {
+    content_by_lua_block {
+     ngx.req.read_body()
+     local post_args = ngx.req.get_post_args()
+
+     -- Transactions can be received in any order, so we need to check both
+     -- possibilities.
+     -- We did 20 requests for each user key, and each request increases
+     -- hits by 2 according to the mapping rules defined.
+     local order1 =
+       (post_args["transactions[0][user_key]"] == '1' and
+         post_args["transactions[0][usage][hits]"] == "40") and
+       (post_args["transactions[1][user_key]"] == '2' and
+         post_args["transactions[1][usage][hits]"] == "40")
+
+     local order2 =
+       (post_args["transactions[1][user_key]"] == '1' and
+         post_args["transactions[1][usage][hits]"] == "40") and
+       (post_args["transactions[0][user_key]"] == '2' and
+         post_args["transactions[0][usage][hits]"] == "40")
+
+      local luassert = require('luassert')
+      luassert.equals('1', ngx.req.get_uri_args()['service_id'])
+      luassert.is_true(order1 or order2)
+    }
+  }
+
+  location /api-backend {
+     echo 'yay, api backend';
+  }
+
+--- request eval
+my $res = [];
+
+for(my $i = 0; $i < 20; $i = $i + 1 ) {
+  push $res, "GET /test?user_key=1";
+  push $res, "GET /test?user_key=2";
+}
+
+push $res, "GET /force_report_to_backend";
+
+$res
+--- no_error_log
+[error]


### PR DESCRIPTION
This PR introduces a new policy. Its goal is to reduce latency and increase throughput by significantly reducing the number of requests made to the 3scale backend. In order to achieve that, this policy caches authorization statuses and batches reports. In order to achieve that, it makes some trade-offs regarding rate-limits accuracy. I've tried to document everything in the README included in this PR.

I've tagged this as WIP because there are some things that need to be fixed. I've documented them in a TODO section included in the first lines of the new policy module. I decided to open the PR because I'd appreciate some early feedback, @mikz 

I need to perform more tests to check that the policy is indeed fast and correct, but my first tests are really promising. The performance of the policy depends heavily on the cache hit ratio. For use cases with a relatively low number of services, apps, etc. this could easily bring a big improvement over the APIcast policy by sacrificing some accuracy when applying rate limits.