### PR TITLE
[policy] run __gc metamethod when policies are garbage collected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Configurable `auth_type` for the token introspection policy [PR #755](https://github.com/3scale/apicast/pull/755)
 - `TimerTask` module to execute recurrent tasks that can be cancelled [PR #782](https://github.com/3scale/apicast/pull/782), [PR #784](https://github.com/3scale/apicast/pull/784), [PR #791](https://github.com/3scale/apicast/pull/791)
 - `GC` module that implements a workaround to be able to define `__gc` on tables [PR #790](https://github.com/3scale/apicast/pull/790)
+- Policies can define `__gc` metamethod that gets called when they are garbage collected to do cleanup [PR #688](https://github.com/3scale/apicast/pull/688)
 
 ### Changed
 

--- a/docker-compose.benchmark.yml
+++ b/docker-compose.benchmark.yml
@@ -1,10 +1,14 @@
-version: '2.1'
+version: '2.2'
 services:
   apicast:
     image: quay.io/3scale/apicast:${IMAGE_TAG:-master}
     command: bin/apicast -c /tmp/apicast/echo.json -b
     volumes:
      - ${CIRCLE_WORKING_DIRECTORY:-.}/examples/configuration/:/tmp/apicast/:ro
+    environment:
+      APICAST_WORKERS: 1
+    cpuset: "0"
+    cpu_count: 1
   wrk:
     image: skandyla/wrk
     environment:

--- a/gateway/src/apicast/configuration_loader.lua
+++ b/gateway/src/apicast/configuration_loader.lua
@@ -84,7 +84,9 @@ function _M.configure(configuration, contents)
   end
 
   if config then
-    return configuration:store(config, ttl())
+    configuration:store(config, ttl())
+    collectgarbage()
+    return config
   end
 end
 

--- a/gateway/src/apicast/policy.lua
+++ b/gateway/src/apicast/policy.lua
@@ -18,7 +18,8 @@ local PHASES = {
     'ssl_certificate',
 }
 
-local setmetatable = setmetatable
+local GC = require('apicast.gc')
+local setmetatable_gc_clone = GC.setmetatable_gc_clone
 local ipairs = ipairs
 local format = string.format
 
@@ -37,22 +38,26 @@ end
 -- @tparam string name Name of the new policy.
 -- @tparam string version Version of the new policy. Default value is 0.0
 -- @treturn policy New policy
+-- @treturn table New policy metatable.
 function _M.new(name, version)
     local policy = {
         _NAME = name,
         _VERSION = version or '0.0',
     }
+
     local mt = { __index = policy, __tostring = __tostring, policy = policy }
 
     function policy.new()
-        return setmetatable({}, mt)
+        local p = setmetatable_gc_clone({}, mt)
+
+        return p
     end
 
     for _, phase in _M.phases() do
         policy[phase] = noop
     end
 
-    return setmetatable(policy, { __tostring = __tostring, __eq = __eq })
+    return setmetatable(policy, { __tostring = __tostring, __eq = __eq }), mt
 end
 
 function _M.phases()

--- a/gateway/src/apicast/policy/echo/echo.lua
+++ b/gateway/src/apicast/policy/echo/echo.lua
@@ -3,7 +3,7 @@
 -- Also can interrupt the execution and skip the current phase or
 -- the whole processing of the request.
 
-local _M = require('apicast.policy').new('Echo Policy')
+local _M  = require('apicast.policy').new('Echo Policy')
 local cjson = require('cjson')
 
 local tonumber = tonumber

--- a/script/s2i
+++ b/script/s2i
@@ -9,9 +9,11 @@ DOCKER_REPO_ROOT=/opt/app-root/src
 source_volume() {
     volume=$(docker volume create)
     container=$(docker create --user root --volume "${volume}:${DOCKER_REPO_ROOT}/cache" "${IMAGE_NAME}" sh -c 'chgrp -fR root . && chmod -fR g+w .')
-    docker cp "$PWD/local" "${container}:${DOCKER_REPO_ROOT}/cache/perl5" 2>/dev/null || true
-    docker cp "$PWD/lua_modules" "${container}:${DOCKER_REPO_ROOT}/cache/" 2>/dev/null || true
-    docker cp "$PWD/vendor" "${container}:${DOCKER_REPO_ROOT}/cache/" 2>/dev/null || true
+    if [ -n "${CI:-}" ]; then
+        docker cp "$PWD/local" "${container}:${DOCKER_REPO_ROOT}/cache/perl5" 2>/dev/null || true
+        docker cp "$PWD/lua_modules" "${container}:${DOCKER_REPO_ROOT}/cache/" 2>/dev/null || true
+        docker cp "$PWD/vendor" "${container}:${DOCKER_REPO_ROOT}/cache/" 2>/dev/null || true
+    fi
     docker start "${container}" >/dev/null
     docker wait "${container}" >/dev/null
     docker logs "${container}" >&2

--- a/spec/policy_spec.lua
+++ b/spec/policy_spec.lua
@@ -116,4 +116,21 @@ describe('policy', function()
       assert.same(phases, res)
     end)
   end)
+
+  describe('garbage collection', function()
+    it('runs __gc metamethod when a policy instance is garbage-collected', function()
+      local MyPolicy, mt = policy.new('my_policy', '1.0')
+      local property
+      mt.__gc = spy.new(function(instance) property = instance.someproperty end)
+      local p = MyPolicy.new()
+      p.someproperty = 'foobar'
+      p = nil
+      assert.is_nil(p)
+
+      collectgarbage()
+
+      assert.spy(mt.__gc).was_called(1)
+      assert.equal('foobar', property)
+    end)
+  end)
 end)


### PR DESCRIPTION
This would allow doing cleanup when policies are reloaded by changed configuration (like shutting down timers).