### PR TITLE
[THREESCALE-852] Add option in the upstream policy to match the original URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - OpenTracing support [PR #669](https://github.com/3scale/apicast/pull/669)
+- Allows applying 'upstream' policy on the original path [PR 689#](https://github.com/3scale/apicast/pull/689), [THREESCALE-852](https://issues.jboss.org/browse/THREESCALE-852)
 
 ### Fixed
 

--- a/gateway/src/apicast/policy/upstream/apicast-policy.json
+++ b/gateway/src/apicast/policy/upstream/apicast-policy.json
@@ -29,6 +29,10 @@
           },
           "required": ["regex", "url"]
         }
+      },
+      "match_original_path": {
+        "description": "use the original path when matching",
+        "type": "boolean"
       }
     }
   }

--- a/gateway/src/apicast/policy/url_rewriting/url_rewriting.lua
+++ b/gateway/src/apicast/policy/url_rewriting/url_rewriting.lua
@@ -62,7 +62,10 @@ function _M.new(config)
   return self
 end
 
-function _M:rewrite()
+function _M:rewrite(context)
+  -- Save original URI in the context in case other policies need it.
+  context.original_uri = ngx.var.uri
+
   for _, command in ipairs(self.commands) do
     local rewritten = apply_rewrite_command(command)
 


### PR DESCRIPTION
This PR adds a new config param to the upstream policy that indicates whether to use the original URI when matching. It's useful when this policy is combined with other policies that can rewrite the URI but we're interested in matching the original one.

Ref: https://issues.jboss.org/browse/THREESCALE-852