### PR TITLE
[THREESCALE-852] Split upstream policy phases so it can match the original path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- The upstream policy now performs the rule matching in the rewrite phase. This allows us to combine it with the URL rewriting policy more easily [PR #690](https://github.com/3scale/apicast/pull/690), [THREESCALE-852](https://issues.jboss.org/browse/THREESCALE-852)
+- The upstream policy now performs the rule matching in the rewrite phase. This allows combining it with the URL rewriting policy – upstream policy regex will be matched against the original path if upstream policy is placed before URL rewriting in the policy chain, and against the rewritten path otherwise [PR #690](https://github.com/3scale/apicast/pull/690), [THREESCALE-852](https://issues.jboss.org/browse/THREESCALE-852)
 
 ## [3.2.0-rc1] - 2018-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed set of valid values for the exit param of the Echo policy [PR #684](https://github.com/3scale/apicast/pull/684/)
 
+### Changed
+
+- The upstream policy now performs the rule matching in the rewrite phase. This allows us to combine it with the URL rewriting policy more easily [PR #690](https://github.com/3scale/apicast/pull/690), [THREESCALE-852](https://issues.jboss.org/browse/THREESCALE-852)
+
 ## [3.2.0-rc1] - 2018-04-24
 
 ### Added

--- a/doc/policies.md
+++ b/doc/policies.md
@@ -67,12 +67,6 @@ mapping rules of APIcast will be applied against the rewritten path.
 However, if the URL policy appears after the APIcast one, the mapping rules
 will be applied against the original path.
 
-Another example, suppose that we combine the upstream policy with the URL
-rewriting one. The upstream policy acts on the content phase, whereas the URL
-rewriting one acts on the rewrite phase. This means that the upstream policy
-will always take into account the rewritten path instead of the original one,
-regardless of the position of the policies in the chain.
-
 ### Types
 
 There are two types of policy chains in APIcast: per-service chains and a

--- a/gateway/src/apicast/policy/upstream/apicast-policy.json
+++ b/gateway/src/apicast/policy/upstream/apicast-policy.json
@@ -4,10 +4,10 @@
   "summary": "Allows to modify the upstream URL of the request based on its path.",
   "description":
     ["This policy allows to modify the upstream URL (scheme, host and port) of the request based on its path. ",
-     "It accepts regular expressions that, when matched against the request path, ",
-     "replaces it with a given string. \n",
+     "It accepts regular expressions and, when matched against the request path, ",
+     "replaces the upstream URL with a given string. \n",
      "When combined with the APIcast policy, the upstream policy should be ",
-     "placed before it in the policy chain"],
+     "placed before it in the policy chain."],
   "version": "builtin",
   "configuration": {
     "type": "object",

--- a/spec/policy/upstream/upstream_spec.lua
+++ b/spec/policy/upstream/upstream_spec.lua
@@ -2,29 +2,28 @@ local balancer = require('apicast.balancer')
 local UpstreamPolicy = require('apicast.policy.upstream')
 
 describe('Upstream policy', function()
-  describe('.content', function()
-    -- Set request URI and matched/non-matched upstream used in all the tests
-    local test_req_uri = 'http://example.com/'
-    local test_upstream_matched_host = 'localhost'
-    local test_upstream_matched = string.format("http://%s/a_path:8080",
-      test_upstream_matched_host)
-    local test_upstream_matched_proxy_pass = 'http://upstream/a_path:8080'
-    local test_upstream_not_matched = 'http://localhost/a_path:80'
+  -- Set request URI and matched/non-matched upstream used in all the tests
+  local test_req_uri = 'http://example.com/'
+  local test_upstream_matched_host = 'localhost'
+  local test_upstream_matched = string.format("http://%s/a_path:8080",
+    test_upstream_matched_host)
+  local test_upstream_matched_proxy_pass = 'http://upstream/a_path:8080'
+  local test_upstream_not_matched = 'http://localhost/a_path:80'
 
-    local context = {} -- Context shared between policies
+  local test_upstream_matched_url = {
+    host = 'localhost',
+    path = '/a_path:8080',
+    scheme = 'http'
+  }
 
-    before_each(function()
-      context = {}
+  local context -- Context shared between policies
 
-      -- Set headers_sent to false, otherwise, the upstream is not changed
-      ngx.headers_sent = false
+  before_each(function()
+    context = {}
+    ngx.var = { uri = test_req_uri }
+  end)
 
-      -- ngx functions and vars
-      ngx.var = { uri = test_req_uri }
-      stub(ngx.req, 'set_header')
-      stub(ngx, 'exec')
-    end)
-
+  describe('.rewrite', function()
     describe('when there is a rule that matches the request URI', function()
       local config_with_a_matching_rule = {
         rules = {
@@ -35,18 +34,9 @@ describe('Upstream policy', function()
 
       local upstream = UpstreamPolicy.new(config_with_a_matching_rule)
 
-      it('changes the upstream according to that rule', function()
-        upstream:content(context)
-
-        assert.equals(test_upstream_matched_proxy_pass, ngx.var.proxy_pass)
-        assert.stub(ngx.req.set_header).was_called_with('Host',
-          test_upstream_matched_host)
-        assert.stub(ngx.exec).was_called_with('@upstream')
-      end)
-
-      it('marks in the context that the upstream has changed', function()
-        upstream:content(context)
-        assert.is_truthy(context.upstream_changed)
+      it('stores in the context the URL of that rule', function()
+        upstream:rewrite(context)
+        assert.same(test_upstream_matched_url, context.new_upstream)
       end)
     end)
 
@@ -61,18 +51,9 @@ describe('Upstream policy', function()
 
       local upstream = UpstreamPolicy.new(config_with_several_matching_rules)
 
-      it('changes the upstream according to the first rule that matches', function()
-        upstream:content(context)
-
-        assert.equals(test_upstream_matched_proxy_pass, ngx.var.proxy_pass)
-        assert.stub(ngx.req.set_header).was_called_with('Host',
-          test_upstream_matched_host)
-        assert.stub(ngx.exec).was_called_with('@upstream')
-      end)
-
-      it('marks in the context that the upstream has changed', function()
-        upstream:content(context)
-        assert.is_truthy(context.upstream_changed)
+      it('stores in the context the URL of the 1st rule that matches', function()
+        upstream:rewrite(context)
+        assert.same(test_upstream_matched_url, context.new_upstream)
       end)
     end)
 
@@ -85,7 +66,52 @@ describe('Upstream policy', function()
 
       local upstream = UpstreamPolicy.new(config_without_matching_rules)
 
+      it('does not store a URL in the context', function()
+        upstream:rewrite(context)
+        assert.is_nil(context.new_upstream)
+      end)
+    end)
+  end)
+
+  describe('.content', function()
+    before_each(function()
+      -- Set headers_sent to false, otherwise, the upstream is not changed
+      ngx.headers_sent = false
+
+      stub(ngx.req, 'set_header')
+      stub(ngx, 'exec')
+    end)
+
+    describe('when there is a new upstream in the context', function()
+      before_each(function()
+        context.new_upstream = test_upstream_matched_url
+      end)
+
+      it('changes the upstream', function()
+        local upstream = UpstreamPolicy.new({})
+
+        upstream:content(context)
+
+        assert.equals(test_upstream_matched_proxy_pass, ngx.var.proxy_pass)
+        assert.stub(ngx.req.set_header).was_called_with('Host',
+          test_upstream_matched_host)
+        assert.stub(ngx.exec).was_called_with('@upstream')
+      end)
+
+      it('marks in the context that the upstream has changed', function()
+        local upstream = UpstreamPolicy.new({})
+        upstream:content(context)
+        assert.is_truthy(context.upstream_changed)
+      end)
+    end)
+
+    describe('when there is not a new upstream in the context', function()
+      before_each(function()
+        context.new_upstream = nil
+      end)
+
       it('does not change the upstream', function()
+        local upstream = UpstreamPolicy.new({})
         upstream:content(context)
 
         assert.is_nil(ngx.var.proxy_pass)
@@ -94,6 +120,7 @@ describe('Upstream policy', function()
       end)
 
       it('does not mark in the context that the upstream has changed', function()
+        local upstream = UpstreamPolicy.new({})
         upstream:content(context)
         assert.is_falsy(context.upstream_changed)
       end)


### PR DESCRIPTION
This PR solves the same problem that #689 solves but in a different way.

This PR modifies the Upstream policy so the matching of rules is done in the rewrite phase instead of the content one. This allows us to combine this policy with the URL rewriting one. Before this change, the upstream policy ran on the content phase, whereas the URL rewriting one ran on the rewrite phase. This means that the upstream policy always took into account the rewritten path instead of the original one, regardless of the position of the policies in the chain.

I opened a new PR instead of fixing the previous one because I think @nmasse-itix might need it until we merge this.

Ref: https://issues.jboss.org/browse/THREESCALE-852