### PR TITLE
[THREESCALE-845] ] Caching policy: specify "none" as default mode in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - OpenTracing support [PR #669](https://github.com/3scale/apicast/pull/669)
+- Default value for the `caching_type` attribute of the caching policy config schema [#691](https://github.com/3scale/apicast/pull/691), [THREESCALE-845](https://issues.jboss.org/browse/THREESCALE-845)
 
 ### Fixed
 

--- a/gateway/src/apicast/policy/caching/apicast-policy.json
+++ b/gateway/src/apicast/policy/caching/apicast-policy.json
@@ -42,7 +42,8 @@
             "enum": ["none"],
             "title": "Disable caching."
           }
-        ]
+        ],
+        "default": "none"
       }
     }
   }


### PR DESCRIPTION
This PR defines a default for the caching mode in the config schema of the caching policy.
This does not change the behavior of the policy. It just documents explicitly the default caching mode so it can be shown in the UI.

Ref: https://issues.jboss.org/browse/THREESCALE-845

/cc @thomasmaas 