### PR TITLE
.s2i/bin/assemble: do not add expiry time to master images

### DIFF
--- a/gateway/.s2i/bin/assemble
+++ b/gateway/.s2i/bin/assemble
@@ -2,7 +2,7 @@
 
 mkdir -p /tmp/.s2i
 
-if [[ -n "${GIT_BRANCH}" && -z "${GIT_TAG}" ]]; then
+if [[ -n "${GIT_BRANCH}" && "${GIT_BRANCH}" != master && -z "${GIT_TAG}" ]]; then
   IMAGE_EXPIRES_AFTER="1w"
   echo "This image is going to have just ${IMAGE_EXPIRES_AFTER} expiration."
 fi


### PR DESCRIPTION
`master` images expire after 7 days in quay. This PR solves the issue.