### PR TITLE
[circle] run nightly build for master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,17 @@ jobs:
 
 workflows:
   version: 2
+  nightly:
+     triggers:
+       - schedule:
+           cron: "0 0 * * *"
+           filters:
+             branches:
+               only:
+                 - master
+     jobs:
+       - deploy:
+          context: org-global
   build:
     jobs:
       - build: &git-tags


### PR DESCRIPTION
A  way to rebuild master image every day.

Suggested in https://github.com/3scale/apicast/pull/693