### PR TITLE
Adapt rate limit config schema to make it compatible with react-jsonschema-form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - The upstream policy now performs the rule matching in the rewrite phase. This allows combining it with the URL rewriting policy – upstream policy regex will be matched against the original path if upstream policy is placed before URL rewriting in the policy chain, and against the rewritten path otherwise [PR #690](https://github.com/3scale/apicast/pull/690), [THREESCALE-852](https://issues.jboss.org/browse/THREESCALE-852)
+- The schema of the rate-limit policy has been adapted so it can be rendered by `react-jsonschema-form`, a library used in the 3scale UI. This is a breaking change. [PR #696](https://github.com/3scale/apicast/pull/696), [THREESCALE-888](https://issues.jboss.org/browse/THREESCALE-888)
 
 ## [3.2.0-rc1] - 2018-04-24
 

--- a/gateway/src/apicast/policy/rate_limit/apicast-policy.json
+++ b/gateway/src/apicast/policy/rate_limit/apicast-policy.json
@@ -7,214 +7,196 @@
   "configuration": {
     "type": "object",
     "properties": {
-      "limiters": {
-        "description": "List of limiters to be applied",
+      "connection_limiters": {
         "type": "array",
         "items": {
-          "anyOf": [{
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "enum": ["connections"],
-                "description": "Limiting request concurrency (or concurrent connections)"
-              },
-              "key": {
-                "description": "The key corresponding to the limiter object",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "The name of the key, must be unique in the scope"
-                  },
-                  "scope": {
-                    "type": "string",
-                    "description": "Scope of the key",
-                    "default": "global",
-                    "oneOf": [{
-                      "enum": ["global"],
-                      "description": "Global scope, affecting to all services"
-                    }, {
-                      "enum": ["service"],
-                      "description": "Service scope, affecting to one service"
-                    }]
-                  },
-                  "service_name": {
-                    "type": "string",
-                    "description": "Name of service, necessary for service scope"
-                  }
+          "type": "object",
+          "properties": {
+            "key": {
+              "description": "The key corresponding to the limiter object",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "The name of the key, must be unique in the scope"
+                },
+                "scope": {
+                  "type": "string",
+                  "description": "Scope of the key",
+                  "default": "global",
+                  "oneOf": [{
+                    "enum": ["global"],
+                    "description": "Global scope, affecting to all services"
+                  }, {
+                    "enum": ["service"],
+                    "description": "Service scope, affecting to one service"
+                  }]
+                },
+                "service_name": {
+                  "type": "string",
+                  "description": "Name of service, necessary for service scope"
                 }
-              },
-              "conn": {
-                "type": "integer",
-                "description": "The maximum number of concurrent requests allowed",
-                "exclusiveminimum": 0
-              },
-              "burst": {
-                "type": "integer",
-                "description": "The number of excessive concurrent requests (or connections) allowed to be delayed",
-                "minimum": 0
-              },
-              "delay": {
-                "type": "number",
-                "description": "The default processing latency of a typical connection (or request)",
-                "exclusiveMinimum": 0
               }
+            },
+            "conn": {
+              "type": "integer",
+              "description": "The maximum number of concurrent requests allowed",
+              "exclusiveminimum": 0
+            },
+            "burst": {
+              "type": "integer",
+              "description": "The number of excessive concurrent requests (or connections) allowed to be delayed",
+              "minimum": 0
+            },
+            "delay": {
+              "type": "number",
+              "description": "The default processing latency of a typical connection (or request)",
+              "exclusiveMinimum": 0
             }
-          }, {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "enum": ["leaky_bucket"],
-                "description": "Limiting request rate"
-              },
-              "key": {
-                "description": "The key corresponding to the limiter object",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "The name of the key, must be unique in the scope"
-                  },
-                  "scope": {
-                    "type": "string",
-                    "description": "Scope of the key",
-                    "default": "global",
-                    "oneOf": [{
-                      "enum": ["global"],
-                      "description": "Global scope, affecting to all services"
-                    }, {
-                      "enum": ["service"],
-                      "description": "Service scope, affecting to one service"
-                    }]
-                  },
-                  "service_name": {
-                    "type": "string",
-                    "description": "Name of service, necessary for service scope"
-                  }
+          }
+        }
+      },
+      "leaky_bucket_limiters": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "description": "The key corresponding to the limiter object",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "The name of the key, must be unique in the scope"
+                },
+                "scope": {
+                  "type": "string",
+                  "description": "Scope of the key",
+                  "default": "global",
+                  "oneOf": [{
+                    "enum": ["global"],
+                    "description": "Global scope, affecting to all services"
+                  }, {
+                    "enum": ["service"],
+                    "description": "Service scope, affecting to one service"
+                  }]
+                },
+                "service_name": {
+                  "type": "string",
+                  "description": "Name of service, necessary for service scope"
                 }
-              },
-              "rate": {
-                "type": "integer",
-                "description": "The specified request rate (number per second) threshold",
-                "exclusiveMinimum": 0
-              },
-              "burst": {
-                "type": "integer",
-                "description": "The number of excessive requests per second allowed to be delayed",
-                "minimum": 0
               }
+            },
+            "rate": {
+              "type": "integer",
+              "description": "The specified request rate (number per second) threshold",
+              "exclusiveMinimum": 0
+            },
+            "burst": {
+              "type": "integer",
+              "description": "The number of excessive requests per second allowed to be delayed",
+              "minimum": 0
             }
-          }, {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string",
-                "enum": ["fixed_window"],
-                "description": "Limiting request counts"
-              },
-              "key": {
-                "description": "The key corresponding to the limiter object",
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "The name of the key, must be unique in the scope"
-                  },
-                  "scope": {
-                    "type": "string",
-                    "description": "Scope of the key",
-                    "default": "global",
-                    "oneOf": [{
-                      "enum": ["global"],
-                      "description": "Global scope, affecting to all services"
-                    }, {
-                      "enum": ["service"],
-                      "description": "Service scope, affecting to one service"
-                    }]
-                  },
-                  "service_name": {
-                    "type": "string",
-                    "description": "Name of service, necessary for service scope"
-                  }
+          }
+        }
+      },
+      "fixed_window_limiters": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "description": "The key corresponding to the limiter object",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "The name of the key, must be unique in the scope"
+                },
+                "scope": {
+                  "type": "string",
+                  "description": "Scope of the key",
+                  "default": "global",
+                  "oneOf": [{
+                    "enum": ["global"],
+                    "description": "Global scope, affecting to all services"
+                  }, {
+                    "enum": ["service"],
+                    "description": "Service scope, affecting to one service"
+                  }]
+                },
+                "service_name": {
+                  "type": "string",
+                  "description": "Name of service, necessary for service scope"
                 }
-              },
-              "count": {
-                "type": "integer",
-                "description": "The specified number of requests threshold",
-                "exclusiveMinimum": 0
-              },
-              "window": {
-                "type": "integer",
-                "description": "The time window in seconds before the request count is reset",
-                "exclusiveMinimum": 0
               }
+            },
+            "count": {
+              "type": "integer",
+              "description": "The specified number of requests threshold",
+              "exclusiveMinimum": 0
+            },
+            "window": {
+              "type": "integer",
+              "description": "The time window in seconds before the request count is reset",
+              "exclusiveMinimum": 0
             }
-          }]
+          }
         }
       },
       "redis_url": {
         "description": "URL of Redis",
         "type": "string"
       },
-      "error_settings": {
-        "description": "List of error settings",
-        "type": "array",
-        "items": {
-          "anyOf": [{
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": ["limits_exceeded"],
-                "description": "The error setting when requests over the limit"
+      "limits_exceeded_error": {
+        "type": "object",
+        "properties": {
+          "status_code": {
+            "type": "integer",
+            "description": "The status code when requests over the limit",
+            "default": 429
+          },
+          "error_handling": {
+            "type": "string",
+            "description": "How to handle an error",
+            "default": "exit",
+            "oneOf": [{
+              "enum": ["exit"],
+              "description": "Respond with an error"
+            }, {
+              "enum": ["log"],
+              "description": "Let the request go through and only output logs"
+            }]
+          }
+        }
+      },
+      "configuration_error": {
+        "type": "object",
+        "properties": {
+          "status_code": {
+            "type": "integer",
+            "description": "The status code when there is some configuration issue",
+            "default": 500
+          },
+          "error_handling": {
+            "type": "string",
+            "description": "How to handle an error",
+            "default": "exit",
+            "oneOf": [
+              {
+                "enum": [
+                  "exit"
+                ],
+                "description": "Respond with an error"
               },
-              "status_code": {
-                "type": "integer",
-                "description": "The status code when requests over the limit",
-                "default": 429
-              },
-              "error_handling": {
-                "type": "string",
-                "description": "How to handle an error",
-                "default": "exit",
-                "oneOf": [{
-                  "enum": ["exit"],
-                  "description": "Respond with an error"
-                }, {
-                  "enum": ["log"],
-                  "description": "Let the request go through and only output logs"
-                }]
+              {
+                "enum": [
+                  "log"
+                ],
+                "description": "Let the request go through and only output logs"
               }
-            }
-          }, {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": ["configuration_issue"],
-                "description": "The error setting when there is some configuration issue"
-              },
-              "status_code": {
-                "type": "integer",
-                "description": "The status code when there is some configuration issue",
-                "default": 500
-              },
-              "error_handling": {
-                "type": "string",
-                "description": "How to handle an error",
-                "default": "exit",
-                "oneOf": [{
-                  "enum": ["exit"],
-                  "description": "Respond with an error"
-                }, {
-                  "enum": ["log"],
-                  "description": "Let the request go through and only output logs"
-                }]
-              }
-            }
-          }]
+            ]
+          }
         }
       }
     }

--- a/spec/policy/rate_limit/rate_limit_spec.lua
+++ b/spec/policy/rate_limit/rate_limit_spec.lua
@@ -57,10 +57,14 @@ describe('Rate limit policy', function()
   describe('.access', function()
     it('success with multiple limiters', function()
       local config = {
-        limiters = {
-          {name = "connections", key = {name = 'test1'}, conn = 20, burst = 10, delay = 0.5},
-          {name = "leaky_bucket", key = {name = 'test2'}, rate = 18, burst = 9},
-          {name = "fixed_window", key = {name = 'test3'}, count = 10, window = 10}
+        connection_limiters = {
+          { key = { name = 'test1' }, conn = 20, burst = 10, delay = 0.5 }
+        },
+        leaky_bucket_limiters = {
+          { key = { name = 'test2' }, rate = 18, burst = 9 }
+        },
+        fixed_window_limiters = {
+          { key = {name = 'test3'}, count = 10, window = 10 }
         },
         redis_url = 'redis://'..redis_host..':'..redis_port..'/1'
       }
@@ -70,10 +74,14 @@ describe('Rate limit policy', function()
 
     it('no redis url', function()
       local config = {
-        limiters = {
-          {name = "connections", key = {name = 'test1'}, conn = 20, burst = 10, delay = 0.5},
-          {name = "leaky_bucket", key = {name = 'test2'}, rate = 18, burst = 9},
-          {name = "fixed_window", key = {name = 'test3'}, count = 10, window = 10}
+        connection_limiters = {
+          { key = { name = 'test1' }, conn = 20, burst = 10, delay = 0.5 }
+        },
+        leaky_bucket_limiters = {
+          { key = { name = 'test2' }, rate = 18, burst = 9 }
+        },
+        fixed_window_limiters = {
+          { key = { name = 'test3' }, count = 10, window = 10 }
         }
       }
       local rate_limit_policy = RateLimitPolicy.new(config)
@@ -82,8 +90,8 @@ describe('Rate limit policy', function()
 
     it('invalid redis url', function()
       local config = {
-        limiters = {
-          {name = "connections", key = {name = 'test1'}, conn = 20, burst = 10, delay = 0.5}
+        connection_limiters = {
+          { key = { name = 'test1' }, conn = 20, burst = 10, delay = 0.5 }
         },
         redis_url = 'redis://invalidhost:'..redis_port..'/1'
       }
@@ -94,8 +102,8 @@ describe('Rate limit policy', function()
 
     it('rejected (conn)', function()
       local config = {
-        limiters = {
-          {name = "connections", key = {name = 'test1'}, conn = 1, burst = 0, delay = 0.5}
+        connection_limiters = {
+          { key = { name = 'test1' }, conn = 1, burst = 0, delay = 0.5 }
         },
         redis_url = 'redis://'..redis_host..':'..redis_port..'/1'
       }
@@ -107,8 +115,8 @@ describe('Rate limit policy', function()
 
     it('rejected (req)', function()
       local config = {
-        limiters = {
-          {name = "leaky_bucket", key = {name = 'test2'}, rate = 1, burst = 0}
+        leaky_bucket_limiters = {
+          { key = { name = 'test2' }, rate = 1, burst = 0 }
         },
         redis_url = 'redis://'..redis_host..':'..redis_port..'/1'
       }
@@ -120,8 +128,8 @@ describe('Rate limit policy', function()
 
     it('rejected (count)', function()
       local config = {
-        limiters = {
-          {name = "fixed_window", key = {name = 'test3'}, count = 1, window = 10}
+        fixed_window_limiters = {
+          { key = { name = 'test3' }, count = 1, window = 10 }
         },
         redis_url = 'redis://'..redis_host..':'..redis_port..'/1'
       }
@@ -133,8 +141,8 @@ describe('Rate limit policy', function()
 
     it('delay (conn)', function()
       local config = {
-        limiters = {
-          {name = "connections", key = {name = 'test1'}, conn = 1, burst = 1, delay = 2}
+        connection_limiters = {
+          { key = {name = 'test1'}, conn = 1, burst = 1, delay = 2 }
         },
         redis_url = 'redis://'..redis_host..':'..redis_port..'/1'
       }
@@ -146,8 +154,8 @@ describe('Rate limit policy', function()
 
     it('delay (req)', function()
       local config = {
-        limiters = {
-          {name = "leaky_bucket", key = {name = 'test2', scope = 'global'}, rate = 1, burst = 1}
+        leaky_bucket_limiters = {
+          { key = { name = 'test2', scope = 'global' }, rate = 1, burst = 1 }
         },
         redis_url = 'redis://'..redis_host..':'..redis_port..'/1'
       }
@@ -159,10 +167,9 @@ describe('Rate limit policy', function()
 
     it('delay (req) service scope', function()
       local config = {
-        limiters = {
+        leaky_bucket_limiters = {
           {
-            name = "leaky_bucket",
-            key = {name = 'test4', scope = 'service', service_name = 'bank_A'},
+            key = { name = 'test4', scope = 'service', service_name = 'bank_A' },
             rate = 1,
             burst = 1
           }
@@ -179,8 +186,8 @@ describe('Rate limit policy', function()
   describe('.log', function()
     it('success in leaving', function()
       local config = {
-        limiters = {
-          {name = "connections", key = {name = 'test1'}, conn = 20, burst = 10, delay = 0.5}
+        connection_limiters = {
+          { key = {name = 'test1'}, conn = 20, burst = 10, delay = 0.5 }
         },
         redis_url = 'redis://'..redis_host..':'..redis_port..'/1'
       }

--- a/t/apicast-policy-rate-limit.t
+++ b/t/apicast-policy-rate-limit.t
@@ -28,9 +28,8 @@ Return 200 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  connection_limiters = {
                     {
-                      name = "connections",
                       key = {name = "test1", scope = "service", service_name = "service_C"},
                       conn = 1,
                       burst = 1,
@@ -43,9 +42,8 @@ Return 200 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  connection_limiters = {
                     {
-                      name = "connections",
                       key = {name = "test1", scope = "service", service_name = "service_C"},
                       conn = 1,
                       burst = 1,
@@ -106,9 +104,8 @@ Return 500 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  connection_limiters = {
                     {
-                      name = "connections",
                       key = {name = "test3"},
                       conn = 20,
                       burst = 10,
@@ -151,9 +148,8 @@ Return 200 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  connection_limiters = {
                     {
-                      name = "connections",
                       key = {name = "test4"},
                       conn = 1,
                       burst = 0,
@@ -161,17 +157,14 @@ Return 200 code.
                     }
                   },
                   redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
-                  error_settings = {
-                    {type = "limits_exceeded", error_handling = "log"}
-                  }
+                  limits_exceeded_error  = { error_handling = "log" }
                 }
               },
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  connection_limiters = {
                     {
-                      name = "connections",
                       key = {name = "test4"},
                       conn = 1,
                       burst = 0,
@@ -179,9 +172,7 @@ Return 200 code.
                     }
                   },
                   redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
-                  error_settings = {
-                    {type = "limits_exceeded", error_handling = "log"}
-                  }
+                  limits_exceeded_error  = { error_handling = "log" }
                 }
               }
             }
@@ -231,9 +222,8 @@ Return 200 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  connection_limiters = {
                     {
-                      name = "connections",
                       key = {name = "test5"},
                       conn = 20,
                       burst = 10,
@@ -277,22 +267,23 @@ Return 200 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  leaky_bucket_limiters = {
                     {
-                      name = "leaky_bucket",
                       key = {name = "test6_1"},
                       rate = 20,
                       burst = 10
-                    },
+                    }
+                  },
+                  connection_limiters = {
                     {
-                      name = "connections",
                       key = {name = "test6_2"},
                       conn = 20,
                       burst = 10,
                       delay = 0.5
-                    },
+                    }
+                  },
+                  fixed_window_limiters = {
                     {
-                      name = "fixed_window",
                       key = {name = "test6_3"},
                       count = 20,
                       window = 10
@@ -351,9 +342,8 @@ Return 429 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  connection_limiters = {
                     {
-                      name = "connections",
                       key = {name = "test7"},
                       conn = 1,
                       burst = 0,
@@ -366,9 +356,8 @@ Return 429 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  connection_limiters = {
                     {
-                      name = "connections",
                       key = {name = "test7"},
                       conn = 1,
                       burst = 0,
@@ -427,18 +416,15 @@ Return 503 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  leaky_bucket_limiters = {
                     {
-                      name = "leaky_bucket",
                       key = {name = "test8"},
                       rate = 1,
                       burst = 0
                     }
                   },
                   redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
-                  error_settings = {
-                    {type = "limits_exceeded", status_code = 503}
-                  }
+                  limits_exceeded_error  = { status_code = 503 }
                 }
               }
             }
@@ -490,18 +476,15 @@ Return 429 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  fixed_window_limiters = {
                     {
-                      name = "fixed_window",
                       key = {name = "test9", scope = "global"},
                       count = 1,
                       window = 10
                     }
                   },
                   redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
-                  error_settings = {
-                    {type = "limits_exceeded", status_code = 429}
-                  }
+                  limits_exceeded_error = { status_code = 429 }
                 }
               }
             }
@@ -553,9 +536,8 @@ Return 200 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  connection_limiters = {
                     {
-                      name = "connections",
                       key = {name = "test10"},
                       conn = 1,
                       burst = 1,
@@ -568,9 +550,8 @@ Return 200 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  connection_limiters = {
                     {
-                      name = "connections",
                       key = {name = "test10"},
                       conn = 1,
                       burst = 1,
@@ -631,9 +612,8 @@ Return 200 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  leaky_bucket_limiters = {
                     {
-                      name = "leaky_bucket",
                       key = {name = "test11"},
                       rate = 1,
                       burst = 1
@@ -693,9 +673,8 @@ Return 429 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  connection_limiters = {
                     {
-                      name = "connections",
                       key = {name = "test12"},
                       conn = 1,
                       burst = 0,
@@ -707,9 +686,8 @@ Return 429 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  connection_limiters = {
                     {
-                      name = "connections",
                       key = {name = "test12"},
                       conn = 1,
                       burst = 0,
@@ -753,17 +731,14 @@ Return 429 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  leaky_bucket_limiters = {
                     {
-                      name = "leaky_bucket",
                       key = {name = "test13"},
                       rate = 1,
                       burst = 0
                     }
                   },
-                  error_settings = {
-                    {type = "limits_exceeded", error_handling = "exit"}
-                  }
+                  limits_exceeded_error = { error_handling = "exit" }
                 }
               }
             }
@@ -800,9 +775,8 @@ Return 429 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  fixed_window_limiters = {
                     {
-                      name = "fixed_window",
                       key = {name = "test14"},
                       count = 1,
                       window = 10
@@ -844,9 +818,8 @@ Return 200 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  connection_limiters = {
                     {
-                      name = "connections",
                       key = {name = "test15"},
                       conn = 1,
                       burst = 1,
@@ -858,9 +831,8 @@ Return 200 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  connection_limiters = {
                     {
-                      name = "connections",
                       key = {name = "test15"},
                       conn = 1,
                       burst = 1,
@@ -908,9 +880,8 @@ Return 200 code.
               {
                 name = "apicast.policy.rate_limit",
                 configuration = {
-                  limiters = {
+                  leaky_bucket_limiters = {
                     {
-                      name = "leaky_bucket",
                       key = {name = "test16"},
                       rate = 1,
                       burst = 1


### PR DESCRIPTION
The rate limit policy has a valid configuration JSON schema. However, it cannot be rendered by `react-jsonschema-form` the library used in the 3scale UI to build HTML forms from the config schemas. 

This PR solves the issue by adapting the schema. The library cannot render arrays of objects with different types, so I've split them into several arrays that have items of only one type. In particular, the properties causing issues in the UI library were `limiters` and `error_settings`.

This is a breaking change, but not between final versions. If you were using this policy in a previous release candidate or beta, your configuration will become invalid.

Ref: https://github.com/3scale/apicast/issues/695