### PR TITLE
CircleCI: Don't try to push docker images in PRs from forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,10 @@ jobs:
       - checkout
       - run: travis/install-s2i.sh /usr/local/bin # needs to be after checkout because it uses script from the repo
       - deploy:
+          # In PRs coming from forks, the docker credentials are not set.
+          # In that case, we just skip the step of pushing to the registry.
           command: |
+            ([ -z "${DOCKER_USERNAME}" ] || [ -z "${DOCKER_PASSWORD}" ]) && return 0;
             docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}" quay.io;
             make runtime-image push IMAGE_NAME="apicast:${CIRCLE_TAG:-${CIRCLE_BRANCH}}";
             make builder-image push IMAGE_NAME="apicast:${CIRCLE_TAG:-${CIRCLE_BRANCH}}-builder";
@@ -298,3 +301,6 @@ workflows:
       - benchmark:
           requires:
             - deploy
+          filters:
+            branches:
+              only: /^[^:]+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,10 @@ build-tags: &build-tags
     tags:
       only: /.*/
 
+ignore-forks: &ignore-forks
+  branches:
+    ignore: '/pull\/\d+/' # forks branch name is pull/PR_NUMBER
+
 workflows:
   version: 2
   nightly:
@@ -296,11 +300,11 @@ workflows:
             - s2i-runtime
             - s2i-builder
           filters:
+            <<: *ignore-forks
             tags:
               only: /^v\d+\..+/
       - benchmark:
           requires:
             - deploy
           filters:
-            branches:
-              only: /^[^:]+$/
+            <<: *ignore-forks


### PR DESCRIPTION
The `deploy` task in CircleCI fails in PRs opened from forks. The reason is that this task tries to push docker images to our registry and the docker credentials are not available in PRs from forks.
This PR solves the issue by skipping the `push` instruction when the credentials are not set.