### PR TITLE
3scale batching policy: fix batching period assignment from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - OpenTracing support [PR #669](https://github.com/3scale/apicast/pull/669)
 - Generate new policy scaffold from the CLI [PR #682](https://github.com/3scale/apicast/pull/682)
-- 3scale batcher policy [PR #685](https://github.com/3scale/apicast/pull/685)
+- 3scale batcher policy [PR #685](https://github.com/3scale/apicast/pull/685), [PR #710](https://github.com/3scale/apicast/pull/710)
 
 ### Changed
 

--- a/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
@@ -25,7 +25,7 @@ function _M.new(config)
   self.reports_batcher = ReportsBatcher.new(
     ngx.shared.batched_reports, 'batched_reports_locks')
 
-  self.batch_reports_seconds = config.batch_reports_seconds or
+  self.batch_reports_seconds = config.batch_report_seconds or
                                default_batch_reports_seconds
 
   self.report_timer_on = false

--- a/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
@@ -65,6 +65,10 @@ end
 local function report(_, service_id, backend, reports_batcher)
   local reports = reports_batcher:get_all(service_id)
 
+  if reports then
+    ngx.log(ngx.DEBUG, '3scale batcher report timer got ', #reports, ' reports')
+  end
+
   -- TODO: verify if we should limit the number of reports sent in a sigle req
   reporter.report(reports, service_id, backend, reports_batcher)
 end
@@ -85,6 +89,8 @@ local function ensure_report_timer_on(self, service_id, backend)
         service_id, backend, self.reports_batcher)
 
       self.report_timer_on = true
+      ngx.log(ngx.DEBUG, 'scheduled 3scale batcher report timer every ',
+                         self.batch_reports_seconds, ' seconds')
     end
 
     self.semaphore_report_timer:post()

--- a/gateway/src/apicast/policy/3scale_batcher/reports_batcher.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/reports_batcher.lua
@@ -99,7 +99,7 @@ function _M:get_all(service_id)
   local ok, unlock_err = lock:unlock()
   if not ok then
     ngx.log(ngx.ERR, 'failed to unlock: ', unlock_err)
-    return
+    return cached_reports
   end
 
   return cached_reports

--- a/spec/policy/3scale_batcher/3scale_batcher_spec.lua
+++ b/spec/policy/3scale_batcher/3scale_batcher_spec.lua
@@ -5,6 +5,22 @@ local configuration = require('apicast.configuration')
 local lrucache = require('resty.lrucache')
 
 describe('3scale batcher policy', function()
+  describe('.new', function()
+    it('allows to configure the batching period', function()
+      local test_batching_period = 3
+      local config = { batch_report_seconds = test_batching_period }
+      local batcher_policy = ThreescaleBatcher.new(config)
+
+      assert.equals(test_batching_period, batcher_policy.batch_reports_seconds)
+    end)
+
+    it('assigns a default of 10s for the batching period', function()
+      local batcher_policy = ThreescaleBatcher.new({})
+
+      assert.equals(10, batcher_policy.batch_reports_seconds)
+    end)
+  end)
+
   describe('.access', function()
     local service = configuration.parse_service({ id = 42 })
     local service_id = service.id

--- a/t/apicast-policy-3scale-batcher.t
+++ b/t/apicast-policy-3scale-batcher.t
@@ -255,6 +255,7 @@ push $res, "Host: one";
 $res
 --- no_error_log
 [error]
+3scale batcher report timer got
 
 === TEST 4: report batched reports to backend
 This test checks that reports are sent correctly to backend. To do that, it performs


### PR DESCRIPTION
This PR fixes a bug in the 3scale batching policy. It didn't assign the batching period according to the given configuration.
While at it, this PR also adds some debugging logs and tests that helped to detect this issue.