### PR TITLE
Fix example JSON config in the policies doc

### DIFF
--- a/doc/policies.md
+++ b/doc/policies.md
@@ -236,7 +236,7 @@ policies can be configured:
             }
           },
           {
-            "name":"apicast", "version": "builtin",
+            "name":"apicast", "version": "builtin"
           }
         ]
       }


### PR DESCRIPTION
Minor fix. The example JSON in the policies doc contained a trailing comma which is not accepted by the JSON standard.