### PR TITLE
Expose jwt in the policies context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `THREESCALE_PORTAL_ENDPOINT` and `THREESCALE_CONFIG_FILE` are not required anymore [PR #702](https://github.com/3scale/apicast/pull/702)
 - The `scope` of the Rate Limit policy is `service` by default [PR #704](https://github.com/3scale/apicast/pull/704)
+- Decoded JWTs are now exposed in the policies context by the APIcast policy [PR #718](https://github.com/3scale/apicast/pull/718)
 
 ## [3.2.0-rc2] - 2018-05-11
 

--- a/gateway/src/apicast/oauth/oidc.lua
+++ b/gateway/src/apicast/oauth/oidc.lua
@@ -128,7 +128,7 @@ function _M:transform_credentials(credentials)
     if ngx.config.debug then
       ngx.log(ngx.DEBUG, 'JWT object: ', require('inspect')(jwt_obj))
     end
-    return nil, nil, jwt_obj and jwt_obj.reason or err
+    return nil, nil, nil, jwt_obj and jwt_obj.reason or err
   end
 
   local payload = jwt_obj.payload
@@ -149,7 +149,7 @@ function _M:transform_credentials(credentials)
   -- OAuth2 credentials for OIDC
   -- @field app_id Client id
   -- @table credentials_oauth
-  return { app_id = app_id }, ttl
+  return { app_id = app_id }, ttl, payload
 end
 
 

--- a/gateway/src/apicast/proxy.lua
+++ b/gateway/src/apicast/proxy.lua
@@ -267,7 +267,8 @@ function _M:rewrite(service, context)
   local ttl
 
   if self.oauth then
-    credentials, ttl, err = self.oauth:transform_credentials(credentials)
+    local jwt_payload
+    credentials, ttl, jwt_payload, err = self.oauth:transform_credentials(credentials)
 
     if err then
       ngx.log(ngx.DEBUG, 'oauth failed with ', err)
@@ -275,6 +276,7 @@ function _M:rewrite(service, context)
     end
     ctx.credentials = credentials
     ctx.ttl = ttl
+    context.jwt = jwt_payload
   end
 
   context.credentials = ctx.credentials

--- a/spec/oauth/oidc_spec.lua
+++ b/spec/oauth/oidc_spec.lua
@@ -31,7 +31,7 @@ describe('OIDC', function()
         },
       })
 
-      local credentials, ttl, err = oidc:transform_credentials({ access_token = access_token })
+      local credentials, ttl, _, err = oidc:transform_credentials({ access_token = access_token })
 
       assert(credentials, err)
 
@@ -53,7 +53,7 @@ describe('OIDC', function()
 
       local stubbed
       for _=1, 10 do
-        local credentials, _, err = oidc:transform_credentials({ access_token = access_token })
+        local credentials, _, _, err = oidc:transform_credentials({ access_token = access_token })
         if not stubbed then
           stubbed = stub(jwt, 'verify_jwt_obj', function(_, jwt_obj, _) return jwt_obj end)
         end
@@ -75,7 +75,7 @@ describe('OIDC', function()
         },
       })
 
-      local credentials, _, err = oidc:transform_credentials({ access_token = access_token })
+      local credentials, _, _, err = oidc:transform_credentials({ access_token = access_token })
 
       assert(credentials, err)
     end)
@@ -93,7 +93,7 @@ describe('OIDC', function()
         },
       })
 
-      local credentials, _, err = oidc:transform_credentials({ access_token = access_token })
+      local credentials, _, _, err = oidc:transform_credentials({ access_token = access_token })
 
       assert.falsy(credentials)
       assert.truthy(err)
@@ -113,7 +113,7 @@ describe('OIDC', function()
 
       jwt_validators.set_system_clock(function() return 0 end)
 
-      local credentials, _, err = oidc:transform_credentials({ access_token = access_token })
+      local credentials, _, _, err = oidc:transform_credentials({ access_token = access_token })
       assert(credentials, err)
 
       jwt_validators.set_system_clock(function() return 1 end)
@@ -130,7 +130,7 @@ describe('OIDC', function()
         payload = { },
       })
 
-      local credentials, _, err = oidc:transform_credentials({ access_token = access_token })
+      local credentials, _, _, err = oidc:transform_credentials({ access_token = access_token })
 
       assert.match('invalid alg', err, nil, true)
       assert.falsy(credentials, err)
@@ -150,7 +150,7 @@ describe('OIDC', function()
         },
       })
 
-      local credentials, _, err = oidc:transform_credentials({ access_token = access_token })
+      local credentials, _, _, err = oidc:transform_credentials({ access_token = access_token })
       assert.same("Claim 'typ' ('Not-Bearer') returned failure", err)
       assert.falsy(credentials, err)
     end)
@@ -169,7 +169,7 @@ describe('OIDC', function()
         },
       })
 
-      local credentials, _, err = oidc:transform_credentials({ access_token = access_token })
+      local credentials, _, _, err = oidc:transform_credentials({ access_token = access_token })
       assert(credentials, err)
     end)
   end)

--- a/t/apicast-policy-headers.t
+++ b/t/apicast-policy-headers.t
@@ -5,16 +5,6 @@ use Cwd qw(abs_path);
 
 our $rsa = `cat t/fixtures/rsa.pem`;
 
-# Make fixtures policies available. There is a test that needs the "decode
-# oidc token" example policy.
-BEGIN {
-    $ENV{TEST_NGINX_APICAST_POLICY_LOAD_PATH} = 't/fixtures/policies';
-}
-
-env_to_apicast(
-    'APICAST_POLICY_LOAD_PATH' => abs_path($ENV{TEST_NGINX_APICAST_POLICY_LOAD_PATH}),
-);
-
 run_tests();
 
 __DATA__


### PR DESCRIPTION
This PR exposes jwt in the policies context in OAuth flows.

This is useful because it allows other policies to access those tokens. For example, the rate-limit policy ( #713 ) could benefit from this.

This PR also adds an integration test that uses OAuth and the headers policy and shows how it can set some headers with information extracted from the decoded jwt.