### PR TITLE
policy/3scale_batcher: add missing log error level

### DIFF
--- a/gateway/src/apicast/policy/3scale_batcher/reports_batcher.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/reports_batcher.lua
@@ -35,7 +35,7 @@ function _M:add(service_id, credentials, usage)
 
   local elapsed, lock_err = lock:lock(service_id)
   if not elapsed then
-    ngx.log("failed to acquire the lock: ", lock_err)
+    ngx.log(ngx.ERR, "failed to acquire the lock: ", lock_err)
     return
   end
 


### PR DESCRIPTION
Minor change. This PR just adds a missing log level error in a `ngx.log()` call. It's important because it's a `ngx.ERR` and we want to see it in the logs when it happens.