### PR TITLE
URL rewriting policy: Allow to modify query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Generate new policy scaffold from the CLI [PR #682](https://github.com/3scale/apicast/pull/682)
 - 3scale batcher policy [PR #685](https://github.com/3scale/apicast/pull/685), [PR #710](https://github.com/3scale/apicast/pull/710)
 - Liquid templating support in the headers policy configuration [PR #716](https://github.com/3scale/apicast/pull/716)
+- Ability to modify query parameters in the URL rewriting policy [PR #724](https://github.com/3scale/apicast/pull/724)
 
 ### Changed
 

--- a/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
+++ b/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
@@ -77,6 +77,10 @@
                 {
                   "enum": ["push"],
                   "title": "Create the arg when not set, add the value when set"
+                },
+                {
+                  "enum": ["delete"],
+                  "title": "Delete an arg"
                 }
               ]
             },

--- a/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
+++ b/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
@@ -55,6 +55,42 @@
           },
           "required": ["op", "regex", "replace"]
         }
+      },
+      "query_args_commands": {
+        "description": "List of commands to apply to the query string args",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "op": {
+              "description": "Operation to apply to the query argument",
+              "type": "string",
+              "oneOf": [
+                {
+                  "enum": ["add"],
+                  "title": "Add a value to an existing argument"
+                },
+                {
+                  "enum": ["set"],
+                  "title": "Create the arg when not set, replace its value when set"
+                },
+                {
+                  "enum": ["push"],
+                  "title": "Create the arg when not set, add the value when set"
+                }
+              ]
+            },
+            "arg": {
+              "description": "Query argument",
+              "type": "string"
+            },
+            "value": {
+              "description": "Value",
+              "type": "string"
+            }
+          }
+        },
+        "required": ["op", "arg", "value"]
       }
     }
   }

--- a/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
+++ b/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
@@ -87,6 +87,21 @@
             "value": {
               "description": "Value",
               "type": "string"
+            },
+            "value_type": {
+              "description": "How to evaluate 'value'",
+              "type": "string",
+              "oneOf": [
+                {
+                  "enum": ["plain"],
+                  "title": "Evaluate 'value' as plain text."
+                },
+                {
+                  "enum": ["liquid"],
+                  "title": "Evaluate 'value' as liquid."
+                }
+              ],
+              "default": "plain"
             }
           }
         },

--- a/gateway/src/apicast/policy/url_rewriting/query_params.lua
+++ b/gateway/src/apicast/policy/url_rewriting/query_params.lua
@@ -62,14 +62,8 @@ end
 --- Set a value for an argument
 -- 1) When the arg is not set, creates it with the given value.
 -- 2) When the arg is set, replaces its value with the given one.
--- 3) Deletes an arg when the value is "".
 function _M:set(arg, value)
-  if value == '' then
-    self.args[arg] = nil
-  else
-    self.args[arg] = value
-  end
-
+  self.args[arg] = value
   update_uri_args(self.args)
 end
 
@@ -80,6 +74,14 @@ end
 function _M:add(arg, value)
   if self.args[arg] then
     add_to_existing_arg(self, arg, value)
+    update_uri_args(self.args)
+  end
+end
+
+--- Deletes an argument
+function _M:delete(arg)
+  if self.args[arg] then
+    self.args[arg] = nil
     update_uri_args(self.args)
   end
 end

--- a/gateway/src/apicast/policy/url_rewriting/query_params.lua
+++ b/gateway/src/apicast/policy/url_rewriting/query_params.lua
@@ -1,0 +1,87 @@
+local setmetatable = setmetatable
+local insert = table.insert
+local type = type
+
+local _M = {}
+
+local mt = { __index = _M }
+
+-- Note: This module calls 'ngx.req.set_uri_args()' on each operation
+-- If this becomes too costly, we can change it by exposing a method that calls
+-- 'ngx.req.set_uri_args()' leaving that responsibility to the caller.
+
+--- Initialize a new QueryStringParams
+-- @tparam[opt] table uri_args URI arguments
+function _M.new(uri_args)
+  local self = setmetatable({}, mt)
+
+  if uri_args then
+    self.args = uri_args
+  else
+    local get_args_err
+    self.args, get_args_err = ngx.req.get_uri_args()
+
+    if not self.args then
+      ngx.log(ngx.ERR, 'Error while getting URI args: ', get_args_err)
+      return nil, get_args_err
+    end
+  end
+
+  return self
+end
+
+--- Updates the URI args
+local function update_uri_args(args)
+  ngx.req.set_uri_args(args)
+end
+
+local function add_to_existing_arg(self, arg, value)
+  -- When the argument has a single value, it is a string and needs to be
+  -- converted to table so we can add a second one.
+  if type(self.args[arg]) ~= 'table' then
+    self.args[arg] = { self.args[arg] }
+  end
+
+  insert(self.args[arg], value)
+end
+
+--- Pushes a value to an argument
+-- 1) When the arg is not set, creates it with the given value.
+-- 2) When the arg is set, it adds a new value for it (becomes an array if it
+--    was not one already).
+function _M:push(arg, value)
+  if not self.args[arg] then
+    self.args[arg] = value
+  else
+    add_to_existing_arg(self, arg, value)
+  end
+
+  update_uri_args(self.args)
+end
+
+--- Set a value for an argument
+-- 1) When the arg is not set, creates it with the given value.
+-- 2) When the arg is set, replaces its value with the given one.
+-- 3) Deletes an arg when the value is "".
+function _M:set(arg, value)
+  if value == '' then
+    self.args[arg] = nil
+  else
+    self.args[arg] = value
+  end
+
+  update_uri_args(self.args)
+end
+
+--- Adds a value for an argument
+-- 1) When the arg is not set, it does nothing.
+-- 2) When the arg is set, it adds a new value for it (becomes an array if it
+--    was not one already).
+function _M:add(arg, value)
+  if self.args[arg] then
+    add_to_existing_arg(self, arg, value)
+    update_uri_args(self.args)
+  end
+end
+
+return _M

--- a/gateway/src/apicast/policy/url_rewriting/url_rewriting.lua
+++ b/gateway/src/apicast/policy/url_rewriting/url_rewriting.lua
@@ -55,14 +55,17 @@ local function apply_query_arg_command(command, query_args, context)
     return
   end
 
-  func(query_args, command.arg, command.template_string:render(context))
+  local value = (command.template_string and command.template_string:render(context)) or nil
+  func(query_args, command.arg, value)
 end
 
 local function build_template(query_arg_command)
-  query_arg_command.template_string = TemplateString.new(
-    query_arg_command.value,
-    query_arg_command.value_type or default_value_type
-  )
+  if query_arg_command.value then -- The 'delete' op does not have a value
+    query_arg_command.template_string = TemplateString.new(
+      query_arg_command.value,
+      query_arg_command.value_type or default_value_type
+    )
+  end
 end
 
 --- Initialize a URL rewriting policy
@@ -83,7 +86,7 @@ end
 --
 -- Each query arg command is a table with the following fields:
 --
---   - op: can be 'push', 'set', and 'add'.
+--   - op: can be 'push', 'set', 'add', and 'delete'.
 --   - arg: query argument.
 --   - value: value to be added, replaced, or set.
 function _M.new(config)

--- a/spec/policy/url_rewriting/query_params_spec.lua
+++ b/spec/policy/url_rewriting/query_params_spec.lua
@@ -64,16 +64,6 @@ describe('QueryParams', function()
         assert.stub(ngx.req.set_uri_args).was_called_with(expected_args)
       end)
     end)
-
-    describe('if value is empty', function()
-      it('deletes the arg', function()
-        local params = QueryParams.new({ a = '1' })
-
-        params:set('a', '')
-
-        assert.stub(ngx.req.set_uri_args).was_called_with({})
-      end)
-    end)
   end)
 
   describe('.add', function()
@@ -108,6 +98,29 @@ describe('QueryParams', function()
           local expected_args = { a = { '1', '2', '3' } }
           assert.stub(ngx.req.set_uri_args).was_called_with(expected_args)
         end)
+      end)
+    end)
+  end)
+
+  describe('.delete', function()
+    describe('if the argument is in the query', function()
+      it('deletes it', function()
+        local params = QueryParams.new({ a = '1', b = '2' })
+
+        params:delete('a')
+
+        local expected_args = { b = '2' }
+        assert.stub(ngx.req.set_uri_args).was_called_with(expected_args)
+      end)
+    end)
+
+    describe('if the argument is not in the query', function()
+      it('does not delete anything', function()
+        local params = QueryParams.new({ a = '1' })
+
+        params:delete('b')
+
+        assert.stub(ngx.req.set_uri_args).was_not_called()
       end)
     end)
   end)

--- a/spec/policy/url_rewriting/query_params_spec.lua
+++ b/spec/policy/url_rewriting/query_params_spec.lua
@@ -1,0 +1,114 @@
+local QueryParams = require('apicast.policy.url_rewriting.query_params')
+
+describe('QueryParams', function()
+  before_each(function()
+    stub(ngx.req, 'set_uri_args')
+  end)
+
+  describe('.push', function()
+    describe('if the arg is not in the query', function()
+      it('creates it with the given value', function()
+        local params = QueryParams.new({ a = '1' })
+
+        params:push('b', '2')
+
+        local expected_args = { a = '1', b = '2' }
+        assert.stub(ngx.req.set_uri_args).was_called_with(expected_args)
+      end)
+    end)
+
+    describe('if the arg is in the query', function()
+      describe('and it has a single value', function()
+        it('adds a new value for it', function()
+          local params = QueryParams.new({ a = '1' })
+
+          params:push('a', '2')
+
+          local expected_args = { a = { '1', '2' } }
+          assert.stub(ngx.req.set_uri_args).was_called_with(expected_args)
+        end)
+      end)
+
+      describe('and it is an array', function()
+        it('adds a new value for it', function()
+          local params = QueryParams.new({ a = { '1', '2' } })
+
+          params:push('a', '3')
+
+          local expected_args = { a = { '1', '2', '3' } }
+          assert.stub(ngx.req.set_uri_args).was_called_with(expected_args)
+        end)
+      end)
+    end)
+  end)
+
+  describe('.set', function()
+    describe('if the arg is not in the query', function()
+      it('creates it with the given value', function()
+        local params = QueryParams.new({ a = '1' })
+
+        params:set('b', '2')
+
+        local expected_args = { a = '1', b = '2' }
+        assert.stub(ngx.req.set_uri_args).was_called_with(expected_args)
+      end)
+    end)
+
+    describe('if the arg is in the query', function()
+      it('replaces its value with the given one', function()
+        local params = QueryParams.new({ a = { '1', '2' } })
+
+        params:set('a', '3')
+
+        local expected_args = { a = '3' }
+        assert.stub(ngx.req.set_uri_args).was_called_with(expected_args)
+      end)
+    end)
+
+    describe('if value is empty', function()
+      it('deletes the arg', function()
+        local params = QueryParams.new({ a = '1' })
+
+        params:set('a', '')
+
+        assert.stub(ngx.req.set_uri_args).was_called_with({})
+      end)
+    end)
+  end)
+
+  describe('.add', function()
+    describe('if the arg is not in the query', function()
+      it('does nothing', function()
+        local params = QueryParams.new({ a = '1' })
+
+        params:add('b', '2')
+
+        assert.stub(ngx.req.set_uri_args).was_not_called()
+      end)
+    end)
+
+    describe('if the arg is in the query', function()
+      describe('and it has a single value', function()
+        it('adds a new value for it', function()
+          local params = QueryParams.new({ a = '1' })
+
+          params:add('a', '2')
+
+          local expected_args = { a = { '1', '2' } }
+          assert.stub(ngx.req.set_uri_args).was_called_with(expected_args)
+        end)
+      end)
+
+      describe('and it is an array', function()
+        it('adds a new value for it', function()
+          local params = QueryParams.new({ a = { '1', '2' } })
+
+          params:add('a', '3')
+
+          local expected_args = { a = { '1', '2', '3' } }
+          assert.stub(ngx.req.set_uri_args).was_called_with(expected_args)
+        end)
+      end)
+    end)
+  end)
+end)

--- a/spec/policy/url_rewriting/url_rewriting_spec.lua
+++ b/spec/policy/url_rewriting/url_rewriting_spec.lua
@@ -132,5 +132,71 @@ describe('URL rewriting policy', function()
 
       assert.stub(ngx.req.set_uri_args).was_called_with({ an_arg = { '1', '2' } })
     end)
+
+    it('supports liquid templates when pushing query args', function()
+      local context = { var_in_context = '123' }
+
+      local config_with_liquid = {
+        query_args_commands = {
+          {
+            op = 'push',
+            arg = 'an_arg',
+            value = '{{ var_in_context }}',
+            value_type = 'liquid'
+          }
+        }
+      }
+
+      local url_rewriting = URLRewriting.new(config_with_liquid)
+
+      url_rewriting:rewrite(context)
+
+      assert.stub(ngx.req.set_uri_args).was_called_with(
+        { an_arg = context.var_in_context })
+    end)
+
+    it('supports liquid templates when setting query args', function()
+      local context = { var_in_context = '123' }
+
+      local config_with_liquid = {
+        query_args_commands = {
+          {
+            op = 'set',
+            arg = 'an_arg',
+            value = '{{ var_in_context }}',
+            value_type = 'liquid'
+          }
+        }
+      }
+
+      local url_rewriting = URLRewriting.new(config_with_liquid)
+
+      url_rewriting:rewrite(context)
+
+      assert.stub(ngx.req.set_uri_args).was_called_with(
+        { an_arg = context.var_in_context })
+    end)
+
+    it('supports liquid templates when adding query args', function()
+      local context = { var_in_context = '123' }
+
+      local config_with_liquid = {
+        query_args_commands = {
+          {
+            op = 'add',
+            arg = 'an_arg',
+            value = '{{ var_in_context }}',
+            value_type = 'liquid'
+          }
+        }
+      }
+
+      local url_rewriting = URLRewriting.new(config_with_liquid)
+
+      url_rewriting:rewrite(context)
+
+      assert.stub(ngx.req.set_uri_args).was_called_with(
+        { an_arg = { 'original_value', context.var_in_context } })
+    end)
   end)
 end)

--- a/t/apicast-policy-url-rewriting.t
+++ b/t/apicast-policy-url-rewriting.t
@@ -265,3 +265,174 @@ yay, api backend
 --- error_code: 200
 --- no_error_log
 [error]
+
+=== TEST 6: "push" a query argument
+Test that the 'push' operation adds the argument when it does not exist already.
+When it exists, it adds a new value for it.
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.url_rewriting",
+            "configuration": {
+              "query_args_commands": [
+                { "op": "push", "arg": "new_arg", "value": "a_value" },
+                { "op": "push", "arg": "existing_arg", "value": "new_value" }
+              ]
+            }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+    content_by_lua_block {
+      local luassert = require('luassert')
+      luassert.equals('a_value', ngx.req.get_uri_args()['new_arg'])
+      luassert.same({ 'original_value', 'new_value' }, ngx.req.get_uri_args()['existing_arg'])
+      ngx.say('yay, api backend')
+    }
+  }
+--- request
+GET /?user_key=value&some_arg=1&existing_arg=original_value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 7: "set" a query argument
+Test that the 'set' operation replaces a query argument when it exists.
+When the argument does not exist, the operation creates it.
+When the value is empty, it deletes the argument.
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.url_rewriting",
+            "configuration": {
+              "query_args_commands": [
+                { "op": "set", "arg": "an_arg", "value": "new_value" },
+                { "op": "set", "arg": "not_in_the_original_query", "value": "val" },
+                { "op": "set", "arg": "to_delete", "value": "" }
+              ]
+            }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+    content_by_lua_block {
+      local luassert = require('luassert')
+      luassert.equals('new_value', ngx.req.get_uri_args()['an_arg'])
+      luassert.equals('val', ngx.req.get_uri_args()['not_in_the_original_query'])
+      luassert.is_nil(ngx.req.get_uri_args()['to_delete'])
+      ngx.say('yay, api backend')
+    }
+  }
+--- request
+GET /?user_key=value&an_arg=original_value&an_arg=another_val
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 8: "add" a query argument
+Test that the 'add' operation adds a value to an argument only when it exists
+already.
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.url_rewriting",
+            "configuration": {
+              "query_args_commands": [
+                { "op": "add", "arg": "new_arg", "value": "a_value" },
+                { "op": "add", "arg": "existing_arg", "value": "new_value" }
+              ]
+            }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+    content_by_lua_block {
+      local luassert = require('luassert')
+      luassert.same({ 'original_value', 'new_value' }, ngx.req.get_uri_args()['existing_arg'])
+      luassert.is_nil(ngx.req.get_uri_args()['new_arg'])
+      ngx.say('yay, api backend')
+    }
+  }
+--- request
+GET /?user_key=value&existing_arg=original_value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]


### PR DESCRIPTION
This PR implements part of #711 
It adds the ability to modify query parameters in the URL rewriting policy.