### PR TITLE
[ci] report unit test code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,10 @@ jobs:
             - lua_modules
       - run: mkdir -p tmp/junit
       - run: $(make rover) exec make busted
+      - run:
+          name: Report Code Coverage
+          command: bash <(curl -s https://codecov.io/bash)
+          when: always
       - restore_cache:
           keys:
             - apicast-cpanm-{{ arch }}-{{ checksum "gateway/cpanfile" }}

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,10 @@ development: build-development ## Run bash inside the development image
 rover: $(ROVER)
 	@echo $(ROVER)
 
-dependencies: $(ROVER)
+$(S2I_CONTEXT)/Roverfile.lock : $(S2I_CONTEXT)/Roverfile
+	$(ROVER) lock --roverfile=$(S2I_CONTEXT)/Roverfile
+
+dependencies: $(ROVER) $(S2I_CONTEXT)/Roverfile.lock
 	$(ROVER) install --roverfile=$(S2I_CONTEXT)/Roverfile
 
 lua_modules/bin/rover:

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ apicast-source: ## Create Docker Volume container with APIcast source code
 
 BUSTED_FILES ?=
 busted: dependencies $(ROVER) ## Test Lua.
-	@$(ROVER) exec bin/busted $(BUSTED_FILES)
+	@$(ROVER) exec bin/busted --coverage $(BUSTED_FILES)
 	@- luacov
 
 nginx:

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ apicast-source: ## Create Docker Volume container with APIcast source code
 
 BUSTED_FILES ?=
 busted: dependencies $(ROVER) ## Test Lua.
-	@$(ROVER) exec bin/busted --coverage $(BUSTED_FILES)
+	@$(ROVER) exec bin/busted $(BUSTED_FILES)
 	@- luacov
 
 nginx:
@@ -166,6 +166,7 @@ clean-containers: apicast-source
 
 clean: clean-containers ## Remove all running docker containers and images
 	- docker rmi apicast-test apicast-runtime-test --force
+	- rm -rf luacov.stats*.out
 
 doc/lua/index.html: $(shell find gateway/src -name '*.lua' 2>/dev/null) | dependencies $(ROVER)
 	$(ROVER) exec ldoc -c doc/config.ld .

--- a/bin/busted.lua
+++ b/bin/busted.lua
@@ -2,15 +2,16 @@ if ngx ~= nil then
   ngx.exit = function()end
 end
 
-local ok, luacov = pcall(require, 'luacov.runner')
-
-if ok then
+if os.getenv('CI') == 'true' then
+  local luacov = require('luacov.runner')
   local pwd = os.getenv('PWD')
 
   for _, option in ipairs({"statsfile", "reportfile"}) do
     -- properly expand current working dir, workaround for https://github.com/openresty/resty-cli/issues/35
     luacov.defaults[option] = pwd .. package.config:sub(1, 1) .. luacov.defaults[option]
   end
+
+  table.insert(arg, '--coverage')
 end
 
 -- Busted command-line runner

--- a/bin/busted.lua
+++ b/bin/busted.lua
@@ -2,7 +2,16 @@ if ngx ~= nil then
   ngx.exit = function()end
 end
 
-pcall(require, 'luarocks.loader')
+local ok, luacov = pcall(require, 'luacov.runner')
+
+if ok then
+  local pwd = os.getenv('PWD')
+
+  for _, option in ipairs({"statsfile", "reportfile"}) do
+    -- properly expand current working dir, workaround for https://github.com/openresty/resty-cli/issues/35
+    luacov.defaults[option] = pwd .. package.config:sub(1, 1) .. luacov.defaults[option]
+  end
+end
 
 -- Busted command-line runner
 require 'busted.runner'({ standalone = false })

--- a/gateway/Roverfile
+++ b/gateway/Roverfile
@@ -4,6 +4,7 @@ luarocks {
 
     group 'testing' {
         module { 'busted' },
+        module { 'luacov' },
         module { 'ljsonschema' },
     },
 

--- a/gateway/Roverfile.lock
+++ b/gateway/Roverfile.lock
@@ -14,6 +14,7 @@ lua-resty-repl 0.0.6-0||development
 lua-resty-url 0.2.0-1||production
 lua-term 0.7-1||testing
 lua_cliargs 3.0-1||testing
+luacov 0.13.0-1||testing
 luafilesystem 1.7.0-2||production,development,testing
 luassert 1.7.10-0||testing
 luasystem 0.2.1-0||testing


### PR DESCRIPTION
Unfortunately it makes busted build about 7x slower. (from 7s to 48s).

There will be more reports when master gets build with coverage, but for now there is a proof it actually measures stuff: https://codecov.io/gh/3scale/apicast/tree/36c56a6868a69020145862f7aa10f14d6ff62c6f/gateway/src/apicast