### PR TITLE
Fixing add-SSL example to work with example in README

### DIFF
--- a/examples/add-ssl/README.md
+++ b/examples/add-ssl/README.md
@@ -9,7 +9,7 @@ APIcast will read all `.conf` files in the `apicast.d` folder inside its prefix 
 ## Starting Docker
 
 ```sh
-docker run -it -v $(pwd)/apicast.d:/opt/app-root/src/apicast.d:ro -v $(pwd)/cert:/opt/app-root/src/conf/cert:ro --env THREESCALE_PORTAL_ENDPOINT=https://git.io/vXHTA --publish 8443:8443 quay.io/3scale/apicast:master
+docker run -it -v $(pwd)/apicast.d:/opt/app-root/src/apicast.d:ro -v $(pwd)/cert:/opt/app-root/src/conf/cert:ro -e THREESCALE_PORTAL_ENDPOINT=https://git.io/vXHTA -e THREESCALE_DEPLOYMENT_ENV=staging -p 8443:8443 quay.io/3scale/apicast:master
 ```
 
 Mounts `cert` and `apicast.d` folder to the correct place and exposes port 8443 that the `ssl.conf` defines.

--- a/examples/add-ssl/apicast.d/ssl.conf
+++ b/examples/add-ssl/apicast.d/ssl.conf
@@ -1,3 +1,3 @@
 listen 8443 ssl;
-ssl_certificate cert/server.crt;
-ssl_certificate_key cert/server.key;
+ssl_certificate /opt/app-root/src/conf/cert/server.crt;
+ssl_certificate_key /opt/app-root/src/conf/cert/server.key;


### PR DESCRIPTION
**Motivation**
Following the current instructions in the README results in the following error.
```
nginx: [emerg] BIO_new_file("/tmp/cert/server.crt") failed (SSL: error:02001002:system library:fopen:No such file or directory:fopen('/tmp/cert/server.crt','r') error:2006D080:BIO routines:BIO_new_file:no such file)
```

Also included `-e THREESCALE_DEPLOYMENT_ENV=staging` in example usage as production loads the config via `boot` and will fail as  https://git.io/vXHTA/admin/api/services.json will 404.

