### PR TITLE
[codecov] configure codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  branch: master
+comment: off


### PR DESCRIPTION
Disable comments, so we have "quiet" period when we get the 
code coverage numbers.

Set default branch to master. Codecov thinks it is v2.