### PR TITLE
[t] generate luacov reports from t files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,8 @@ jobs:
       - run: mkdir -p tmp/junit
       - run: $(make rover) exec make busted
       - run:
-          name: Report Code Coverage
-          command: bash <(curl -s https://codecov.io/bash)
+          name: Report Unit Test Code Coverage
+          command: curl -s https://codecov.io/bash | bash -s - -F busted -c
           when: always
       - restore_cache:
           keys:
@@ -75,6 +75,11 @@ jobs:
           environment:
             JUNIT_OUTPUT_FILE: tmp/junit/prove.xml
             HARNESS: TAP::Harness::JUnit
+      - run:
+          name: Report Integration Test Code Coverage
+          command:
+            curl -s https://codecov.io/bash | bash -s - -f 'luacov.report.*.out' -F prove -c
+          when: always
       - save_cache:
           key: apicast-cpanm-{{ arch }}-{{ checksum "gateway/cpanfile" }}
           paths:

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ prove: HARNESS ?= TAP::Harness
 prove: PROVE_FILES ?= $(filter-out $(call find-file, "*.t", examples/scaffold),$(call find-file, *.t, t examples))
 prove: export TEST_NGINX_RANDOMIZE=1
 prove: $(ROVER) nginx cpan ## Test nginx
-	$(ROVER) exec prove -j$(NPROC) --harness=$(HARNESS) $(PROVE_FILES) 2>&1 | awk '/found ONLY/ { print "FAIL: because found ONLY in test"; print; exit 1 }; { print }'
+	$(ROVER) exec script/prove -j$(NPROC) --harness=$(HARNESS) $(PROVE_FILES)
 
 prove-docker: apicast-source
 prove-docker: export IMAGE_NAME ?= apicast-test

--- a/gateway/http.d/init.conf
+++ b/gateway/http.d/init.conf
@@ -3,6 +3,41 @@ init_by_lua_block {
     -- require('jit.p').start('vl')
     -- require('jit.dump').start('bsx', 'jit.log')
 
+    if os.getenv('CI') == 'true' then
+      pcall(require, 'luacov.runner')
+    end
+
+    local luacov = package.loaded['luacov.runner']
+
+    if luacov then
+        local pwd = os.getenv('PWD') .. package.config:sub(1, 1)
+        local pid = require("ngx.process").get_master_pid
+
+        if not pid then
+          do
+            local ffi = require("ffi")
+            ffi.cdef[[int getpid(void);]]
+            pid = ffi.C.getpid()
+          end
+        end
+
+        local config = { }
+        for _, option in ipairs({"statsfile", "reportfile"}) do
+          -- properly expand current working dir, workaround for https://github.com/openresty/resty-cli/issues/35
+          config[option] = pwd .. luacov.defaults[option]
+          luacov.defaults[option] = pwd
+        end
+
+        luacov.defaults.savestepsize = 3
+        jit.off()
+
+        luacov.init()
+
+        for option, value in pairs(config) do
+          luacov.configuration[option] = value
+        end
+    end
+
     require("resty.core")
 
     local resty_env = require('resty.env')
@@ -50,6 +85,20 @@ init_by_lua_block {
 }
 
 init_worker_by_lua_block {
+    local luacov = package.loaded['luacov.runner']
+
+    if luacov then
+      luacov.configuration.statsfile = luacov.defaults.statsfile .. 'luacov.stats.' .. ngx.worker.pid() .. '.out'
+      luacov.resume()
+
+      ngx.timer.every(100, function(premature)
+        if premature then
+          luacov.save_stats()
+          luacov.tick = true
+        end
+      end)
+    end
+
     require('apicast.executor'):init_worker()
 }
 

--- a/script/luacov
+++ b/script/luacov
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -euo pipefail
+
+stats=$1
+pid=$(echo "$stats" | awk -F"." '{print $4}')
+
+mv -v "$stats" luacov.stats.out
+luacov
+mv -v luacov.report.out "luacov.report.${pid}.out"
+rm luacov.stats.out

--- a/script/prove
+++ b/script/prove
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -euo pipefail
+
+coverage='luacov.stats.*.out'
+
+generate_coverage() {
+  find . -maxdepth 1 -name "$coverage" -exec script/luacov '{}' \;
+}
+trap generate_coverage EXIT
+
+# shellcheck disable=SC2086
+rm -f $coverage luacov.report.*.out
+
+if (prove "$@" 2>&1 | awk '/found ONLY/ { print "FAIL: because found ONLY in test"; print; exit 1 }; { print }'); then
+  echo "Success"
+else
+  status="$?"
+  echo "Failure. Exit code: ${status}"
+  exit $status
+fi


### PR DESCRIPTION
Load luacov in APIcast when `CI` environment variable is set. 

This allows collecting code coverage metrics from blackbox integration tests as well as live APIcast instances (if luacov is available).

It also splits code coverage into `busted` and `prove` so we know which covers what.