### PR TITLE
OpenResty 1.13.6.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 s2i-image: &s2i-image
-  image: quay.io/3scale/s2i-openresty-centos7:1.13.6.1-rover12
+  image: quay.io/3scale/s2i-openresty-centos7:1.13.6.2-1
   environment:
     TEST_NGINX_BINARY: openresty
     LUA_BIN_PATH: /opt/app-root/bin
@@ -55,7 +55,7 @@ jobs:
     environment:
       S2I_VERSION: "1.1.9a-40ad911d"
       DOCKER_COMPOSE_VERSION: "1.16.1"
-      OPENRESTY_VERSION: "1.13.6.1-rover12"
+      OPENRESTY_VERSION: "1.13.6.2-1"
     steps:
       - <<: *setup-docker
       - run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `THREESCALE_PORTAL_ENDPOINT` and `THREESCALE_CONFIG_FILE` are not required anymore [PR #702](https://github.com/3scale/apicast/pull/702)
 - The `scope` of the Rate Limit policy is `service` by default [PR #704](https://github.com/3scale/apicast/pull/704)
 - Decoded JWTs are now exposed in the policies context by the APIcast policy [PR #718](https://github.com/3scale/apicast/pull/718)
+- Upgraded OpenResty to 1.13.6.2, uses OpenSSL 1.1 [PR #733](https://github.com/3scale/apicast/pull/733)
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ prove: HARNESS ?= TAP::Harness
 prove: PROVE_FILES ?= $(call prove-files)
 prove: export TEST_NGINX_RANDOMIZE=1
 prove: $(ROVER) nginx ## Test nginx
-	$(ROVER) exec script/prove -j$(NPROC) --harness=$(HARNESS) $(PROVE_FILES)
+	$(ROVER) exec script/prove --verbose -j$(NPROC) --harness=$(HARNESS) $(PROVE_FILES)
 
 prove-docker: apicast-source
 prove-docker: export IMAGE_NAME ?= apicast-test

--- a/gateway/Roverfile.lock
+++ b/gateway/Roverfile.lock
@@ -9,7 +9,7 @@ lua-resty-env 0.4.0-1||production
 lua-resty-execvp 0.1.1-1||production
 lua-resty-http 0.12-0||production
 lua-resty-iputils 0.3.0-1||development
-lua-resty-jwt 0.1.11-0||production
+lua-resty-jwt 0.2.0-0||production
 lua-resty-repl 0.0.6-0||development
 lua-resty-url 0.2.0-1||production
 lua-term 0.7-1||testing

--- a/gateway/src/apicast/management.lua
+++ b/gateway/src/apicast/management.lua
@@ -10,8 +10,6 @@ local resolver_cache = require('resty.resolver.cache')
 local env = require('resty.env')
 local policy_manifests_loader = require('apicast.policy_manifests_loader')
 
-local setmetatable = setmetatable
-
 local live = { status = 'live', success = true }
 
 local function json_response(body, status)
@@ -129,7 +127,6 @@ end
 
 function _M.get_all_policy_manifests()
   local manifests = policy_manifests_loader.get_all()
-  setmetatable(manifests, cjson.array_mt)
   return json_response({ policies = manifests })
 end
 


### PR DESCRIPTION
Upgrade OpenResty to 1.13.6.2. See the changelog: http://openresty.org/en/changelog-1013006.html
Major change is OpenSSL 1.1, so some FFI code needed to be changed: (https://github.com/cdbattags/lua-resty-jwt/pull/4)

using https://github.com/3scale/s2i-openresty/pull/58