### PR TITLE
Do not upgrade base image installed packages on development Dockerfile

### DIFF
--- a/Dockerfile-development
+++ b/Dockerfile-development
@@ -8,8 +8,7 @@ USER root
 ARG USER_NAME=default
 ARG USER_HOME=/home/centos
 
-RUN yum -y update \
- && yum -y install sudo \
+RUN yum -y install sudo \
  && yum -y autoremove \
  && yum -y clean all
 


### PR DESCRIPTION
Improve reproducibility and repeatability on development image not upgrading existing base image packages.

Base image ( quay.io/3scale/s2i-openresty-centos7:1.13.6.1-rover12 ) has installed
```
openresty-openssl-1.0.2k-1.el7.centos.x86_64
```

After
```
yum update
```

installed package was
```
openresty-openssl-1.1.0h-3.el7.centos.x86_64
```

which broke compatibility with used openresty package, specifically when using *jwt* resty module.

This effect may happen again when new packages are available in remote repositories unless upgrading step is avoided.

