### PR TITLE
Fix invalid JSON in URL rewriting policy tests

### DIFF
--- a/t/apicast-policy-url-rewriting.t
+++ b/t/apicast-policy-url-rewriting.t
@@ -351,7 +351,7 @@ When the argument does not exist, the operation creates it.
             "configuration": {
               "query_args_commands": [
                 { "op": "set", "arg": "an_arg", "value": "new_value" },
-                { "op": "set", "arg": "not_in_the_original_query", "value": "val" },
+                { "op": "set", "arg": "not_in_the_original_query", "value": "val" }
               ]
             }
           },


### PR DESCRIPTION
The tests were failing silently due to a bug in the Test::APIcast library.
This has been solved. Updating to the new version detects the error : #737 