### PR TITLE
[Refactor] 3scale batching policy: extract Transaction module

### DIFF
--- a/gateway/src/apicast/policy/3scale_batcher/auths_cache.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/auths_cache.lua
@@ -31,13 +31,10 @@ local function value_to_cache(auth_status, rejection_reason)
 end
 
 --- Get a cached authorization.
--- @tparam service_id string Service ID
--- @tparam credentials table The keys of the table are the credential type
---   (user_key, app_id or access_token) and the values are the credentials
--- @tparam usage Usage The usage to authorize
+-- @tparam transaction Transaction A transaction
 -- @treturn table The table has a "status" and a "rejection_reason"
-function _M:get(service_id, credentials, usage)
-  local key = keys_helper.key_for_cached_auth(service_id, credentials, usage)
+function _M:get(transaction)
+  local key = keys_helper.key_for_cached_auth(transaction)
   local cached_value = self.storage:get(key)
 
   if not cached_value then return nil end
@@ -47,15 +44,12 @@ function _M:get(service_id, credentials, usage)
 end
 
 --- Store an authorization in the cache.
--- @tparam service_id string Service ID
--- @tparam credentials table The keys of the table are the credential type
---   (user_key, app_id or access_token) and the values are the credentials
--- @tparam usage Usage Usage of the authorization
+-- @tparam transaction Transaction A transaction
 -- @tparam auth_status integer Status returned by backend (200, 409, etc.)
 -- @tparam[opt] rejection_reason string Rejection reason given by backend
 --   when it denies an authorization
-function _M:set(service_id, credentials, usage, auth_status, rejection_reason)
-  local key = keys_helper.key_for_cached_auth(service_id, credentials, usage)
+function _M:set(transaction, auth_status, rejection_reason)
+  local key = keys_helper.key_for_cached_auth(transaction)
   local val_to_cache = value_to_cache(auth_status, rejection_reason)
 
   local ok, err = self.storage:set(key, val_to_cache, self.ttl)

--- a/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
@@ -42,10 +42,10 @@ local regexes_report_key = {
   "service_id:(?<service_id>[\\w-]+),app_id:(?<app_id>[\\w-]+),app_key:(?<app_key>[\\w-]+),metric:(?<metric>[\\w-]+)"
 }
 
-function _M.key_for_cached_auth(service_id, credentials, usage)
-  local service_part = format("service_id:%s", service_id)
-  local creds_part = creds_part_in_key(credentials)
-  local metrics_part = metrics_part_in_key(usage)
+function _M.key_for_cached_auth(transaction)
+  local service_part = format("service_id:%s", transaction.service_id)
+  local creds_part = creds_part_in_key(transaction.credentials)
+  local metrics_part = metrics_part_in_key(transaction.usage)
 
   return format("%s,%s,%s", service_part, creds_part, metrics_part)
 end

--- a/gateway/src/apicast/policy/3scale_batcher/transaction.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/transaction.lua
@@ -1,0 +1,21 @@
+--- Transaction
+-- A transaction contains the information that APIcast needs to send to the
+-- 3scale backend in order to know whether a call should be authorized.
+
+local setmetatable = setmetatable
+
+local _M = {}
+
+local mt = { __index = _M }
+
+function _M.new(service_id, credentials, usage)
+  local self = setmetatable({}, mt)
+
+  self.service_id = service_id
+  self.credentials = credentials
+  self.usage = usage
+
+  return self
+end
+
+return _M

--- a/spec/policy/3scale_batcher/auths_cache_spec.lua
+++ b/spec/policy/3scale_batcher/auths_cache_spec.lua
@@ -1,5 +1,6 @@
 local AuthsCache = require 'apicast.policy.3scale_batcher.auths_cache'
 local Usage = require 'apicast.usage'
+local Transaction = require 'apicast.policy.3scale_batcher.transaction'
 local lrucache =require 'resty.lrucache'
 
 local storage
@@ -20,28 +21,31 @@ describe('Auths cache', function()
 
   it('caches auth with user key', function()
     local user_key = { user_key = 'uk' }
+    local transaction = Transaction.new(service_id, user_key, usage)
 
-    cache:set(service_id, user_key, usage, auth_status)
+    cache:set(transaction, auth_status)
 
-    local cached = cache:get(service_id, user_key, usage)
+    local cached = cache:get(transaction)
     assert.equals(auth_status, cached.status)
   end)
 
   it('caches auth with app id + app key', function()
     local app_id_and_key = { app_id = 'an_id', app_key = 'a_key' }
+    local transaction = Transaction.new(service_id, app_id_and_key, usage)
 
-    cache:set(service_id, app_id_and_key, usage, auth_status)
+    cache:set(transaction, auth_status)
 
-    local cached = cache:get(service_id, app_id_and_key, usage)
+    local cached = cache:get(transaction)
     assert.equals(auth_status, cached.status)
   end)
 
   it('caches auth with access token', function()
     local access_token = { access_token = 'a_token' }
+    local transaction = Transaction.new(service_id, access_token, usage)
 
-    cache:set(service_id, access_token, usage, auth_status)
+    cache:set(transaction, auth_status)
 
-    local cached = cache:get(service_id, access_token, usage)
+    local cached = cache:get(transaction)
     assert.equals(auth_status, cached.status)
   end)
 
@@ -56,27 +60,32 @@ describe('Auths cache', function()
 
     local user_key = { user_key = 'uk' }
 
-    cache:set(service_id, user_key, usage_order_1, auth_status)
+    local transaction_with_order_1 = Transaction.new(service_id, user_key, usage_order_1)
+    local transaction_with_order_2 = Transaction.new(service_id, user_key, usage_order_2)
 
-    local cached = cache:get(service_id, user_key, usage_order_2)
+    cache:set(transaction_with_order_1, auth_status)
+
+    local cached = cache:get(transaction_with_order_2)
     assert.equals(auth_status, cached.status)
   end)
 
   it('caches a rejection reason when given', function()
     local rejection_reason = 'limits_exceeded'
     local app_id_and_key = { app_id = 'an_id', app_key = 'a_key' }
+    local transaction = Transaction.new(service_id, app_id_and_key, usage)
     local not_authorized_status = 409
 
-    cache:set(service_id, app_id_and_key, usage, not_authorized_status, rejection_reason)
+    cache:set(transaction, not_authorized_status, rejection_reason)
 
-    local cached = cache:get(service_id, app_id_and_key, usage)
+    local cached = cache:get(transaction)
     assert.equals(not_authorized_status, cached.status)
     assert.equals(rejection_reason, cached.rejection_reason)
   end)
 
   it('returns nil when something is not cached', function()
     local user_key = { user_key = 'uk' }
+    local transaction = Transaction.new(service_id, user_key, usage)
 
-    assert.is_nil(cache:get(service_id, user_key, usage))
+    assert.is_nil(cache:get(transaction))
   end)
 end)

--- a/spec/policy/3scale_batcher/keys_helper_spec.lua
+++ b/spec/policy/3scale_batcher/keys_helper_spec.lua
@@ -1,5 +1,6 @@
 local keys_helper = require 'apicast.policy.3scale_batcher.keys_helper'
 local Usage = require 'apicast.usage'
+local Transaction = require 'apicast.policy.3scale_batcher.transaction'
 
 describe('Keys Helper', function()
   describe('.key_for_cached_auth', function()
@@ -9,8 +10,9 @@ describe('Keys Helper', function()
       local usage = Usage.new()
       usage:add('m1', 1)
       usage:add('m2', 2)
+      local transaction = Transaction.new(service_id, credentials, usage)
 
-      local key = keys_helper.key_for_cached_auth(service_id, credentials, usage)
+      local key = keys_helper.key_for_cached_auth(transaction)
       assert.equals('service_id:s1,app_id:ai,app_key:ak,metrics:m1=1;m2=2', key)
     end)
   end)


### PR DESCRIPTION
Refactoring.

In many parts of the code of the policy, these 3 attributes are used together: `service_id`, `credentials`, `usage`. Those 3 are the information that APIcast sends to the 3scale backend to know whether a call should be authorized. This PR creates a new Transaction module that groups those attributes.

This refactoring will make it easier to implement #738 