### PR TITLE
[circleci] allow codecov to fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,9 @@ jobs:
 
         - run:
             name: Report Unit Test Code Coverage
-            command: curl -s https://codecov.io/bash | bash -s - -F busted -c
+            command: |
+              set +x # allow failures
+              curl -s https://codecov.io/bash | bash -s - -F busted -c
             when: always
         - store_test_results:
             path: tmp/junit
@@ -200,7 +202,8 @@ jobs:
             HARNESS: TAP::Harness::JUnit
       - run:
           name: Report Integration Test Code Coverage
-          command:
+          command: |
+            set +x # allow failures
             curl -s https://codecov.io/bash | bash -s - -f 'luacov.report.*.out' -F prove -c
           when: always
       - store_test_results:


### PR DESCRIPTION
codecov failed in https://circleci.com/gh/3scale/apicast/9097

```
bash: line 1: html: No such file or directory
bash: line 2: syntax error near unexpected token `<'
```