### PR TITLE
[brew] install OpenResty with OpenTracing support

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,5 @@
 tap "3scale/openresty"
 tap "3scale/opentracing"
 
-brew "3scale/opentracing/openresty", args: ["with-debug"]
-brew "3scale/openresty/luarocks"
+brew "3scale/opentracing/openresty", args: ["with-debug"], link: true
+brew "3scale/openresty/luarocks", link: true

--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,5 @@
 tap "3scale/openresty"
+tap "3scale/opentracing"
 
-brew "homebrew/nginx/openresty", args: ["with-debug"]
+brew "3scale/opentracing/openresty", args: ["with-debug"]
 brew "3scale/openresty/luarocks"

--- a/README.md
+++ b/README.md
@@ -105,13 +105,10 @@ Use `docker kill -s $SIGNAL CONTAINER` to send them, where _CONTAINER_ is the co
 For developing and testing APIcast the following tools are needed:
 
 - [OpenResty](http://openresty.org/en/) - a bundle based on NGINX core and including LuaJIT and Lua modules. Follow the [installation instructions](http://openresty.org/en/installation.html) according to your OS.
+   On macOS you can run `brew bundle` to install OpenResty and LuaRocks.
 
 - [LuaRocks](https://luarocks.org/) - the Lua package manager.
    You can find [installation instructions](https://github.com/keplerproject/luarocks/wiki/Download#installing) for different platforms in the documentation.
-   For Mac OS X the following [Homebrew](http://brew.sh/) formula can be used:
-```shell
- brew install apitools/openresty/luarocks
-```
 
 - Install the APIcast [development dependencies](gateway/Roverfile)
 ```shell


### PR DESCRIPTION
Simplify install instructions on macOS by defining everything in Brewfile and suggesting `brew bundle`.

We have homebrew tap with OpenResty+OpenTracing: https://github.com/3scale/homebrew-opentracing