### PR TITLE
[github] change owner to core team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-# APIcast team owns everything.
-* @3scale/apicast
+# APIcast Core team owns everything.
+* @3scale/apicast-core
 
 # But documentation is also owned by the documentation team.
 /doc/ @3scale/documentation


### PR DESCRIPTION
So we don't notify everyone on every PR, but just the core team.