### PR TITLE
Token Introspection Policy to get client information from "oidc_issuer_endpoint".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `APICAST_ACCESS_LOG_FILE` env to make the access log location configurable [THREESCALE-743](https://github.com/3scale/apicast/pull/743)
 - ENV variables to make APIcast listen on HTTPS port [PR #622](https://github.com/3scale/apicast/pull/622) 
 - New `ssl_certificate` phase allows policies to provide certificate to terminate HTTPS connection [PR #622](https://github.com/3scale/apicast/pull/622).
+- Configurable `auth_type` for the token introspection policy [PR #755](https://github.com/3scale/apicast/pull/755)
 
 ### Changed
 

--- a/examples/policies/token_introspection_configuration.lua
+++ b/examples/policies/token_introspection_configuration.lua
@@ -1,6 +1,7 @@
 local policy_chain = require('apicast.policy_chain').default()
 
 local token_policy = require('apicast.policy.token_introspection').new({
+        auth_type = "client_id+client_secret",
         introspection_url = "http://localhost:8080/auth/realms/3scale/protocol/openid-connect/token/introspect",
         client_id = "YOUR_CLIENT_ID",
         client_secret = "YOUR_CLIENT_SECRET"

--- a/gateway/src/apicast/policy/token_introspection/apicast-policy.json
+++ b/gateway/src/apicast/policy/token_introspection/apicast-policy.json
@@ -2,24 +2,17 @@
   "$schema": "http://apicast.io/poolicy-v1/schema#manifest#",
   "name": "OAuth 2.0 Token Introspection",
   "summary": "Configures OAuth 2.0 Token Introspection.",
-  "description": 
-  ["This policy executes OAuth 2.0 Token Introspection ",
-   "(https://tools.ietf.org/html/rfc7662) for every API call."],
+  "description": ["This policy executes OAuth 2.0 Token Introspection ",
+    "(https://tools.ietf.org/html/rfc7662) for every API call."
+  ],
   "version": "builtin",
   "configuration": {
     "type": "object",
     "properties": {
-      "introspection_url": {
-        "description": "Introspection Endpoint URL",
-        "type": "string"
-      },
-      "client_id": {
-        "description": "Client ID for the Token Introspection Endpoint",
-        "type": "string"
-      },
-      "client_secret": {
-        "description": "Client Secret for the Token Introspection Endpoint",
-        "type": "string"
+      "auth_type": {
+        "type": "string",
+        "enum": ["use_3scale_oidc_issuer_endpoint", "client_id+client_secret"],
+        "default": "client_id+client_secret"
       },
       "max_ttl_tokens": {
         "description": "Max TTL for cached tokens",
@@ -32,6 +25,43 @@
         "type": "integer",
         "minimum": 0,
         "maximum": 10000
+      }
+    },
+    "required": [
+      "auth_type"
+    ],
+    "dependencies": {
+      "auth_type": {
+        "oneOf": [{
+          "properties": {
+            "auth_type": {
+              "describe": "Use the Client credentials and the Token Introspection Endpoint from the OpenID Connect Issuer setting.",
+              "enum": ["use_3scale_oidc_issuer_endpoint"]
+            }
+          }
+        }, {
+          "properties": {
+            "auth_type": {
+              "describe": "Specify the Token Introspection Endpoint, Client ID, and Client Secret.",
+              "enum": ["client_id+client_secret"]
+            },
+            "client_id": {
+              "description": "Client ID for the Token Introspection Endpoint",
+              "type": "string"
+            },
+            "client_secret": {
+              "description": "Client Secret for the Token Introspection Endpoint",
+              "type": "string"
+            },
+            "introspection_url": {
+              "description": "Introspection Endpoint URL",
+              "type": "string"
+            }
+          },
+          "required": [
+            "client_id", "client_secret", "introspection_url"
+          ]
+        }]
       }
     }
   }

--- a/spec/policy/token_introspection/token_introspection_spec.lua
+++ b/spec/policy/token_introspection/token_introspection_spec.lua
@@ -33,6 +33,7 @@ describe("token introspection policy", function()
     it('success with valid token', function()
       local introspection_url = "http://example/token/introspection"
       local policy_config = {
+        auth_type = "client_id+client_secret",
         introspection_url = introspection_url,
         client_id = test_client_id,
         client_secret = test_client_secret
@@ -61,6 +62,7 @@ describe("token introspection policy", function()
     it('failed with invalid token', function()
       local introspection_url = "http://example/token/introspection"
       local policy_config = {
+        auth_type = "client_id+client_secret",
         introspection_url = introspection_url,
         client_id = "client",
         client_secret = "secret"
@@ -93,6 +95,7 @@ describe("token introspection policy", function()
     it('failed with bad status code', function()
       local introspection_url = "http://example/token/introspection"
       local policy_config = {
+        auth_type = "client_id+client_secret",
         introspection_url = introspection_url,
         client_id = "client",
         client_secret = "secret"
@@ -122,6 +125,7 @@ describe("token introspection policy", function()
     it('failed with null response', function()
       local introspection_url = "http://example/token/introspection"
       local policy_config = {
+        auth_type = "client_id+client_secret",
         introspection_url = introspection_url,
         client_id = "client",
         client_secret = "secret"
@@ -152,6 +156,7 @@ describe("token introspection policy", function()
     it('failed with bad contents type', function()
       local introspection_url = "http://example/token/introspection"
       local policy_config = {
+        auth_type = "client_id+client_secret",
         introspection_url = introspection_url,
         client_id = "client",
         client_secret = "secret"
@@ -182,6 +187,7 @@ describe("token introspection policy", function()
     describe('when caching is enabled', function()
       local introspection_url = "http://example/token/introspection"
       local policy_config = {
+        auth_type = "client_id+client_secret",
         introspection_url = introspection_url,
         client_id = test_client_id,
         client_secret = test_client_secret,
@@ -241,4 +247,3 @@ describe("token introspection policy", function()
     end)
   end)
 end)
-


### PR DESCRIPTION
Since it is troublesome to define the `client_id` and `client_secret` twice in the `AUTHENTICATION SETTINGS` and in the `POLICIES` of the Admin Portal, this PR adds "use_oidc_issuer_endpoint" property to get client information from `oidc_issuer_endpoint`.