### PR TITLE
[spec] fix leaking url rewriting spec

### DIFF
--- a/spec/policy/url_rewriting/url_rewriting_spec.lua
+++ b/spec/policy/url_rewriting/url_rewriting_spec.lua
@@ -5,14 +5,19 @@ local URLRewriting = require('apicast.policy.url_rewriting')
 -- not want to check its internals.
 local QueryParams = require('apicast.policy.url_rewriting.query_params')
 local noop = function() end
-local mocked_query_params = { push = noop, set = noop, add = noop, delete = noop }
-QueryParams.new = function() return mocked_query_params end
-local spy_mocked_query_params_push
-local spy_mocked_query_params_set
-local spy_mocked_query_params_add
-local spy_mocked_query_params_delete
 
 describe('URL rewriting policy', function()
+
+  local mocked_query_params = { push = noop, set = noop, add = noop, delete = noop }
+  local spy_mocked_query_params_push
+  local spy_mocked_query_params_set
+  local spy_mocked_query_params_add
+  local spy_mocked_query_params_delete
+
+  before_each(function ()
+    stub(QueryParams, 'new', function() return mocked_query_params end)
+  end)
+
   describe('.rewrite', function()
     before_each(function()
       ngx.var = { uri = '/some_path/to_be_replaced/123/to_be_replaced' }


### PR DESCRIPTION
use stubs that are reset after the test


so the tests can be executed with `--no-auto-insulate`.