### PR TITLE
[rate-limit] fix failure when shdict is missing

### DIFF
--- a/gateway/src/resty/limit/count-inc.lua
+++ b/gateway/src/resty/limit/count-inc.lua
@@ -11,7 +11,13 @@ local mt = {
 }
 
 function _M.new(...)
-    return setmetatable(resty_limit_count.new(...), mt)
+    local lim, err = resty_limit_count.new(...)
+
+    if lim then
+        return setmetatable(lim, mt)
+    else
+        return nil, err
+    end
 end
 
 function _M.incoming(self, key, commit)

--- a/spec/policy/rate_limit/rate_limit_spec.lua
+++ b/spec/policy/rate_limit/rate_limit_spec.lua
@@ -59,8 +59,30 @@ describe('Rate limit policy', function()
   end)
 
   describe('.access', function()
+    describe('missing shdict', function ()
+      before_each(function()
+        ngx.shared.limiter = nil
+      end)
+
+      it('does not crash', function()
+        local rate_limit_policy = RateLimitPolicy.new({
+          connection_limiters = {
+            { key = { name = 'test1', scope = 'global' }, conn = 0, burst = 0, delay = 0 }
+          },
+          leaky_bucket_limiters = {
+            { key = { name = 'test2', scope = 'global' }, rate = 0, burst = 0 }
+          },
+          fixed_window_limiters = {
+            { key = { name = 'test3', scope = 'global' }, count = 0, window = 0 }
+          },
+        })
+
+        assert(rate_limit_policy:access(context))
+      end)
+    end)
+
     describe('using #shmem', function()
-      setup(function()
+      before_each(function()
         ngx.shared.limiter = shdict()
       end)
 


### PR DESCRIPTION
* count-int wasn't counting with failures

Fixing rather cryptic:
```
...ast/gateway/src/apicast/policy/rate_limit/rate_limit.lua:88: bad argument #1 to '?' (table expected, got nil)

stack traceback:
	...ast/gateway/src/apicast/policy/rate_limit/rate_limit.lua:88: in function 'build_limiters_and_keys'
```