### PR TITLE
[busted] reload apicast.loader to prevent caching policies between tests

### DIFF
--- a/spec/spec_helper.lua
+++ b/spec/spec_helper.lua
@@ -7,7 +7,7 @@ require 'ngx_helper'
 require 'luassert_helper'
 require 'jwt_helper'
 
-require('apicast.loader')
+require('resty.limit.req') -- because it uses ffi.cdef and can't be reloaded
 
 local busted = require('busted')
 local env = require('resty.env')
@@ -46,3 +46,11 @@ end
 
 busted.before_each(reset)
 busted.after_each(reset)
+
+busted.subscribe({ 'file', 'start' }, function ()
+  require('apicast.loader')
+end)
+
+busted.subscribe({ 'file', 'end' }, function ()
+  collectgarbage()
+end)


### PR DESCRIPTION
Busted uses automatic insulation and clears `_G` and `package.loaded` between test files.
However, `apicast.loader` added itself to `package.searchers` and stayed active including its own upvalues.
So all policies loaded using `apicast.loader` used different packages than everyone else.

The solution is to make `apicast.loader` to clean up after itself when it is garbage collected.