### PR TITLE
init and init_worker phases called on all policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use forked `resty.limit.count` that uses increments instead of decrements [PR #758](https://github.com/3scale/apicast/pull/758)
 - Rate Limit policy to take into account changes in the config [PR #703](https://github.com/3scale/apicast/pull/703)
 - The regular expression for mapping rules has been changed, so that special characters are accepted in the wildcard values for path [PR #717](https://github.com/3scale/apicast/pull/714)
+- Call `init` and `init_worker` on all available policies regardless they are used or not [PR #770](https://github.com/3scale/apicast/pull/770)
+- Cache loaded policies. Loading one policy several times will use the same instance [PR #770](https://github.com/3scale/apicast/pull/770)
+- Load all policies into cache when starting APIcast master process. [PR #770](https://github.com/3scale/apicast/pull/770)
+- `init` and `init_worker` phases are executed on the policy module, not the instance of a policy with a configuration [PR #770](https://github.com/3scale/apicast/pull/770)
 
 ### Fixed
 

--- a/examples/custom-module/blacklist.lua
+++ b/examples/custom-module/blacklist.lua
@@ -35,7 +35,7 @@ end
 
 function _M.init()
   iputils.enable_lrucache()
-  apicast:init()
+  apicast.init()
 end
 
 local balancer_with_blacklist = resty_balancer.new(function(peers)

--- a/gateway/src/apicast/executor.lua
+++ b/gateway/src/apicast/executor.lua
@@ -7,7 +7,7 @@
 require('apicast.loader') -- to load code from deprecated paths
 
 local PolicyChain = require('apicast.policy_chain')
-local policy = require('apicast.policy')
+local Policy = require('apicast.policy')
 local linked_list = require('apicast.linked_list')
 local prometheus = require('apicast.prometheus')
 
@@ -20,7 +20,7 @@ local _M = { }
 local mt = { __index = _M }
 
 -- forward all policy methods to the policy chain
-for _,phase in policy.phases() do
+for _,phase in Policy.phases() do
     _M[phase] = function(self, ...)
         ngx.log(ngx.DEBUG, 'executor phase: ', phase)
         return self.policy_chain[phase](self.policy_chain, self:context(phase), ...)

--- a/gateway/src/apicast/executor.lua
+++ b/gateway/src/apicast/executor.lua
@@ -98,6 +98,10 @@ do
             end
         end
     end
+
+    function _M.reset_available_policies()
+        policies = policy_loader:get_all()
+    end
 end
 
 local metrics = _M.metrics

--- a/gateway/src/apicast/policy/load_configuration/load_configuration.lua
+++ b/gateway/src/apicast/policy/load_configuration/load_configuration.lua
@@ -6,9 +6,11 @@ local configuration_store = require('apicast.configuration_store')
 
 local new = _M.new
 
+_M.configuration = configuration_store.new()
+
 function _M.new(...)
     local policy = new(...)
-    policy.configuration = configuration_store.new()
+    policy.configuration = _M.configuration
     return policy
 end
 
@@ -18,12 +20,12 @@ function _M:export()
     }
 end
 
-function _M:init()
-    configuration_loader.init(self.configuration)
+function _M.init()
+    configuration_loader.init(_M.configuration)
 end
 
-function _M:init_worker()
-    configuration_loader.init_worker(self.configuration)
+function _M.init_worker()
+    configuration_loader.init_worker(_M.configuration)
 end
 
 function _M:rewrite(context)

--- a/gateway/src/apicast/policy_chain.lua
+++ b/gateway/src/apicast/policy_chain.lua
@@ -9,6 +9,7 @@ local setmetatable = setmetatable
 local error = error
 local rawset = rawset
 local type = type
+local ipairs = ipairs
 local require = require
 local insert = table.insert
 local sub = string.sub
@@ -153,6 +154,8 @@ local function call_chain(phase_name)
             ngx.log(ngx.DEBUG, 'policy chain execute phase: ', phase_name, ', policy: ', self[i]._NAME, ', i: ', i)
             self[i][phase_name](self[i], ...)
         end
+
+        return ipairs(self)
     end
 end
 

--- a/gateway/src/apicast/policy_loader.lua
+++ b/gateway/src/apicast/policy_loader.lua
@@ -10,6 +10,7 @@ local cjson = require('cjson')
 
 local format = string.format
 local ipairs = ipairs
+local pairs = pairs
 local insert = table.insert
 local setmetatable = setmetatable
 local pcall = pcall
@@ -165,5 +166,23 @@ function _M:pcall(name, version, dir)
     return nil, ret
   end
 end
+
+-- Returns all the policy modules
+function _M:get_all()
+  local policy_modules = {}
+
+  local policy_manifests_loader = require('apicast.policy_manifests_loader')
+  local manifests = policy_manifests_loader.get_all()
+
+  for policy_name, policy_manifests in pairs(manifests) do
+    for _, manifest in ipairs(policy_manifests) do
+      local policy = self:call(policy_name, manifest.version)
+      insert(policy_modules, policy)
+    end
+  end
+
+  return policy_modules
+end
+
 
 return setmetatable(_M, { __call = _M.call })

--- a/gateway/src/apicast/policy_loader.lua
+++ b/gateway/src/apicast/policy_loader.lua
@@ -12,6 +12,7 @@ local format = string.format
 local ipairs = ipairs
 local pairs = pairs
 local insert = table.insert
+local concat = table.concat
 local setmetatable = setmetatable
 local pcall = pcall
 
@@ -140,7 +141,9 @@ function _M:call(name, version, dir)
   local v = version or 'builtin'
   local load_path, policy_config_schema, invalid_paths = self:load_path(name, v, dir)
 
-  local cache = package_cache[table.concat({name, v, dir}, '-')]
+  local cache_key = concat({name, v, dir and concat(dir, ',') or '' }, '-')
+
+  local cache = package_cache[cache_key]
   local loader = sandbox.new(load_path and { load_path } or invalid_paths,
           cache)
 

--- a/gateway/src/apicast/policy_loader.lua
+++ b/gateway/src/apicast/policy_loader.lua
@@ -131,11 +131,17 @@ function _M:load_path(name, version, paths)
   return nil, nil, failures
 end
 
+local package_cache = setmetatable({}, {
+  __index = function(t, k) local n = { }; t[k] = n; return n end
+})
+
 function _M:call(name, version, dir)
   local v = version or 'builtin'
   local load_path, policy_config_schema, invalid_paths = self:load_path(name, v, dir)
 
-  local loader = sandbox.new(load_path and { load_path } or invalid_paths)
+  local cache = package_cache[table.concat({name, v, dir}, '-')]
+  local loader = sandbox.new(load_path and { load_path } or invalid_paths,
+          cache)
 
   ngx.log(ngx.DEBUG, 'loading policy: ', name, ' version: ', v)
 

--- a/gateway/src/resty/sandbox.lua
+++ b/gateway/src/resty/sandbox.lua
@@ -87,7 +87,7 @@ local function gen_require(package)
     -- to determine whether modname is already loaded.
     -- NOTE: this is different from the spec: use the top level package.loaded,
     --       otherwise it would try to sandbox load already loaded shared code
-    local mod = root_loaded[modname]
+    local mod = root_loaded[modname] or package.loaded[modname]
 
     --  If it is, then require returns the value stored at package.loaded[modname].
     if mod then return mod end
@@ -211,10 +211,10 @@ local mt = {
 
 local empty_t = {}
 
-function _M.new(load_paths)
+function _M.new(load_paths, cache)
   -- need to create global variable package that mimics the native one
   local package = {
-    loaded = {},
+    loaded = cache or {},
     preload = preload,
     searchers = {}, -- http://www.lua.org/manual/5.2/manual.html#pdf-package.searchers
     searchpath = searchpath,

--- a/spec/executor_spec.lua
+++ b/spec/executor_spec.lua
@@ -56,6 +56,38 @@ describe('executor', function()
     end)
   end)
 
+  describe('when there are policies that are not in the chain', function()
+    local policy_not_in_chain = {
+      init = function() return '1' end,
+      init_worker = function() return '2' end
+    }
+
+    before_each(function()
+      stub(policy_not_in_chain, 'init')
+      stub(policy_not_in_chain, 'init_worker')
+
+      local policy_loader = require('apicast.policy_loader')
+      stub(policy_loader, 'get_all').returns({ policy_not_in_chain })
+
+      Executor.reset_available_policies()
+    end)
+
+    it('init() calls their init method', function()
+      local executor = Executor.new(PolicyChain.default())
+
+      executor:init()
+
+      assert.stub(policy_not_in_chain.init).was_called(1)
+    end)
+
+    it('init_worker() calls their init_worker method', function()
+      local executor = Executor.new(PolicyChain.default())
+
+      executor:init_worker()
+
+      assert.stub(policy_not_in_chain.init_worker).was_called(1)
+    end)
+  end)
 
   it('is initialized with default chain', function()
     local default = PolicyChain.default()

--- a/spec/policy_loader_spec.lua
+++ b/spec/policy_loader_spec.lua
@@ -38,7 +38,7 @@ describe('APIcast Policy Loader', function()
       assert.are_not.same(test, test2)
 
       assert.are.same(test.dependency, test2.dependency)
-      assert.are_not.equal(test.dependency, test2.dependency)
+      assert.are.equal(test.dependency, test2.dependency)
     end)
 
     it('loads two versions of the same policy', function()

--- a/t/apicast-policy-chains.t
+++ b/t/apicast-policy-chains.t
@@ -9,7 +9,8 @@ __DATA__
 This test uses the phase logger policy to verify that all of its phases are run
 when we use a policy chain that contains it. The policy chain also contains the
 normal apicast policy, so we can check that the authorize flow continues working.
-Phases init and init_worker are not executed for policies defined at the service level.
+Phases init and init_worker do not appear in the test because they're run just
+once, not on every request.
 
 --- http_config
   include $TEST_NGINX_UPSTREAM_CONFIG;


### PR DESCRIPTION
During master process boot all available policies are loaded 
and get their `init` and `init_worker` phases executed.

Increases initial memory use by about 800 kB (which is later shared between workers).