### PR TITLE
[proxy] refactor post_post action

### DIFF
--- a/gateway/src/apicast/policy/apicast/apicast.lua
+++ b/gateway/src/apicast/policy/apicast/apicast.lua
@@ -62,7 +62,7 @@ function _M:post_action(context)
   local p = context and context.proxy or ngx.ctx.proxy or self.proxy
 
   if p then
-    return p:post_action()
+    return p:post_action(context)
   else
     ngx.log(ngx.ERR, 'could not find proxy for request')
     return nil, 'no proxy for request'


### PR DESCRIPTION
Extracted from https://github.com/3scale/apicast/pull/774

Refactors `proxy:post_action` to ease changes in #774. Proxy post_action should receive a context and be called from just one point - the policy.


