### PR TITLE
Make referrer policy compatible with async reporting threads option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - 3scale batcher policy [PR #685](https://github.com/3scale/apicast/pull/685), [PR #710](https://github.com/3scale/apicast/pull/710), [PR #757](https://github.com/3scale/apicast/pull/757)
 - Liquid templating support in the headers policy configuration [PR #716](https://github.com/3scale/apicast/pull/716)
 - Ability to modify query parameters in the URL rewriting policy [PR #724](https://github.com/3scale/apicast/pull/724)
-- 3scale referrer policy [PR #728](https://github.com/3scale/apicast/pull/728)
+- 3scale referrer policy [PR #728](https://github.com/3scale/apicast/pull/728), [PR #777](https://github.com/3scale/apicast/pull/777)
 - Liquid templating support in the rate-limit policy [PR #719](https://github.com/3scale/apicast/pull/719)
 - Default credentials policy [PR #741](https://github.com/3scale/apicast/pull/741), [THREESCALE-586](https://issues.jboss.org/browse/THREESCALE-586)
 - Configurable caching for the token introspection policy [PR #656](https://github.com/3scale/apicast/pull/656)

--- a/gateway/src/apicast/proxy.lua
+++ b/gateway/src/apicast/proxy.lua
@@ -340,7 +340,18 @@ local function async_post_action(self, cached_key, service, credentials, formatt
     -- TODO: try to do this in different phase and use semaphore to limit number of background threads
     -- TODO: Also it is possible to use sets in shared memory to enqueue work
 
-    ngx.timer.at(0, handle_timer_post_action, self, timers, cached_key, backend, formatted_usage, credentials, response_codes_data())
+    ngx.timer.at(
+      0,
+      handle_timer_post_action,
+      self,
+      timers,
+      cached_key,
+      backend,
+      formatted_usage,
+      credentials,
+      response_codes_data(),
+      self.extra_params_backend_authrep
+    )
   else
     ngx.log(ngx.ERR, 'failed to acquire timer: ', err)
     return sync_post_action(self, cached_key, service)

--- a/t/apicast-policy-3scale-referrer.t
+++ b/t/apicast-policy-3scale-referrer.t
@@ -165,3 +165,61 @@ yay, api backend
 --- error_code: 200
 --- no_error_log
 [error]
+
+=== TEST 4: Referrer sent in authrep call when using reporting threads
+Checks that the referrer policy works well when the out-of-band reporting to
+the 3scale backend is enabled (APICAST_REPORTING_THREADS > 0)
+--- env eval
+("APICAST_REPORTING_THREADS", "2")
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" },
+          {
+            "name": "apicast.policy.3scale_referrer",
+            "configuration": {}
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      -- Notice that we're checking that the referrer receive is the one sent
+      -- in the 'Referer' header of the query.
+      -- We also check that the rest of the params are correct.
+      require('luassert').equals('3scale.net', ngx.req.get_uri_args()['referrer'])
+      require('luassert').equals('token-value', ngx.req.get_uri_args()['service_token'])
+      require('luassert').equals('42', ngx.req.get_uri_args()['service_id'])
+      require('luassert').equals('uk', ngx.req.get_uri_args()['user_key'])
+      require('luassert').equals('2', ngx.req.get_uri_args()['usage[hits]'])
+    }
+  }
+--- request
+GET /?user_key=uk
+--- more_headers
+Referer: 3scale.net
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]


### PR DESCRIPTION
The referrer policy does not work correctly when the async reporting threads option is enabled (`APICAST_REPORTING_THREADS > 0`)