### PR TITLE
Add option to run immediately or wait 'interval' second in TimerTask.execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - ENV variables to make APIcast listen on HTTPS port [PR #622](https://github.com/3scale/apicast/pull/622) 
 - New `ssl_certificate` phase allows policies to provide certificate to terminate HTTPS connection [PR #622](https://github.com/3scale/apicast/pull/622).
 - Configurable `auth_type` for the token introspection policy [PR #755](https://github.com/3scale/apicast/pull/755)
-- `TimerTask` module to execute recurrent tasks that can be cancelled [PR #782](https://github.com/3scale/apicast/pull/782)
+- `TimerTask` module to execute recurrent tasks that can be cancelled [PR #782](https://github.com/3scale/apicast/pull/782), [#784](https://github.com/3scale/apicast/pull/784)
 
 ### Changed
 

--- a/gateway/src/resty/concurrent/timer_task.lua
+++ b/gateway/src/resty/concurrent/timer_task.lua
@@ -60,10 +60,12 @@ end
 
 local run_periodic, schedule_next, timer_execute
 
-run_periodic = function(self)
+run_periodic = function(self, run_now)
   if not _M.task_is_active(self.id) then return end
 
-  self.task(unpack(self.args))
+  if run_now then
+    self.task(unpack(self.args))
+  end
 
   schedule_next(self)
 end
@@ -72,7 +74,7 @@ end
 -- "premature" is boolean value indicating whether it is a premature timer
 -- expiration.
 timer_execute = function(_, self)
-  run_periodic(self)
+  run_periodic(self, true)
 end
 
 schedule_next = function(self)
@@ -83,8 +85,11 @@ schedule_next = function(self)
   end
 end
 
-function _M:execute()
-  run_periodic(self)
+--- Execute a task
+-- @tparam[opt] run_now boolean True to run the task immediately or False to
+--   wait 'interval' seconds. (Defaults to false)
+function _M:execute(run_now)
+  run_periodic(self, run_now or false)
 end
 
 function _M:cancel()

--- a/spec/resty/concurrent/timer_task_spec.lua
+++ b/spec/resty/concurrent/timer_task_spec.lua
@@ -87,7 +87,7 @@ describe('TimerTask', function()
         local timer_task = TimerTask.new(func, { args = args, interval = interval })
         local func_stub = stub(timer_task, 'task')
 
-        timer_task:execute()
+        timer_task:execute(true)
 
         assert.stub(func_stub).was_called_with(unpack(args))
       end)
@@ -95,7 +95,7 @@ describe('TimerTask', function()
       it('schedules the next one', function()
         local timer_task = TimerTask.new(func, { args = args, interval = interval })
 
-        timer_task:execute()
+        timer_task:execute(true)
 
         assert.stub(ngx_timer_stub).was_called()
       end)
@@ -107,7 +107,7 @@ describe('TimerTask', function()
         local func_stub = stub(timer_task, 'task')
         timer_task:cancel()
 
-        timer_task:execute()
+        timer_task:execute(true)
 
         assert.stub(func_stub).was_not_called()
       end)
@@ -116,9 +116,29 @@ describe('TimerTask', function()
         local timer_task = TimerTask.new(func, { args = args, interval = interval })
         timer_task:cancel()
 
-        timer_task:execute()
+        timer_task:execute(true)
 
         assert.stub(ngx_timer_stub).was_not_called()
+      end)
+    end)
+
+    describe('when the option to wait an interval instead of running now is passed', function()
+      it('does not run the task inmediately', function()
+        local timer_task = TimerTask.new(func, { args = args, interval = interval })
+        local func_stub = stub(timer_task, 'task')
+
+        timer_task:execute(false)
+
+        -- It will be called in 'interval' seconds, but not now
+        assert.stub(func_stub).was_not_called()
+      end)
+
+      it('schedules the next one', function()
+        local timer_task = TimerTask.new(func, { args = args, interval = interval })
+
+        timer_task:execute(false)
+
+        assert.stub(ngx_timer_stub).was_called()
       end)
     end)
   end)


### PR DESCRIPTION
This PR adds an option to run immediately or wait 'interval' seconds in TimerTask.execute.

When scheduling a recurrent job, we might want to delay the first execution 'interval' seconds instead of running it immediately.

This is going to be used in the batching policy when scheduling reports to backend. In that case, we don't need to report immediately, because when scheduling the task, the set of pending reports will be empty.