### PR TITLE
Use TimerTask in the 3scale batcher policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - OpenTracing support [PR #669](https://github.com/3scale/apicast/pull/669)
 - Generate new policy scaffold from the CLI [PR #682](https://github.com/3scale/apicast/pull/682)
-- 3scale batcher policy [PR #685](https://github.com/3scale/apicast/pull/685), [PR #710](https://github.com/3scale/apicast/pull/710), [PR #757](https://github.com/3scale/apicast/pull/757)
+- 3scale batcher policy [PR #685](https://github.com/3scale/apicast/pull/685), [PR #710](https://github.com/3scale/apicast/pull/710), [PR #757](https://github.com/3scale/apicast/pull/757), [PR #786](https://github.com/3scale/apicast/pull/786)
 - Liquid templating support in the headers policy configuration [PR #716](https://github.com/3scale/apicast/pull/716)
 - Ability to modify query parameters in the URL rewriting policy [PR #724](https://github.com/3scale/apicast/pull/724)
 - 3scale referrer policy [PR #728](https://github.com/3scale/apicast/pull/728), [PR #777](https://github.com/3scale/apicast/pull/777)

--- a/gateway/src/apicast/policy/3scale_batcher/reporter.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/reporter.lua
@@ -1,5 +1,6 @@
 local ReportsBatch = require('apicast.policy.3scale_batcher.reports_batch')
 local Usage = require('apicast.usage')
+local Transaction = require('apicast.policy.3scale_batcher.transaction')
 
 local pairs = pairs
 
@@ -14,11 +15,13 @@ local function return_reports(service_id, batch, reports_batcher)
       usage:add(metric, value)
     end
 
-    reports_batcher:add(
+    local transaction = Transaction.new(
       service_id,
       { [credentials_type] = credential },
       usage
     )
+
+    reports_batcher:add(transaction)
   end
 end
 

--- a/gateway/src/resty/concurrent/timer_task.lua
+++ b/gateway/src/resty/concurrent/timer_task.lua
@@ -64,7 +64,7 @@ run_periodic = function(run_now, id, func, args, interval)
     func(unpack(args))
   end
 
-  schedule_next(interval, id, func, args, interval)
+  schedule_next(id, func, args, interval)
 end
 
 -- Note: ngx.timer.at always sends "premature" as the first param.

--- a/spec/resty/concurrent/timer_task_spec.lua
+++ b/spec/resty/concurrent/timer_task_spec.lua
@@ -114,6 +114,12 @@ describe('TimerTask', function()
         timer_task:execute(true)
 
         assert.stub(ngx_timer_stub).was_called()
+
+        -- Can't check all the arguments of ngx.timer.at because it calls an
+        -- private function but at least we can check the interval (first arg),
+        -- and that the second argument is a function.
+        assert.equals(interval, ngx_timer_stub.calls[1].vals[1])
+        assert.is_function(ngx_timer_stub.calls[1].vals[2])
       end)
     end)
 

--- a/spec/resty/concurrent/timer_task_spec.lua
+++ b/spec/resty/concurrent/timer_task_spec.lua
@@ -6,6 +6,7 @@ describe('TimerTask', function()
 
   before_each(function()
     TimerTask.active_tasks = {}
+    TimerTask.last_one = {}
   end)
 
   after_each(function()
@@ -85,6 +86,14 @@ describe('TimerTask', function()
 
       assert.is_false(TimerTask.task_is_active(task.id))
     end)
+
+    it('marks the task to run for the last time when specified in the params', function()
+      local task = TimerTask.new(test_task)
+
+      task:cancel(true)
+
+      assert.is_true(TimerTask.last_one[task.id])
+    end)
   end)
 
   describe(':execute', function()
@@ -163,6 +172,27 @@ describe('TimerTask', function()
         assert.stub(ngx_timer_stub).was_called()
       end)
     end)
+
+    describe('when the task should run for the last time', function()
+      it('runs the task', function()
+        local timer_task = TimerTask.new(func, { args = args, interval = interval })
+        local func_spy = spy.on(timer_task, 'task')
+        timer_task:cancel(true)
+
+        timer_task:execute(true)
+
+        assert.spy(func_spy).was_called_with(unpack(args))
+      end)
+
+      it('does not schedule another task', function()
+        local timer_task = TimerTask.new(func, { args = args, interval = interval })
+        timer_task:cancel(true)
+
+        timer_task:execute(true)
+
+        assert.stub(ngx_timer_stub).was_not_called()
+      end)
+    end)
   end)
 
   it('cancels itself when it is garbage collected', function()
@@ -173,5 +203,15 @@ describe('TimerTask', function()
     collectgarbage()
 
     assert.is_false(TimerTask.task_is_active(id))
+  end)
+
+  it('does not ensure a last run when garbage collected', function()
+    local timer_task = TimerTask.new(test_task)
+    local id = timer_task.id
+
+    timer_task = nil
+    collectgarbage()
+
+    assert.is_falsy(TimerTask.last_one[id])
   end)
 end)


### PR DESCRIPTION
This PR replaces the usages of `ngx.timer.every` with `TimerTask` instances.

This solves the issue of not being able to cancel timers. Recurrent tasks created using `TimerTask` can be canceled, but we cannot cancel timers created with `ngx.timer.every`. This was causing a bug, Timer would continue running even after a config reload.