### PR TITLE
[example] update add-ssl example

### DIFF
--- a/examples/add-ssl/apicast.d/ssl.conf
+++ b/examples/add-ssl/apicast.d/ssl.conf
@@ -1,3 +1,0 @@
-listen 8443 ssl;
-ssl_certificate /opt/app-root/src/conf/cert/server.crt;
-ssl_certificate_key /opt/app-root/src/conf/cert/server.key;


### PR DESCRIPTION
Use builtin HTTPS functionality instead of a customization.

/cc @3scale/documentation 