### PR TITLE
TimerTask improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - ENV variables to make APIcast listen on HTTPS port [PR #622](https://github.com/3scale/apicast/pull/622) 
 - New `ssl_certificate` phase allows policies to provide certificate to terminate HTTPS connection [PR #622](https://github.com/3scale/apicast/pull/622).
 - Configurable `auth_type` for the token introspection policy [PR #755](https://github.com/3scale/apicast/pull/755)
-- `TimerTask` module to execute recurrent tasks that can be cancelled [PR #782](https://github.com/3scale/apicast/pull/782), [#784](https://github.com/3scale/apicast/pull/784)
+- `TimerTask` module to execute recurrent tasks that can be cancelled [PR #782](https://github.com/3scale/apicast/pull/782), [PR #784](https://github.com/3scale/apicast/pull/784), [PR #791](https://github.com/3scale/apicast/pull/791)
 - `GC` module that implements a workaround to be able to define `__gc` on tables [PR #790](https://github.com/3scale/apicast/pull/790)
 
 ### Changed

--- a/spec/resty/concurrent/timer_task_spec.lua
+++ b/spec/resty/concurrent/timer_task_spec.lua
@@ -85,11 +85,11 @@ describe('TimerTask', function()
     describe('when the task is active', function()
       it('runs the task', function()
         local timer_task = TimerTask.new(func, { args = args, interval = interval })
-        local func_stub = stub(timer_task, 'task')
+        local func_spy = spy.on(timer_task, 'task')
 
         timer_task:execute(true)
 
-        assert.stub(func_stub).was_called_with(unpack(args))
+        assert.spy(func_spy).was_called_with(unpack(args))
       end)
 
       it('schedules the next one', function()
@@ -104,12 +104,12 @@ describe('TimerTask', function()
     describe('when the task is not active', function()
       it('does not run the task', function()
         local timer_task = TimerTask.new(func, { args = args, interval = interval })
-        local func_stub = stub(timer_task, 'task')
+        local func_spy = spy.on(timer_task, 'task')
         timer_task:cancel()
 
         timer_task:execute(true)
 
-        assert.stub(func_stub).was_not_called()
+        assert.spy(func_spy).was_not_called()
       end)
 
       it('does not schedule another task', function()
@@ -125,12 +125,12 @@ describe('TimerTask', function()
     describe('when the option to wait an interval instead of running now is passed', function()
       it('does not run the task inmediately', function()
         local timer_task = TimerTask.new(func, { args = args, interval = interval })
-        local func_stub = stub(timer_task, 'task')
+        local func_spy = spy.on(timer_task, 'task')
 
         timer_task:execute(false)
 
         -- It will be called in 'interval' seconds, but not now
-        assert.stub(func_stub).was_not_called()
+        assert.spy(func_spy).was_not_called()
       end)
 
       it('schedules the next one', function()


### PR DESCRIPTION
This PR implements several improvements in the `TimerTask` module:

1) Adapts the module to use the new `GC` module introduced in the previous PR #790
2) Fixes a bug that prevents the task from being garbage collected. This is done by avoiding passing `self`.
3) Fixes a bug when calculating the delay when scheduling the next task.