### PR TITLE
[codeclimate] luacheck was released to the stable channel

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,7 +2,6 @@
 engines:
   luacheck:
     enabled: true
-    channel: beta
     checks:
       LC631:
         enabled: false


### PR DESCRIPTION
Latest release is now in stable channel.

Luacheck finds 56 new failures. We can fix them over time.