### PR TITLE
[busted] fix leaking tests

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -23,6 +23,7 @@ if(defined $ENV{JUNIT_OUTPUT_FILE}) {
 exec '/usr/bin/env', 'resty',
     '--errlog-level', $ENV{APICAST_LOG_LEVEL} || 'alert',
     '--http-include', "$apicast/spec/fixtures/echo.conf",
+    '-l', 'resty.core',
     "$apicast/bin/busted.lua",
     '--config-file', "$apicast/.busted",
     '--directory', "$cwd",

--- a/spec/configuration_store_spec.lua
+++ b/spec/configuration_store_spec.lua
@@ -20,18 +20,8 @@ describe('Configuration Store', function()
     end)
 
     describe('when path routing is enabled', function()
-      local path_routing_enabled = configuration.path_routing
-
-      setup(function() -- Wouldn't be needed if we injected path_routing_enabled
-        configuration.path_routing = true;
-      end)
-
-      teardown(function()
-        configuration.path_routing = path_routing_enabled
-      end)
-
       it('defines several services for the same host', function()
-        local store = configuration.new()
+        local store = configuration.new(configuration.cache_size, { path_routing = true })
         local service1 = { id = '21', hosts = { 'example.com' } }
         local service2 = { id = '22', hosts = { 'example.com' } }
 
@@ -43,7 +33,7 @@ describe('Configuration Store', function()
 
     describe('when path routing is disabled', function()
       it('ignores defining a host for a service if already defined for another', function()
-        local store = configuration.new()
+        local store = configuration.new(configuration.cache_size, { path_routing = false })
         local service1 = { id = '21', hosts = { 'example.com' } }
         local service2 = { id = '22', hosts = { 'example.com' } }
 

--- a/spec/ngx_helper.lua
+++ b/spec/ngx_helper.lua
@@ -12,7 +12,6 @@ local copy = tablex.copy
 
 local pairs = pairs
 
-local ngx_shared = ngx.shared
 local ngx_original = copy(ngx)
 local ngx_var_original = deepcopy(ngx.var)
 local ngx_ctx_original = deepcopy(ngx.ctx)

--- a/spec/ngx_helper.lua
+++ b/spec/ngx_helper.lua
@@ -1,9 +1,19 @@
+-- not really required, but makes it obvious it is loaded
+-- so we can copy ngx object and compare it later to check modifications
+require('resty.core')
+
 local busted = require('busted')
 local misc = require('resty.core.misc')
-local deepcopy = require('pl.tablex').deepcopy
+local tablex = require('pl.tablex')
+local inspect = require('inspect')
+local spy = require('luassert.spy')
+local deepcopy = tablex.deepcopy
+local copy = tablex.copy
 
 local pairs = pairs
 
+local ngx_shared = ngx.shared
+local ngx_original = copy(ngx)
 local ngx_var_original = deepcopy(ngx.var)
 local ngx_ctx_original = deepcopy(ngx.ctx)
 local ngx_shared_original = deepcopy(ngx.shared)
@@ -42,10 +52,17 @@ local function reset_ngx_shared(state)
   end
 end
 
+--- ngx keys that are going to be reset in between tests.
+local ngx_reset = {
+  var = ngx_var_original,
+  ctx = ngx_ctx_original,
+  header = ngx_header_original,
+}
+
 local function reset_ngx_state()
-  ngx.var = deepcopy(ngx_var_original)
-  ngx.ctx = deepcopy(ngx_ctx_original)
-  ngx.header = deepcopy(ngx_header_original)
+  for key, val in pairs(ngx_reset) do
+    ngx[key] = deepcopy(val)
+  end
 
   -- We can't replace the whole table, as some code like resty.limit.req takes reference to it when loading.
   reset_ngx_shared(ngx_shared_original)
@@ -76,6 +93,20 @@ local function setup()
 
   register_getter('headers_sent', function() return headers_sent end)
 end
+
+--- Verify ngx global variable against unintentional changes.
+--- Some specs could be for example setting `ngx.req = { }` and leak
+--- to other tests.
+busted.subscribe({ 'it', 'end' }, function ()
+  for key, value in pairs(ngx_original) do
+    if ngx[key] ~= value and not ngx_reset[key] and not spy.is_spy(ngx[key]) then
+      ngx[key] = value
+      busted.fail('ngx.' .. key .. ' changed from ' .. inspect(value) .. ' to ' .. inspect(ngx[key]))
+    end
+  end
+
+  return nil, true -- continue executing callbacks
+end)
 
 busted.after_each(cleanup)
 busted.teardown(cleanup)

--- a/spec/policy/3scale_batcher/3scale_batcher_spec.lua
+++ b/spec/policy/3scale_batcher/3scale_batcher_spec.lua
@@ -41,7 +41,7 @@ describe('3scale batcher policy', function()
     before_each(function()
       ngx.var = {}
       ngx.header = {}
-      ngx.print = function() end
+      stub(ngx, 'print')
 
       batcher_policy = ThreescaleBatcher.new({})
       batcher_policy.auths_cache = AuthsCache.new(lrucache.new(10), 10)

--- a/spec/policy/find_service/find_service_spec.lua
+++ b/spec/policy/find_service/find_service_spec.lua
@@ -10,10 +10,8 @@ describe('find_service', function()
         -- directly in the code, so we need to mock them. We should probably
         -- try to avoid this kind of coupling.
         ngx.var = { uri = '/def' }
-        ngx.req = {
-          get_uri_args = function() return {} end,
-          get_method = function() return 'GET' end
-        }
+        stub(ngx.req, 'get_uri_args', function() return {} end)
+        stub(ngx.req, 'get_method', function() return 'GET' end)
 
         local find_service_policy = require('apicast.policy.find_service').new()
         local host = 'example.com'
@@ -59,10 +57,9 @@ describe('find_service', function()
         it('finds a service for the host in the context and stores the service there', function()
           require('apicast.configuration_store').path_routing = true
           ngx.var = { uri = '/abc' }
-          ngx.req = {
-            get_uri_args = function() return {} end,
-            get_method = function() return 'GET' end
-          }
+
+          stub(ngx.req, 'get_uri_args', function() return {} end)
+          stub(ngx.req, 'get_method', function() return 'GET' end)
 
           local host = 'example.com'
           local find_service_policy = require('apicast.policy.find_service').new()
@@ -90,10 +87,8 @@ describe('find_service', function()
         it('stores nil in the service field of the given context', function()
           require('apicast.configuration_store').path_routing = true
           ngx.var = { uri = '/abc' }
-          ngx.req = {
-            get_uri_args = function() return {} end,
-            get_method = function() return 'GET' end
-          }
+          stub(ngx.req, 'get_uri_args', function() return {} end)
+          stub(ngx.req, 'get_method', function() return 'GET' end)
 
           local find_service_policy = require('apicast.policy.find_service').new()
           local configuration_store = require('apicast.configuration_store').new()

--- a/spec/policy/rate_limit/rate_limit_spec.lua
+++ b/spec/policy/rate_limit/rate_limit_spec.lua
@@ -28,19 +28,15 @@ local redis_url = 'redis://'..redis_host..':'..redis_port..'/1'
 local redis = ts.connect_redis{ url = redis_url }
 
 describe('Rate limit policy', function()
-  local ngx_exit
-  local ngx_sleep
   local context
-
-  setup(function()
-    ngx_exit = stub(ngx, 'exit')
-    ngx_sleep = stub(ngx, 'sleep')
-
-    stub(ngx, 'time', function() return 11111 end)
-  end)
 
   before_each(function()
     redis:flushdb()
+
+    stub(ngx, 'exit')
+    stub(ngx, 'sleep')
+
+    stub(ngx, 'time', function() return 11111 end)
   end)
 
   before_each(function()
@@ -141,7 +137,7 @@ describe('Rate limit policy', function()
 
         assert.returns_error('failed to connect to redis on invalidhost:6379', rate_limit_policy:access(context))
 
-        assert.spy(ngx_exit).was_called_with(500)
+        assert.spy(ngx.exit).was_called_with(500)
       end)
 
       describe('rejection', function()
@@ -156,7 +152,7 @@ describe('Rate limit policy', function()
           assert(rate_limit_policy:access(context))
           assert.returns_error('limits exceeded', rate_limit_policy:access(context))
 
-          assert.spy(ngx_exit).was_called_with(429)
+          assert.spy(ngx.exit).was_called_with(429)
         end)
 
         it('rejected (req)', function()
@@ -170,7 +166,7 @@ describe('Rate limit policy', function()
           assert(rate_limit_policy:access(context))
           assert.returns_error('limits exceeded', rate_limit_policy:access(context))
 
-          assert.spy(ngx_exit).was_called_with(429)
+          assert.spy(ngx.exit).was_called_with(429)
         end)
 
         it('rejected (count), name_type is plain', function()
@@ -185,7 +181,7 @@ describe('Rate limit policy', function()
           assert.returns_error('limits exceeded', rate_limit_policy:access(context))
 
           assert.equal('2', redis:get('11110_fixed_window_test3'))
-          assert.spy(ngx_exit).was_called_with(429)
+          assert.spy(ngx.exit).was_called_with(429)
         end)
 
         it('rejected (count), name_type is liquid', function()
@@ -202,7 +198,7 @@ describe('Rate limit policy', function()
           assert.returns_error('limits exceeded', rate_limit_policy:access(ctx))
 
           assert.equal('2', redis:get('11110_fixed_window_test3'))
-          assert.spy(ngx_exit).was_called_with(429)
+          assert.spy(ngx.exit).was_called_with(429)
         end)
 
         it('rejected (count), name_type is liquid, ngx variable', function()
@@ -217,7 +213,7 @@ describe('Rate limit policy', function()
           assert.returns_error('limits exceeded', rate_limit_policy:access(context))
 
           assert.equal('2', redis:get('11110_fixed_window_test3'))
-          assert.spy(ngx_exit).was_called_with(429)
+          assert.spy(ngx.exit).was_called_with(429)
         end)
       end)
 
@@ -233,7 +229,7 @@ describe('Rate limit policy', function()
           assert(rate_limit_policy:access(context))
           assert(rate_limit_policy:access(context))
 
-          assert.spy(ngx_sleep).was_called_with(match.is_gt(0.000))
+          assert.spy(ngx.sleep).was_called_with(match.is_gt(0.000))
         end)
 
         it('delay (req)', function()
@@ -247,7 +243,7 @@ describe('Rate limit policy', function()
           assert(rate_limit_policy:access(context))
           assert(rate_limit_policy:access(context))
 
-          assert.spy(ngx_sleep).was_called_with(match.is_gt(0.000))
+          assert.spy(ngx.sleep).was_called_with(match.is_gt(0.000))
         end)
 
         it('delay (req) service scope', function()
@@ -265,7 +261,7 @@ describe('Rate limit policy', function()
           assert(rate_limit_policy:access(context))
           assert(rate_limit_policy:access(context))
 
-          assert.spy(ngx_sleep).was_called_with(match.is_gt(0.001))
+          assert.spy(ngx.sleep).was_called_with(match.is_gt(0.001))
         end)
 
         it('delay (req) default service scope', function()
@@ -283,7 +279,7 @@ describe('Rate limit policy', function()
           assert(rate_limit_policy:access(context))
           assert(rate_limit_policy:access(context))
 
-          assert.spy(ngx_sleep).was_called_with(match.is_gt(0.001))
+          assert.spy(ngx.sleep).was_called_with(match.is_gt(0.001))
         end)
       end)
     end)

--- a/spec/proxy_spec.lua
+++ b/spec/proxy_spec.lua
@@ -26,7 +26,7 @@ describe('Proxy', function()
       ngx.header = {}
 
       ngx.var = { backend_endpoint = 'http://localhost:1853', uri = '/a/uri' }
-      ngx.req = { get_method = function () return 'GET' end}
+      stub(ngx.req, 'get_method', function () return 'GET' end)
       service = Service.new({ extract_usage = function() end })
     end)
 

--- a/spec/spec_helper.lua
+++ b/spec/spec_helper.lua
@@ -92,10 +92,12 @@ busted.after_each(reset)
 
 busted.subscribe({ 'file', 'start' }, function ()
   require('apicast.loader')
+  return nil, true -- needs to return true as second return value to continue executing the chain
 end)
 
 busted.subscribe({ 'file', 'end' }, function ()
   collectgarbage()
+  return nil, true
 end)
 
 do


### PR DESCRIPTION
Stubs and global env modifications would leak in between tests.

This PR introduces several protections against that and fixes running the tests in loop without automatic insulation from busted.

```shell
rover exec bin/busted  --repeat=100 --no-auto-insulate
rover exec bin/busted  --repeat=10 # less repetitions, because busted leaks memory
```