### PR TITLE
[resty.http_ng] use http/s proxy for backend and upstream connections 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Conditional policy. This policy includes a condition and a policy chain, and only executes the chain when the condition is true [PR #812](https://github.com/3scale/apicast/pull/812), [PR #814](https://github.com/3scale/apicast/pull/814), [PR #820](https://github.com/3scale/apicast/pull/820)
 - Request headers are now exposed in the context available when evaluating Liquid [PR #819](https://github.com/3scale/apicast/pull/819)
 - Rewrite URL captures policy. This policy captures arguments in a URL and rewrites the URL using them [PR #827](https://github.com/3scale/apicast/pull/827), [THREESCALE-1139](https://issues.jboss.org/browse/THREESCALE-1139)
-- Support for HTTP Proxy [THREESCALE-221](https://issues.jboss.org/browse/THREESCALE-221), [PR #835](https://github.com/3scale/apicast/pull/835)
+- Support for HTTP Proxy [THREESCALE-221](https://issues.jboss.org/browse/THREESCALE-221), [#709](https://github.com/3scale/apicast/issues/709)
 - Conditions for the limits of the rate-limit policy [PR #839](https://github.com/3scale/apicast/pull/839)
 
 ### Changed

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -311,3 +311,15 @@ Path to a file with X.509 certificate in the PEM format for HTTPS.
 **Default:** no value
 
 Path to a file with the X.509 certificate secret key in the PEM format.
+
+### `http_proxy`, `HTTP_PROXY`
+
+**Default:** no value
+
+Defines a HTTP proxy to be used for connecting to HTTP services.
+
+### `https_proxy`, `HTTPS_PROXY`
+
+**Default:** no value
+
+Defines a HTTPS (TLS) proxy to be used for connecting to HTTPS services.

--- a/gateway/conf/proxy.conf
+++ b/gateway/conf/proxy.conf
@@ -1,0 +1,22 @@
+daemon off;
+
+events {
+    worker_connections 1024;
+}
+
+error_log stderr debug;
+
+stream {
+    lua_code_cache on;
+
+    resolver local=on;
+    lua_socket_log_errors off;
+
+    init_by_lua_block { proxy = require('t.fixtures.proxy') }
+
+    # define a TCP server listening on the port 1234:
+    server {
+        listen 8099;
+        content_by_lua_block { proxy() }
+    }
+}

--- a/gateway/src/apicast/http_proxy.lua
+++ b/gateway/src/apicast/http_proxy.lua
@@ -1,0 +1,150 @@
+local format = string.format
+
+local http = require 'resty.resolver.http'
+local resty_url = require "resty.url"
+local resty_resolver = require 'resty.resolver'
+local round_robin = require 'resty.balancer.round_robin'
+local http_proxy = require 'resty.http.proxy'
+
+local _M = { }
+
+function _M.reset()
+    _M.balancer = round_robin.new()
+    _M.resolver = resty_resolver
+    _M.http_backend = require('resty.http_ng.backend.resty')
+    _M.dns_resolution = 'apicast' -- can be set to 'proxy' to let proxy do the name resolution
+
+    return _M
+end
+
+local function resolve_servers(uri)
+    local resolver = _M.resolver:instance()
+
+    if not resolver then
+        return nil, 'not initialized'
+    end
+
+    if not uri then
+        return nil, 'no url'
+    end
+
+    return resolver:get_servers(uri.host, uri)
+end
+
+function _M.resolve(uri)
+    local balancer = _M.balancer
+
+    if not balancer then
+        return nil, 'not initialized'
+    end
+
+    local servers, err = resolve_servers(uri)
+
+    if err then
+        return nil, err
+    end
+
+    local peers = balancer:peers(servers)
+    local peer = balancer:select_peer(peers)
+
+    local ip = uri.host
+    local port = uri.port
+
+    if peer then
+        ip = peer[1]
+        port = peer[2]
+    end
+
+    return ip, port
+end
+
+local function resolve(uri)
+    local host = uri.host
+    local port = uri.port
+
+    if _M.dns_resolution == 'apicast' then
+        host, port = _M.resolve(uri)
+    end
+
+    return host, port or resty_url.default_port(uri.scheme)
+end
+
+local function absolute_url(uri)
+    local host, port = resolve(uri)
+
+    return format('%s://%s:%s%s',
+            uri.scheme,
+            host,
+            port,
+            uri.path or ngx.var.uri or ''
+    )
+end
+
+local function current_path(uri)
+    return format('%s%s%s', uri.path or ngx.var.uri, ngx.var.is_args, ngx.var.query_string)
+end
+
+local function forward_https_request(proxy_uri, uri)
+    local request = {
+        uri = uri,
+        method = ngx.req.get_method(),
+        headers = ngx.req.get_headers(0, true),
+        path = current_path(uri),
+        body = http:get_client_body_reader(),
+    }
+
+    local httpc, err = http_proxy.new(request)
+
+    if not httpc then
+        ngx.log(ngx.ERR, 'could not connect to proxy: ',  proxy_uri, ' err: ', err)
+
+        return ngx.exit(ngx.HTTP_SERVICE_UNAVAILABLE)
+    end
+
+    local res
+    res, err = httpc:request(request)
+
+    if res then
+        httpc:proxy_response(res)
+        httpc:set_keepalive()
+    else
+        ngx.log(ngx.ERR, 'failed to proxy request to: ', proxy_uri, ' err : ', err)
+        return ngx.exit(ngx.HTTP_BAD_GATEWAY)
+    end
+end
+
+local function get_proxy_uri(uri)
+    local proxy_uri, err = http_proxy.find(uri)
+    if not proxy_uri then return nil, err or 'invalid proxy url' end
+
+    if not proxy_uri.port then
+        proxy_uri.port = resty_url.default_port(proxy_uri.scheme)
+    end
+
+    return proxy_uri
+end
+
+function _M.find(upstream)
+    return get_proxy_uri(upstream.uri)
+end
+
+function _M.request(upstream, proxy_uri)
+    local uri = upstream.uri
+
+    if uri.scheme == 'http' then -- rewrite the request to use http_proxy
+        upstream.host = uri.host -- to keep correct Host header in case we need to resolve it to IP
+        upstream.servers = resolve_servers(proxy_uri)
+        upstream.uri.path = absolute_url(uri)
+        upstream:rewrite_request()
+        return
+    elseif uri.scheme == 'https' then
+        upstream:rewrite_request()
+        forward_https_request(proxy_uri, uri)
+        return ngx.exit(ngx.OK) -- terminate phase
+    else
+        ngx.log(ngx.ERR, 'could not connect to proxy: ',  proxy_uri, ' err: ', 'invalid request scheme')
+        return ngx.exit(ngx.HTTP_BAD_GATEWAY)
+    end
+end
+
+return _M.reset()

--- a/gateway/src/apicast/policy/apicast/apicast.lua
+++ b/gateway/src/apicast/policy/apicast/apicast.lua
@@ -1,4 +1,5 @@
 local balancer = require('apicast.balancer')
+
 local math = math
 local setmetatable = setmetatable
 local assert = assert
@@ -85,7 +86,6 @@ function _M:content(context)
   local upstream = assert(context[self], 'missing upstream')
 
   if upstream then
-    upstream:set_request_host()
     upstream:call(context)
   end
 end

--- a/gateway/src/resty/http_ng/backend/ngx.lua
+++ b/gateway/src/resty/http_ng/backend/ngx.lua
@@ -65,7 +65,6 @@ function backend.resolver()
   ngx.var.options = headers['3scale-options']
   ngx.var.grant_type = headers['X-3scale-OAuth2-Grant-Type']
 
-  upstream:set_request_host()
   upstream:call(ngx.ctx)
 end
 

--- a/spec/policy/upstream/upstream_spec.lua
+++ b/spec/policy/upstream/upstream_spec.lua
@@ -81,13 +81,12 @@ describe('Upstream policy', function()
         local upstream = Upstream.new(test_upstream_matched)
         local policy = UpstreamPolicy.new({})
 
-        stub.new(upstream, 'set_request_host')
+        stub.new(upstream, 'rewrite_request')
         stub.new(upstream, 'call')
 
         local ctx = { [policy] = upstream }
         policy:content(ctx)
 
-        assert.spy(upstream.set_request_host).was_called_with(upstream)
         assert.spy(upstream.call).was_called_with(upstream, ctx)
       end)
     end)

--- a/spec/proxy_spec.lua
+++ b/spec/proxy_spec.lua
@@ -60,14 +60,12 @@ describe('Proxy', function()
   describe('.authorize', function()
     local service = { backend_authentication = { value = 'not_baz' }, backend = { endpoint = 'http://0.0.0.0' } }
 
-    local ngx_backend = require('resty.http_ng.backend.ngx')
-
     it('takes ttl value if sent', function()
       local ttl = 80
       ngx.var = { cached_key = 'client_id=blah', http_x_3scale_debug='baz', real_url='blah' }
 
       local response = { status = 200 }
-      stub(ngx_backend, 'send', function() return response end)
+      stub(test_backend, 'send', function() return response end)
 
       stub(proxy, 'cache_handler').returns(true)
 
@@ -83,7 +81,7 @@ describe('Proxy', function()
       ngx.var = { cached_key = "client_id=blah", http_x_3scale_debug='baz', real_url='blah' }
 
       local response = { status = 200 }
-      stub(ngx_backend, 'send', function() return response end)
+      stub(test_backend, 'send', function() return response end)
       stub(proxy, 'cache_handler').returns(true)
 
       local usage = Usage.new()

--- a/t/http-proxy.t
+++ b/t/http-proxy.t
@@ -125,3 +125,563 @@ content_by_lua_block {
 proxy request: CONNECT 127.0.0.1:$TEST_NGINX_RANDOM_PORT
 --- no_error_log
 [error]
+
+=== TEST 4: 3scale backend connection uses proxy
+--- env eval
+("http_proxy" => $ENV{TEST_NGINX_HTTP_PROXY})
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     echo 'yay, api backend: $http_host';
+  }
+--- request
+GET /?user_key=value
+--- response_body
+yay, api backend: test
+--- error_code: 200
+--- error_log env
+proxy request: GET http://127.0.0.1:$TEST_NGINX_SERVER_PORT/transactions/authrep.xml?service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value HTTP/1.1
+--- no_error_log
+[error]
+
+
+
+=== TEST 5: 3scale backend connection uses proxy for HTTPS
+--- env random_port eval
+(
+  'https_proxy' => $ENV{TEST_NGINX_HTTPS_PROXY},
+  'BACKEND_ENDPOINT_OVERRIDE' => "https://test_backend:$ENV{TEST_NGINX_RANDOM_PORT}"
+)
+--- configuration env
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend env
+listen $TEST_NGINX_RANDOM_PORT ssl;
+
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+location /transactions/authrep.xml {
+  access_by_lua_block {
+    assert = require('luassert')
+    assert.equal('https', ngx.var.scheme)
+    assert.equal('$TEST_NGINX_RANDOM_PORT', ngx.var.server_port)
+    assert.equal('test_backend', ngx.var.ssl_server_name)
+  }
+
+  content_by_lua_block {
+    local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
+    require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+  }
+}
+--- upstream
+  location / {
+     echo 'yay, api backend: $http_host';
+  }
+--- request
+GET /?user_key=value
+--- response_body
+yay, api backend: test
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT 127.0.0.1:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- no_error_log
+[error]
+--- user_files fixture=tls.pl eval
+
+
+
+=== TEST 6: 3scale backend connection uses proxy even when using workers
+--- env eval
+(
+  'http_proxy' => $ENV{TEST_NGINX_HTTP_PROXY},
+  'APICAST_REPORTING_THREADS' => '1'
+)
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     echo 'yay, api backend: $http_host';
+  }
+--- test
+content_by_lua_block {
+  local pending = ngx.timer.pending_count()
+  ngx.shared.api_keys:set('42:value:usage%5Bhits%5D=2', 200)
+
+  local res = ngx.location.capture('/apicast?user_key=value')
+
+  while ngx.timer.pending_count() + ngx.timer.running_count() > pending do
+    ngx.sleep(0.0001)
+  end
+
+  ngx.status = res.status
+  ngx.print(res.body)
+}
+
+location /apicast {
+  internal;
+  proxy_set_header Host localhost;
+  proxy_pass http://$server_addr:$apicast_port;
+}
+--- response_body
+yay, api backend: test
+--- error_code: 200
+--- error_log env
+proxy request: GET http://127.0.0.1:$TEST_NGINX_SERVER_PORT/transactions/authrep.xml?service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value HTTP/1.1
+apicast cache write key: 42:value:usage%5Bhits%5D=2, ttl: nil, context: ngx.timer
+--- no_error_log
+[error]
+
+
+
+=== TEST 7: 3scale backend connection uses proxy even when using workers + TLS
+--- env random_port eval
+(
+  'https_proxy' => $ENV{TEST_NGINX_HTTP_PROXY},
+  'APICAST_REPORTING_THREADS' => '1',
+  'BACKEND_ENDPOINT_OVERRIDE' => "https://test_backend:$ENV{TEST_NGINX_RANDOM_PORT}"
+)
+--- configuration  env
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend env
+listen $TEST_NGINX_RANDOM_PORT ssl;
+
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+location /transactions/authrep.xml {
+  access_by_lua_block {
+    assert = require('luassert')
+    assert.equal('https', ngx.var.scheme)
+    assert.equal('$TEST_NGINX_RANDOM_PORT', ngx.var.server_port)
+    assert.equal('test_backend', ngx.var.ssl_server_name)
+  }
+
+  content_by_lua_block {
+    local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
+    require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+  }
+}
+--- upstream
+  location / {
+     echo 'yay, api backend: $http_host';
+  }
+--- test
+content_by_lua_block {
+  local pending = ngx.timer.pending_count()
+  ngx.shared.api_keys:set('42:value:usage%5Bhits%5D=2', 200)
+
+  local res = ngx.location.capture('/apicast?user_key=value')
+
+  while ngx.timer.pending_count() + ngx.timer.running_count() > pending do
+    ngx.sleep(0.001)
+  end
+
+  ngx.status = res.status
+  ngx.print(res.body)
+}
+
+location /apicast {
+  internal;
+  proxy_set_header Host localhost;
+  proxy_pass http://$server_addr:$apicast_port;
+}
+--- response_body
+yay, api backend: test
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT 127.0.0.1:$TEST_NGINX_RANDOM_PORT
+apicast cache write key: 42:value:usage%5Bhits%5D=2, ttl: nil, context: ngx.timer
+--- no_error_log
+[error]
+--- user_files fixture=tls.pl eval
+
+
+
+=== TEST 8: upstream API connection uses proxy
+--- env eval
+("http_proxy" => $ENV{TEST_NGINX_HTTP_PROXY})
+--- configuration
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+  location /test {
+     echo 'yay, api backend: $http_host, uri: $uri, is_args: $is_args, args: $args';
+  }
+--- request
+GET /test?user_key=value
+--- response_body
+yay, api backend: test, uri: /test, is_args: ?, args: user_key=value
+--- error_code: 200
+--- error_log env
+proxy request: GET http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test?user_key=value HTTP/1.1
+--- no_error_log
+[error]
+
+
+
+=== TEST 9: upstream API connection uses proxy for https
+--- env eval
+("https_proxy" => $ENV{TEST_NGINX_HTTPS_PROXY})
+--- configuration random_port env
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://test:$TEST_NGINX_RANDOM_PORT/",
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream env
+listen $TEST_NGINX_RANDOM_PORT ssl;
+
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+location /test {
+    echo_foreach_split '\r\n' $echo_client_request_headers;
+    echo $echo_it;
+    echo_end;
+
+    access_by_lua_block {
+       assert = require('luassert')
+       assert.equal('https', ngx.var.scheme)
+       assert.equal('$TEST_NGINX_RANDOM_PORT', ngx.var.server_port)
+       assert.equal('test', ngx.var.ssl_server_name)
+    }
+}
+--- request
+GET /test?user_key=test3
+--- more_headers
+User-Agent: Test::APIcast::Blackbox
+ETag: foobar
+--- response_body
+GET /test?user_key=test3 HTTP/1.1
+User-Agent: Test::APIcast::Blackbox
+ETag: foobar
+Connection: close
+Host: test
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT 127.0.0.1:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- no_error_log
+[error]
+--- user_files fixture=tls.pl eval
+
+
+
+=== TEST 10: Upstream Policy connection uses proxy
+--- env eval
+("http_proxy" => $ENV{TEST_NGINX_HTTP_PROXY})
+--- configuration
+{
+  "services": [
+    {
+      "proxy": {
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/test", "url": "http://test" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /test {
+    echo_foreach_split '\r\n' $echo_client_request_headers;
+    echo $echo_it;
+    echo_end;
+  }
+--- request
+GET /test?user_key=test3
+--- more_headers
+User-Agent: Test::APIcast::Blackbox
+ETag: foobar
+--- response_body
+GET /test?user_key=test3 HTTP/1.1
+X-Real-IP: 127.0.0.1
+Host: test
+User-Agent: Test::APIcast::Blackbox
+ETag: foobar
+--- error_code: 200
+--- error_log env
+proxy request: GET http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test?user_key=test3 HTTP/1.1
+--- no_error_log
+[error]
+
+
+
+=== TEST 11: Upstream Policy connection uses proxy for https
+--- env eval
+("https_proxy" => $ENV{TEST_NGINX_HTTPS_PROXY})
+--- configuration random_port env
+{
+  "services": [
+    {
+      "proxy": {
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/test", "url": "https://test:$TEST_NGINX_RANDOM_PORT" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream env
+listen $TEST_NGINX_RANDOM_PORT ssl;
+
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+location /test {
+    echo_foreach_split '\r\n' $echo_client_request_headers;
+    echo $echo_it;
+    echo_end;
+
+    access_by_lua_block {
+       assert = require('luassert')
+       assert.equal('https', ngx.var.scheme)
+       assert.equal('$TEST_NGINX_RANDOM_PORT', ngx.var.server_port)
+       assert.equal('test', ngx.var.ssl_server_name)
+    }
+}
+--- request
+GET /test?user_key=test3
+--- more_headers
+User-Agent: Test::APIcast::Blackbox
+ETag: foobar
+--- response_body
+GET /test?user_key=test3 HTTP/1.1
+User-Agent: Test::APIcast::Blackbox
+ETag: foobar
+Connection: close
+Host: test
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT 127.0.0.1:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- no_error_log
+[error]
+--- user_files fixture=tls.pl eval
+
+
+
+=== TEST 12: Upstream Policy connection uses proxy
+--- env eval
+("http_proxy" => $ENV{TEST_NGINX_HTTP_PROXY})
+--- configuration
+{
+  "services": [
+    {
+      "proxy": {
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/test", "url": "http://test" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /test {
+    echo_foreach_split '\r\n' $echo_client_request_headers;
+    echo $echo_it;
+    echo_end;
+    echo '';
+    echo_read_request_body;
+    echo $request_body;
+  }
+--- request
+POST /test?user_key=test3
+this-is-some-request-body
+--- more_headers
+User-Agent: Test::APIcast::Blackbox
+--- response_body
+POST /test?user_key=test3 HTTP/1.1
+X-Real-IP: 127.0.0.1
+Host: test
+Content-Length: 25
+User-Agent: Test::APIcast::Blackbox
+
+this-is-some-request-body
+--- error_code: 200
+--- error_log env
+proxy request: POST http://127.0.0.1:$TEST_NGINX_SERVER_PORT/test?user_key=test3 HTTP/1.1
+--- no_error_log
+[error]
+
+
+
+=== TEST 13: Upstream Policy connection uses proxy for https and forwards request body
+--- env eval
+("https_proxy" => $ENV{TEST_NGINX_HTTPS_PROXY})
+--- configuration random_port env
+{
+  "services": [
+    {
+      "proxy": {
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/test", "url": "https://test:$TEST_NGINX_RANDOM_PORT" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream env
+listen $TEST_NGINX_RANDOM_PORT ssl;
+
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+location /test {
+    echo_foreach_split '\r\n' $echo_client_request_headers;
+    echo $echo_it;
+    echo_end;
+    echo '';
+    echo_read_request_body;
+    echo $request_body;
+
+    access_by_lua_block {
+       assert = require('luassert')
+       assert.equal('https', ngx.var.scheme)
+       assert.equal('$TEST_NGINX_RANDOM_PORT', ngx.var.server_port)
+       assert.equal('test', ngx.var.ssl_server_name)
+    }
+}
+--- request
+POST /test?user_key=test3
+this-is-some-request-body
+--- more_headers
+User-Agent: Test::APIcast::Blackbox
+--- response_body
+POST /test?user_key=test3 HTTP/1.1
+User-Agent: Test::APIcast::Blackbox
+Content-Length: 25
+Connection: close
+Host: test
+
+this-is-some-request-body
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT 127.0.0.1:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- no_error_log
+[error]
+--- user_files fixture=tls.pl eval


### PR DESCRIPTION
Fixes https://github.com/3scale/apicast/issues/709

Builds on top of https://github.com/3scale/apicast/pull/835

By configuring standard environment variables `http_proxy`, `HTTP_PROXY`, `no_proxy`, `NO_PROXY`, `http_proxy`, `HTTPS_PROXY` you can instruct APIcast to use those instead of direct connection.

Proxy does not support any authentication yet.

# Tests

- [x] test http_ng.backend.ngx
- [x] test http_ng.backend.ngx + SSL
- [x] test http_ng.backend.resty
- [x] test http_ng.backend.resty + SSL
- [x] test nginx upstream `ngx.exec(@upstream)`
- [x] test nginx upstream `ngx.exec(@upstream)` + SSL
- [x] test upstream policy 
- [x] test upstream policy + SSL
- [x] test downloading configuration
- [x] test downloading configuration + SSL
- [x] test forwarding request body