### PR TITLE
stub ngx.print in Keycloack scopes policy specs

### DIFF
--- a/spec/policy/keycloak_role_check/keycloak_role_check_spec.lua
+++ b/spec/policy/keycloak_role_check/keycloak_role_check_spec.lua
@@ -4,6 +4,7 @@ describe('Keycloak Role check policy', function()
 
   before_each(function()
     ngx.header = {}
+    stub(ngx, 'print')
   end)
 
   describe('.access', function()


### PR DESCRIPTION
When running the tests, 'auth failed' is printed several times. This PR fixes the issue:
```
bash-4.2$ make busted
/usr/local/openresty/luajit/bin/rover exec bin/busted 
●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●auth failed●auth failed●auth failed●auth failed●auth failed●auth failedauth failed●auth failed●auth failed●auth fail
ed●●●●●●●●●●●●●●●●●●●◌●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●◌●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●
●●
630 successes / 0 failures / 0 errors / 2 pending : 3.473393 seconds

```