### PR TITLE
[s2i] fix unbound variable on OpenShift 3.9 [THREESCALE-1138] 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Do not crash when initializing unreachable/invalid DNS resolver [PR #730](https://github.com/3scale/apicast/pull/730)
 - Reporting only 50% calls to 3scale backend when using OIDC [PR #774](https://github.com/3scale/apicast/pull/774)
+- Building container image on OpenShift 3.9 [PR #810](https://github.com/3scale/apicast/pull/810), [THREESCALE-1138](https://issues.jboss.org/browse/THREESCALE-1138)
 
 ## [3.2.0-rc2] - 2018-05-11
 

--- a/gateway/.s2i/bin/assemble
+++ b/gateway/.s2i/bin/assemble
@@ -3,7 +3,7 @@ set -euo pipefail
 
 mkdir -p /tmp/.s2i
 
-if [[ -n "${GIT_BRANCH}" && "${GIT_BRANCH}" != master && -z "${GIT_TAG}" ]]; then
+if [[ -n "${GIT_BRANCH:-}" && "${GIT_BRANCH:-}" != master && -z "${GIT_TAG:-}" ]]; then
   IMAGE_EXPIRES_AFTER="1w"
   echo "This image is going to have just ${IMAGE_EXPIRES_AFTER} expiration."
 fi


### PR DESCRIPTION
Fixes https://issues.jboss.org/browse/THREESCALE-1138.

OpenShift source builder behaves differently from s2i and has different ENV variables.