### PR TITLE
[openshift] replace "docker" with "container"

### DIFF
--- a/openshift/apicast-template.yml
+++ b/openshift/apicast-template.yml
@@ -105,11 +105,11 @@ parameters:
   value: apicast-configuration-url-secret
   name: CONFIGURATION_URL_SECRET
   required: true
-- description: "Path to saved JSON file with configuration for the gateway. Has to be injected to the docker image as read only volume."
+- description: "Path to saved JSON file with configuration for the gateway. Has to be injected to the container image as read only volume."
   value:
   name: CONFIGURATION_FILE_PATH
   required: false
-- description: "Docker image to use."
+- description: "Container image to use."
   value: 'quay.io/3scale/apicast:master'
   name: IMAGE_NAME
 - description: "Deployment environment. Can be sandbox or production."


### PR DESCRIPTION
We can use other container runtimes, not just Docker.

3scale/3scale-amp-openshift-templates#26

Credits: Marcus Carvalho