### PR TITLE
[dev] do not set timer_resolution in development mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Cache loaded policies. Loading one policy several times will use the same instance [PR #770](https://github.com/3scale/apicast/pull/770)
 - Load all policies into cache when starting APIcast master process. [PR #770](https://github.com/3scale/apicast/pull/770)
 - `init` and `init_worker` phases are executed on the policy module, not the instance of a policy with a configuration [PR #770](https://github.com/3scale/apicast/pull/770)
+- `timer_resolution` set only in development environment [PR #815](https://github.com/3scale/apicast/pull/815)
 
 ### Fixed
 

--- a/gateway/conf/nginx.conf.liquid
+++ b/gateway/conf/nginx.conf.liquid
@@ -9,6 +9,10 @@ env OPENSSL_VERIFY;
   {% for file in "modules/ngx_http_opentracing_module.so" | filesystem %}
 load_module {{file}};
   {% endfor %}
+{% else %}
+  {% if timer_resolution %}
+    timer_resolution {{ timer_resolution }};
+  {% endif %}
 {% endif %}
 
 daemon {{ daemon | default: 'off' }};
@@ -16,10 +20,6 @@ master_process {{ master_process | default: 'on' }};
 worker_processes {{ worker_processes | default: 'auto' }};
 pcre_jit on;
 pid {{ pid | default: 'nginx.pid' }};
-
-{% unless opentracing_tracer != empty %}
-timer_resolution {{ timer_resolution | default: '100ms' }};
-{% endunless %}
 
 {% for file in "main.d/*.conf" | filesystem %}
   {% include file %}

--- a/gateway/config/development.lua
+++ b/gateway/config/development.lua
@@ -29,5 +29,6 @@ return {
     configuration_loader = 'lazy',
     configuration_cache = 0,
     configuration = data_url('application/json', configuration),
-    port = { metrics = 9421 }, -- see https://github.com/prometheus/prometheus/wiki/Default-port-allocations
+    port = { metrics = 9421 }, -- see https://github.com/prometheus/prometheus/wiki/Default-port-allocations,
+    timer_resolution = false,
 }

--- a/gateway/config/production.lua
+++ b/gateway/config/production.lua
@@ -3,4 +3,5 @@ return {
     lua_code_cache = 'on',
     configuration_loader = 'boot',
     configuration_cache = os.getenv('APICAST_CONFIGURATION_CACHE') or 5*60,
+    timer_resolution = '100ms',
 }

--- a/gateway/src/apicast/linked_list.lua
+++ b/gateway/src/apicast/linked_list.lua
@@ -10,7 +10,7 @@ local noop = function() end
 
 local empty_t = setmetatable({}, { __newindex = noop })
 local __index = function(t,k)
-    return t.current[k] or t.next[k]
+    if t.current[k] == nil then return t.next[k] else return t.current[k] end
 end
 
 local ro_mt = {

--- a/spec/linked_list_spec.lua
+++ b/spec/linked_list_spec.lua
@@ -26,6 +26,12 @@ describe('linked_list', function()
       assert.same({ b = 2 }, list.next.current)
       assert.same({ c = 3 }, list.next.next)
     end)
+
+    it('takes false over nil', function()
+      local list = linked_list.readonly({ a = false }, { a = 'value' })
+
+      assert.is_false(list.a)
+    end)
   end)
 
   describe('readwrite', function()
@@ -53,6 +59,14 @@ describe('linked_list', function()
       assert.same({ a = 1 }, list.current)
       assert.same({ b = 2 }, list.next.current)
       assert.same({ c = 3 }, list.next.next)
+    end)
+
+    it('can override values with false', function()
+      local list = linked_list.readwrite({  }, { a = 'value' })
+
+      list.a = false
+
+      assert.is_false(list.a)
     end)
   end)
 end)


### PR DESCRIPTION
Setting `timer_resolution` in nginx configuration will result in logging ~7 lines every 100ms (or other timer_resolution interval) in debug log. That makes any debugging impossible.

Disabling this in development is reasonable as it is just a performance  optimization for production environment.