### PR TITLE
Set LOG_LEVEL param to required

### DIFF
--- a/openshift/apicast-template.yml
+++ b/openshift/apicast-template.yml
@@ -137,7 +137,8 @@ parameters:
   required: false
 - description: "Log level. One of the following: debug, info, notice, warn, error, crit, alert, or emerg."
   name: LOG_LEVEL
-  required: false
+  required: true
+  value: "warn"
 - description: "Enable path routing. Experimental feature."
   name: PATH_ROUTING
   required: false


### PR DESCRIPTION
When following the [openshift-guide](https://github.com/3scale/apicast/blob/master/doc/openshift-guide.md), running the `oc new-app` command without specifying a log level causes the apicast pods to crash due to invalid config. 