### PR TITLE
policy/url_rewriting: avoid assigning self.something in rewrite()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Generate new policy scaffold from the CLI [PR #682](https://github.com/3scale/apicast/pull/682)
 - 3scale batcher policy [PR #685](https://github.com/3scale/apicast/pull/685), [PR #710](https://github.com/3scale/apicast/pull/710), [PR #757](https://github.com/3scale/apicast/pull/757), [PR #786](https://github.com/3scale/apicast/pull/786)
 - Liquid templating support in the headers policy configuration [PR #716](https://github.com/3scale/apicast/pull/716)
-- Ability to modify query parameters in the URL rewriting policy [PR #724](https://github.com/3scale/apicast/pull/724)
+- Ability to modify query parameters in the URL rewriting policy [PR #724](https://github.com/3scale/apicast/pull/724), [PR #818](https://github.com/3scale/apicast/pull/818)
 - 3scale referrer policy [PR #728](https://github.com/3scale/apicast/pull/728), [PR #777](https://github.com/3scale/apicast/pull/777)
 - Liquid templating support in the rate-limit policy [PR #719](https://github.com/3scale/apicast/pull/719)
 - Default credentials policy [PR #741](https://github.com/3scale/apicast/pull/741), [THREESCALE-586](https://issues.jboss.org/browse/THREESCALE-586)

--- a/gateway/src/apicast/policy/url_rewriting/url_rewriting.lua
+++ b/gateway/src/apicast/policy/url_rewriting/url_rewriting.lua
@@ -110,9 +110,9 @@ function _M:rewrite(context)
     end
   end
 
-  self.query_args = QueryParams.new()
+  local query_args = QueryParams.new()
   for _, query_arg_command in ipairs(self.query_args_commands) do
-    apply_query_arg_command(query_arg_command, self.query_args, context)
+    apply_query_arg_command(query_arg_command, query_args, context)
   end
 end
 


### PR DESCRIPTION
Consider the case of 2 requests being attended at the same time by the same worker. Each request could modify the value that the other sees.

As a general rule, in the case of policies, we should only assign "self._something" in new().