### PR TITLE
Expose request headers in Liquid available context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Policies can define `__gc` metamethod that gets called when they are garbage collected to do cleanup [PR #688](https://github.com/3scale/apicast/pull/688)
 - Keycloak Role Check policy [PR #773](https://github.com/3scale/apicast/pull/773)
 - Conditional policy. This policy includes a condition and a policy chain, and only executes the chain when the condition is true [PR #812](https://github.com/3scale/apicast/pull/812), [PR #814](https://github.com/3scale/apicast/pull/814)
+- Request headers are now exposed in the context available when evaluating Liquid [PR #819](https://github.com/3scale/apicast/pull/819)
 
 ### Changed
 

--- a/gateway/src/apicast/policy/ngx_variable.lua
+++ b/gateway/src/apicast/policy/ngx_variable.lua
@@ -4,7 +4,8 @@ local function context_values()
   return {
     uri = ngx.var.uri,
     host = ngx.var.host,
-    remote_addr = ngx.var.remote_addr
+    remote_addr = ngx.var.remote_addr,
+    headers = ngx.req.get_headers()
   }
 end
 

--- a/spec/policy/ngx_variable_spec.lua
+++ b/spec/policy/ngx_variable_spec.lua
@@ -1,0 +1,19 @@
+local ngx_variable = require('apicast.policy.ngx_variable')
+
+describe('ngx_variable', function()
+  describe('.available_context', function()
+    before_each(function()
+      ngx.var = {}
+    end)
+
+    it('exposes request headers in the "headers" table', function()
+      stub(ngx.req, 'get_headers', function()
+        return { some_header = 'some_val' }
+      end)
+
+      local context = ngx_variable.available_context()
+
+      assert('some_val', context.headers['some_header'])
+    end)
+  end)
+end)


### PR DESCRIPTION
The goal of this PR is to cover the use case mentioned in https://github.com/3scale/apicast/issues/744#issuecomment-407077679

The objective is to be able to combine the conditional policy with the upstream one and be able to choose an upstream based on a request header. In order to do that, I needed to expose the request headers in the `ngx_variable` module. I also added an integration test that checks that it works as expected.