### PR TITLE
[rate-limit] Multi limits using the same type of limiter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Do not crash when initializing unreachable/invalid DNS resolver [PR #730](https://github.com/3scale/apicast/pull/730)
 - Reporting only 50% calls to 3scale backend when using OIDC [PR #774](https://github.com/3scale/apicast/pull/774)
 - Building container image on OpenShift 3.9 [PR #810](https://github.com/3scale/apicast/pull/810), [THREESCALE-1138](https://issues.jboss.org/browse/THREESCALE-1138)
+- Rate Limit policy to define multiple limiters of the same type [PR #825](https://github.com/3scale/apicast/pull/825)
 
 ## [3.2.0-rc2] - 2018-05-11
 

--- a/gateway/src/apicast/policy/rate_limit/rate_limit.lua
+++ b/gateway/src/apicast/policy/rate_limit/rate_limit.lua
@@ -16,7 +16,6 @@ local shdict_key = 'limiter'
 
 local insert = table.insert
 local ipairs = ipairs
-local unpack = table.unpack
 local format = string.format
 local concat = table.concat
 
@@ -165,7 +164,9 @@ function _M:access(context)
   local limiter_groups = { conn_limiters, leaky_bucket_limiters, fixed_window_limiters }
   for _, limiter_group in ipairs(limiter_groups) do
     if #limiter_group > 0 then
-      insert(limiters, unpack(limiter_group))
+      for _, limiter in ipairs(limiter_group) do
+        insert(limiters, limiter)
+      end
     end
   end
 
@@ -173,7 +174,9 @@ function _M:access(context)
   local keys_groups = { conn_keys, leaky_bucket_keys, fixed_window_keys }
   for _, keys_group in ipairs(keys_groups) do
     if #keys_group > 0 then
-      insert(keys, unpack(keys_group))
+      for _, key in ipairs(keys_group) do
+        insert(keys, key)
+      end
     end
   end
 

--- a/t/apicast-policy-rate-limit.t
+++ b/t/apicast-policy-rate-limit.t
@@ -1170,8 +1170,9 @@ so only the third call returns 429.
 --- no_error_log
 [error]
 
-=== TEST 19: Rejected (count).
-Return 429 code.
+=== TEST 19: Rejected (count). Using multiple limiters of the same type.
+To confirm that multiple limiters of the same type are configurable
+and rejected properly.
 --- http_config
   include $TEST_NGINX_UPSTREAM_CONFIG;
   lua_package_path "$TEST_NGINX_LUA_PATH";
@@ -1216,11 +1217,7 @@ Return 429 code.
       local redis = require('resty.redis'):new()
       redis:connect(redis_host, redis_port)
       redis:select(1)
-      local redis_key1 = redis:keys('*_fixed_window_localhost')[1]
-      local redis_key2 = redis:keys('*_fixed_window_/test19_1')[1]
-      local redis_key3 = redis:keys('*_fixed_window_/test19_2')[1]
-      local redis_key4 = redis:keys('*_fixed_window_/test19_3')[1]
-      redis:del(redis_key1, redis_key2, redis_key3, redis_key4)
+      redis:flushdb()
     }
   }
 

--- a/t/apicast-policy-rate-limit.t
+++ b/t/apicast-policy-rate-limit.t
@@ -1169,3 +1169,64 @@ so only the third call returns 429.
 [200, 200, 200, 429]
 --- no_error_log
 [error]
+
+=== TEST 19: Rejected (count).
+Return 429 code.
+--- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+
+  init_by_lua_block {
+    require "resty.core"
+    ngx.shared.limiter:flush_all()
+    require('apicast.configuration_loader').mock({
+      services = {
+        {
+          id = 42,
+          proxy = {
+            policy_chain = {
+              {
+                name = "apicast.policy.rate_limit",
+                configuration = {
+                  fixed_window_limiters = {
+                    { key = {name = "{{host}}", name_type = "liquid"}, count = 2, window = 10 },
+                    { key = {name = "{{uri}}", name_type = "liquid"}, count = 1, window = 10 }
+                  },
+                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
+                  limits_exceeded_error = { status_code = 429 }
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+  }
+  lua_shared_dict limiter 1m;
+
+--- config
+  include $TEST_NGINX_APICAST_CONFIG;
+  resolver $TEST_NGINX_RESOLVER;
+
+  location /flush_redis {
+    content_by_lua_block {
+      local env = require('resty.env')
+      local redis_host = "$TEST_NGINX_REDIS_HOST" or '127.0.0.1'
+      local redis_port = "$TEST_NGINX_REDIS_PORT" or 6379
+      local redis = require('resty.redis'):new()
+      redis:connect(redis_host, redis_port)
+      redis:select(1)
+      local redis_key1 = redis:keys('*_fixed_window_localhost')[1]
+      local redis_key2 = redis:keys('*_fixed_window_/test19_1')[1]
+      local redis_key3 = redis:keys('*_fixed_window_/test19_2')[1]
+      local redis_key4 = redis:keys('*_fixed_window_/test19_3')[1]
+      redis:del(redis_key1, redis_key2, redis_key3, redis_key4)
+    }
+  }
+
+--- pipelined_requests eval
+["GET /flush_redis","GET /test19_1","GET /test19_2","GET /test19_3"]
+--- error_code eval
+[200, 200, 200, 429]
+--- no_error_log
+[error]


### PR DESCRIPTION
When I define multipul limits using the same type of limiter, 

```json
"fixed_window_limiters" : [
  { "limit 1" },
  { "limit 2" }
]
```

The following error message is displayed.

````
"2018/07/30 17:52:07 [error] 18007\#18007: *1 lua entry thread aborted: runtime error: ...ast/gateway/src/apicast/policy/rate_limit/rate_limit.lua:168: bad argument \#2 to 'insert' (number expected, got table)"
````

I fixed this by removing `table.unpack`.