### PR TITLE
rate limit policy: fix exclusiveMininum for 'conn' in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Do not crash when initializing unreachable/invalid DNS resolver [PR #730](https://github.com/3scale/apicast/pull/730)
 - Reporting only 50% calls to 3scale backend when using OIDC [PR #774](https://github.com/3scale/apicast/pull/774), [THREESCALE-1080](https://issues.jboss.org/browse/THREESCALE-1080)
 - Building container image on OpenShift 3.9 [PR #810](https://github.com/3scale/apicast/pull/810), [THREESCALE-1138](https://issues.jboss.org/browse/THREESCALE-1138)
+- Fix `exclusiveMinimum` field for `conn` property in the rate-limit JSON schema [PR #832](https://github.com/3scale/apicast/pull/832)
 
 ## [3.2.0-rc2] - 2018-05-11
 

--- a/gateway/src/apicast/policy/rate_limit/apicast-policy.json
+++ b/gateway/src/apicast/policy/rate_limit/apicast-policy.json
@@ -68,7 +68,7 @@
             "conn": {
               "type": "integer",
               "description": "The maximum number of concurrent requests allowed",
-              "exclusiveminimum": 0
+              "exclusiveMinimum": 0
             },
             "burst": {
               "type": "integer",


### PR DESCRIPTION
This is not just a typo. The validation fails because of this.