### PR TITLE
[circleci] temporarily disable jobs that are not used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,8 +282,6 @@ workflows:
           context: org-global
   build-test-deploy:
     jobs:
-      - profile:
-          <<: *build-tags
       - build-lua:
           <<: *build-tags
       - build-perl:
@@ -322,8 +320,3 @@ workflows:
             <<: *ignore-forks
             tags:
               only: /^v\d+\..+/
-      - benchmark:
-          requires:
-            - deploy
-          filters:
-            <<: *ignore-forks


### PR DESCRIPTION
We need to make our build less resource intensive, as it is taking a lot
of time in queue now.