### PR TITLE
do not depend on /etc/resolv.conf

### DIFF
--- a/gateway/src/resty/resolver.lua
+++ b/gateway/src/resty/resolver.lua
@@ -106,7 +106,7 @@ function _M.parse_nameservers(path)
   local resolv_conf, err = read_resolv_conf(path)
 
   if err then
-    ngx.log(ngx.WARN, 'resolver could not get nameservers: ', err)
+    ngx.log(ngx.NOTICE, 'resolver could not get nameservers: ', err)
   end
 
   ngx.log(ngx.DEBUG, '/etc/resolv.conf:\n', resolv_conf)

--- a/spec/oauth_spec.lua
+++ b/spec/oauth_spec.lua
@@ -2,11 +2,11 @@ local oauth = require 'apicast.oauth'
 
 describe('OAuth', function()
   describe('.oidc', function()
-    it(function() assert.equal(require('apicast.oauth.oidc'), oauth.oidc) end)
+    it('loads oidc module', function() assert.equal(require('apicast.oauth.oidc'), oauth.oidc) end)
   end)
 
   describe('.apicast', function()
-    it(function() assert.equal(require('apicast.oauth.apicast_oauth'), oauth.apicast) end)
+    it('loads apicast module', function() assert.equal(require('apicast.oauth.apicast_oauth'), oauth.apicast) end)
   end)
 
 end)

--- a/spec/policy/rate_limit/rate_limit_spec.lua
+++ b/spec/policy/rate_limit/rate_limit_spec.lua
@@ -22,7 +22,7 @@ end
 
 local ts = require ('apicast.threescale_utils')
 
-local redis_host = env.get('TEST_NGINX_REDIS_HOST') or 'localhost'
+local redis_host = env.get('TEST_NGINX_REDIS_HOST') or '127.0.0.1'
 local redis_port = env.get('TEST_NGINX_REDIS_PORT') or 6379
 
 local redis_url = 'redis://'..redis_host..':'..redis_port..'/1'

--- a/spec/policy/rate_limit/redis_shdict_spec.lua
+++ b/spec/policy/rate_limit/redis_shdict_spec.lua
@@ -1,7 +1,7 @@
 local env = require('resty.env')
 local ts = require ('apicast.threescale_utils')
 
-local redis_host = env.get('TEST_NGINX_REDIS_HOST') or 'localhost'
+local redis_host = env.get('TEST_NGINX_REDIS_HOST') or '127.0.0.1'
 local redis_port = env.get('TEST_NGINX_REDIS_PORT') or 6379
 
 local redis_shdict = require('apicast.policy.rate_limit.redis_shdict')

--- a/spec/resty/resolver/dns_client_spec.lua
+++ b/spec/resty/resolver/dns_client_spec.lua
@@ -2,7 +2,7 @@ local dns_client = require 'resty.resolver.dns_client'
 
 describe('resty.resolver.dns_client', function()
 
-  describe(':init_resolvers', function()
+  describe(':init_resolvers #network', function()
     it('is called only once', function()
       local dns = dns_client:new{ nameservers = { '127.0.0.1' } }
       local s = spy.on(dns, 'init_resolvers')

--- a/t/apicast-oauth.t
+++ b/t/apicast-oauth.t
@@ -2,7 +2,6 @@ use lib 't';
 use Test::APIcast 'no_plan';
 
 $ENV{TEST_NGINX_REDIS_HOST} ||= $ENV{REDIS_HOST} || "127.0.0.1";
-$ENV{TEST_NGINX_RESOLVER} ||= `grep nameserver /etc/resolv.conf | awk '{print \$2}' | head -1 | tr '\n' ' '`;
 $ENV{BACKEND_ENDPOINT_OVERRIDE} ||= "http://127.0.0.1:$Test::Nginx::Util::ServerPortForClient/backend";
 
 env_to_nginx('BACKEND_ENDPOINT_OVERRIDE');
@@ -47,7 +46,6 @@ called oauth_authorize.xml
 [Section 1.3.1 of RFC 6749](https://tools.ietf.org/html/rfc6749#section-1.3.1)
 --- main_config
   env REDIS_HOST=$TEST_NGINX_REDIS_HOST;
-  env RESOLVER=$TEST_NGINX_RESOLVER;
 --- http_config
   include $TEST_NGINX_UPSTREAM_CONFIG;
   lua_package_path "$TEST_NGINX_LUA_PATH";
@@ -221,7 +219,6 @@ include $TEST_NGINX_APICAST_CONFIG;
 === TEST 8: calling /callback redirects to correct error when state is missing
 --- main_config
   env REDIS_HOST=$TEST_NGINX_REDIS_HOST;
-  env RESOLVER=$TEST_NGINX_RESOLVER;
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";
   init_by_lua_block {
@@ -245,7 +242,6 @@ include $TEST_NGINX_APICAST_CONFIG;
 Not part of the RFC. This is the Gateway API to create access tokens and redirect back to the Client.
 --- main_config
   env REDIS_HOST=$TEST_NGINX_REDIS_HOST;
-  env RESOLVER=$TEST_NGINX_RESOLVER;
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";
   init_by_lua_block {
@@ -285,7 +281,6 @@ Location: http://example.com/redirect\?code=\w+&state=clientstate
 === TEST 10: calling /oauth/token returns correct error message on invalid parameters
 --- main_config
   env REDIS_HOST=$TEST_NGINX_REDIS_HOST;
-  env RESOLVER=$TEST_NGINX_RESOLVER;
   env APICAST_OAUTH_TOKENS_TTL=123;
 --- http_config
   include $TEST_NGINX_UPSTREAM_CONFIG;
@@ -402,7 +397,6 @@ yay, upstream
 === TEST 12: calling /authorize with state returns same value back on redirect_uri
 --- main_config
   env REDIS_HOST=$TEST_NGINX_REDIS_HOST;
-  env RESOLVER=$TEST_NGINX_RESOLVER;
 --- http_config
   lua_package_path "$TEST_NGINX_LUA_PATH";
 
@@ -554,7 +548,6 @@ credentials missing!
 Regression test for CVE-2017-7512
 --- main_config
   env REDIS_HOST=$TEST_NGINX_REDIS_HOST;
-  env RESOLVER=$TEST_NGINX_RESOLVER;
 --- http_config
   include $TEST_NGINX_UPSTREAM_CONFIG;
   lua_package_path "$TEST_NGINX_LUA_PATH";
@@ -617,7 +610,6 @@ GET /t
 === TEST 17: return error status code and message when access token couldn't be stored in 3scale
 --- main_config
   env REDIS_HOST=$TEST_NGINX_REDIS_HOST;
-  env RESOLVER=$TEST_NGINX_RESOLVER;
 --- http_config
   include $TEST_NGINX_UPSTREAM_CONFIG;
   lua_package_path "$TEST_NGINX_LUA_PATH";
@@ -682,7 +674,6 @@ GET /t
 === TEST 18: when calling /oauth/token request headers are not passed to the backend
 --- main_config
   env REDIS_HOST=$TEST_NGINX_REDIS_HOST;
-  env RESOLVER=$TEST_NGINX_RESOLVER;
   env APICAST_OAUTH_TOKENS_TTL=123;
 --- http_config
   include $TEST_NGINX_UPSTREAM_CONFIG;
@@ -758,7 +749,6 @@ Content-Type: application/json
 When a token TTL is not specified, it applies a default of 7 days (604800 s)
 --- main_config
   env REDIS_HOST=$TEST_NGINX_REDIS_HOST;
-  env RESOLVER=$TEST_NGINX_RESOLVER;
 --- http_config
   include $TEST_NGINX_UPSTREAM_CONFIG;
   lua_package_path "$TEST_NGINX_LUA_PATH";
@@ -835,7 +825,6 @@ Content-Type: application/json
 When an empty token TTL is received, Apicast applies a default of 7 days (604800 s)
 --- main_config
   env REDIS_HOST=$TEST_NGINX_REDIS_HOST;
-  env RESOLVER=$TEST_NGINX_RESOLVER;
   env APICAST_OAUTH_TOKENS_TTL=;
 --- http_config
   include $TEST_NGINX_UPSTREAM_CONFIG;

--- a/t/apicast-policy-rate-limit.t
+++ b/t/apicast-policy-rate-limit.t
@@ -5,7 +5,6 @@ use Cwd qw(abs_path);
 $ENV{TEST_NGINX_LUA_PATH} = "$Test::APIcast::spec/?.lua;$ENV{TEST_NGINX_LUA_PATH}";
 $ENV{TEST_NGINX_REDIS_HOST} ||= $ENV{REDIS_HOST} || "127.0.0.1";
 $ENV{TEST_NGINX_REDIS_PORT} ||= $ENV{REDIS_PORT} || 6379;
-$ENV{TEST_NGINX_RESOLVER} ||= `grep nameserver /etc/resolv.conf | awk '{print \$2}' | head -1 | tr '\n' ' '`;
 $ENV{BACKEND_ENDPOINT_OVERRIDE} ||= "http://127.0.0.1:$Test::Nginx::Util::ServerPortForClient/backend";
 
 our $rsa = `cat t/fixtures/rsa.pem`;
@@ -69,7 +68,6 @@ Return 200 code.
 
 --- config
   include $TEST_NGINX_APICAST_CONFIG;
-  resolver $TEST_NGINX_RESOLVER;
 
   location /transactions/authrep.xml {
     content_by_lua_block { ngx.exit(200) }
@@ -145,7 +143,6 @@ Return 200 code.
 
 --- config
   include $TEST_NGINX_APICAST_CONFIG;
-  resolver $TEST_NGINX_RESOLVER;
 
   location /transactions/authrep.xml {
     content_by_lua_block { ngx.exit(200) }
@@ -267,7 +264,6 @@ Return 200 code.
 
 --- config
   include $TEST_NGINX_APICAST_CONFIG;
-  resolver $TEST_NGINX_RESOLVER;
 
   location /flush_redis {
     content_by_lua_block {
@@ -384,7 +380,6 @@ Return 200 code.
 
 --- config
   include $TEST_NGINX_APICAST_CONFIG;
-  resolver $TEST_NGINX_RESOLVER;
 
   location /flush_redis {
     content_by_lua_block {
@@ -460,7 +455,6 @@ Return 429 code.
 
 --- config
   include $TEST_NGINX_APICAST_CONFIG;
-  resolver $TEST_NGINX_RESOLVER;
 
   location /flush_redis {
     content_by_lua_block {
@@ -520,7 +514,6 @@ Return 503 code.
 
 --- config
   include $TEST_NGINX_APICAST_CONFIG;
-  resolver $TEST_NGINX_RESOLVER;
 
   location /flush_redis {
     content_by_lua_block {
@@ -580,7 +573,6 @@ Return 429 code.
 
 --- config
   include $TEST_NGINX_APICAST_CONFIG;
-  resolver $TEST_NGINX_RESOLVER;
 
   location /flush_redis {
     content_by_lua_block {
@@ -655,7 +647,6 @@ Return 200 code.
 
 --- config
   include $TEST_NGINX_APICAST_CONFIG;
-  resolver $TEST_NGINX_RESOLVER;
 
   location /transactions/authrep.xml {
     content_by_lua_block { ngx.exit(200) }
@@ -716,7 +707,6 @@ Return 200 code.
 
 --- config
   include $TEST_NGINX_APICAST_CONFIG;
-  resolver $TEST_NGINX_RESOLVER;
 
   location /transactions/authrep.xml {
     content_by_lua_block { ngx.exit(200) }
@@ -1057,7 +1047,6 @@ so only the third call returns 429.
 
 --- config
   include $TEST_NGINX_APICAST_CONFIG;
-  resolver $TEST_NGINX_RESOLVER;
 
   location /flush_redis {
     content_by_lua_block {
@@ -1147,7 +1136,6 @@ so only the third call returns 429.
 
 --- config
   include $TEST_NGINX_APICAST_CONFIG;
-  resolver $TEST_NGINX_RESOLVER;
 
   location /flush_redis {
     content_by_lua_block {
@@ -1207,7 +1195,6 @@ and rejected properly.
 
 --- config
   include $TEST_NGINX_APICAST_CONFIG;
-  resolver $TEST_NGINX_RESOLVER;
 
   location /flush_redis {
     content_by_lua_block {


### PR DESCRIPTION
AKA airplane mode - when there is no network, there is no `/etc/resolv.conf`

All integration tests can be executed without network. Some busted tests require network, but can be skipped: `rover exec bin/busted --exclude-tags=network`.