### PR TITLE
[rate-limit] Use shdict when redis_url is empty in the same way as redis_url is null.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Load all policies into cache when starting APIcast master process. [PR #770](https://github.com/3scale/apicast/pull/770)
 - `init` and `init_worker` phases are executed on the policy module, not the instance of a policy with a configuration [PR #770](https://github.com/3scale/apicast/pull/770)
 - `timer_resolution` set only in development environment [PR #815](https://github.com/3scale/apicast/pull/815)
+- The rate-limit policy, when `redis_url` is empty, now applies per-gateway limits instead of trying to use a localhost Redis [PR #842](https://github.com/3scale/apicast/pull/842)
 
 ### Fixed
 

--- a/gateway/src/apicast/policy/rate_limit/rate_limit.lua
+++ b/gateway/src/apicast/policy/rate_limit/rate_limit.lua
@@ -141,7 +141,7 @@ end
 
 function _M:access(context)
   local red
-  if self.redis_url then
+  if self.redis_url and self.redis_url ~= '' then
     local rederr
     red, rederr = redis_shdict.new{ url = self.redis_url }
     if not red then

--- a/gateway/src/apicast/policy/rate_limit/rate_limit.lua
+++ b/gateway/src/apicast/policy/rate_limit/rate_limit.lua
@@ -224,7 +224,7 @@ local function checkin(_, ctx, time, semaphore, redis_url, error_settings)
   local latency = tonumber(time)
 
   local red
-  if redis_url then
+  if redis_url and redis_url ~= '' then
     local rederr
     red, rederr = redis_shdict.new{ url = redis_url }
     if not red then

--- a/spec/policy/rate_limit/rate_limit_spec.lua
+++ b/spec/policy/rate_limit/rate_limit_spec.lua
@@ -143,6 +143,17 @@ describe('Rate limit policy', function()
         assert.spy(ngx.exit).was_called_with(500)
       end)
 
+      it('redis url is empty', function()
+        local rate_limit_policy = RateLimitPolicy.new({
+          connection_limiters = {
+            { key = { name = 'test1', scope = 'global' }, conn = 20, burst = 10, delay = 0.5 }
+          },
+          redis_url = ''
+        })
+
+        assert(rate_limit_policy:access(context))
+      end)
+
       describe('rejection', function()
         it('rejected (conn)', function()
           local rate_limit_policy = RateLimitPolicy.new({

--- a/spec/policy/rate_limit/rate_limit_spec.lua
+++ b/spec/policy/rate_limit/rate_limit_spec.lua
@@ -339,6 +339,19 @@ describe('Rate limit policy', function()
 
         assert(rate_limit_policy:log())
       end)
+
+      it('success when redis url is empty', function()
+        local rate_limit_policy = RateLimitPolicy.new({
+          connection_limiters = {
+            { key = { name = 'test1', scope = 'global' }, conn = 20, burst = 10, delay = 0.5 }
+          },
+          redis_url = ''
+        })
+
+        assert(rate_limit_policy:access(context))
+
+        assert(rate_limit_policy:log())
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
Closes #834.