### PR TITLE
[cli] fix relative access/error log paths [THREESCALE-1090]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix case where debug headers are returned without enabling the option [PR #577](https://github.com/3scale/apicast/pull/577)
 - Fix errors loading openresty libraries when rover is active [PR #598](https://github.com/3scale/apicast/pull/598)
 - Passthrough "invalid" headers [PR #612](https://github.com/3scale/apicast/pull/612), [THREESCALE-630](https://issues.jboss.org/browse/THREESCALE-630)
+- Fix using relative path for access and error log [THREESCALE-1090](https://issues.jboss.org/browse/THREESCALE-1090)
 
 ### Changed
 

--- a/gateway/src/apicast/cli/command/start.lua
+++ b/gateway/src/apicast/cli/command/start.lua
@@ -175,6 +175,12 @@ end
 
 local load_env = split_by(':')
 
+local function abspath(path)
+    if not path then return nil end
+
+    return pl.path.abspath(path)
+end
+
 local function configure(cmd)
     cmd:option("--template", "Nginx config template.", 'conf/nginx.conf.liquid')
 
@@ -237,8 +243,8 @@ local function configure(cmd)
         :count(("0-%s"):format(_M.log_level - 1))
     )
     cmd:option('--log-level', 'Set log level', resty_env.value('APICAST_LOG_LEVEL') or 'warn')
-    cmd:option('--log-file', 'Set log file', resty_env.value('APICAST_LOG_FILE') or 'stderr')
-    cmd:option('--access-log-file', 'Set access log file', resty_env.value('APICAST_ACCESS_LOG_FILE') or '/dev/stdout')
+    cmd:option('--log-file', 'Set log file', abspath(resty_env.value('APICAST_LOG_FILE')) or 'stderr')
+    cmd:option('--access-log-file', 'Set access log file', abspath(resty_env.value('APICAST_ACCESS_LOG_FILE')) or '/dev/stdout')
 
     cmd:epilog([[
       Example: apicast start --dev


### PR DESCRIPTION
Expand the access/error log paths to absolue paths from the current directory.

Fixes https://issues.jboss.org/browse/THREESCALE-1090