### PR TITLE
[cli] fix logging to syslog

### DIFF
--- a/gateway/src/apicast/cli/command/start.lua
+++ b/gateway/src/apicast/cli/command/start.lua
@@ -7,6 +7,7 @@ local concat = table.concat
 local format = string.format
 local tostring = tostring
 local tonumber = tonumber
+local sub = string.sub
 
 local exec = require('resty.execvp')
 local resty_env = require('resty.env')
@@ -175,8 +176,14 @@ end
 
 local load_env = split_by(':')
 
+local function has_prefix(str, prefix)
+    return sub(str, 1, #prefix) == prefix
+end
+
 local function abspath(path)
     if not path then return nil end
+    if has_prefix(path, 'syslog:') then return path end
+    if has_prefix(path, 'memory:') then return path end
 
     return pl.path.abspath(path)
 end

--- a/gateway/src/apicast/policy/phase_logger/phase_logger.lua
+++ b/gateway/src/apicast/policy/phase_logger/phase_logger.lua
@@ -5,8 +5,37 @@
 local policy = require('apicast.policy')
 local _M = policy.new('Phase logger')
 
+local new = _M.new
+
+local log_levels = {
+  stderr = ngx.STDERR,
+  emerg = ngx.EMERG,
+  alert = ngx.ALERT,
+  crit = ngx.CRIT,
+  err = ngx.ERR,
+  error = ngx.ERR,
+  warn = ngx.WARN,
+  notice = ngx.NOTICE,
+  info = ngx.INFO,
+  debug = ngx.DEBUG,
+  default = ngx.DEBUG,
+}
+
+function _M.new(configuration)
+  local self = new(configuration)
+  local level
+
+  if configuration then
+    level = log_levels[configuration.log_level]
+  end
+
+  self.level = level or log_levels.default
+
+  return self
+end
+
 for _, phase in policy.phases() do
-  _M[phase] = function() ngx.log(ngx.DEBUG, 'running phase: ', phase) end
+  _M[phase] = function(self) ngx.log(self.level, 'running phase: ', phase) end
 end
 
 return _M

--- a/t/apicast-syslog.t
+++ b/t/apicast-syslog.t
@@ -1,0 +1,57 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+repeat_each(3);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: sends access logs to syslog
+--- env random_port eval
+(
+  'APICAST_ACCESS_LOG_FILE' => "syslog:server=127.0.0.1:$ENV{TEST_NGINX_RANDOM_PORT}",
+)
+--- configuration fixture=echo.json
+--- request
+GET /
+--- response_body
+GET / HTTP/1.1
+X-Real-IP: 127.0.0.1
+Host: echo
+--- error_code: 200
+--- udp_listen random_port env: $TEST_NGINX_RANDOM_PORT
+--- udp_query eval: qr{"GET / HTTP/1.1" 200}
+--- udp_reply
+
+
+
+=== TEST 2: sends error logs to syslog
+--- error_log_file env random_port eval
+"syslog:server=127.0.0.1:$ENV{TEST_NGINX_RANDOM_PORT}"
+--- log_level: emerg
+--- configuration
+{
+  "services": [{
+    "proxy": {
+      "policy_chain": [
+        {
+          "name": "apicast.policy.phase_logger",
+          "configuration": { "log_level": "emerg" }
+        },
+        { "name": "apicast.policy.upstream",
+          "configuration": { "rules": [ { "regex": "/", "url": "http://echo" } ] } }
+      ]
+    }
+  }]
+}
+--- request
+GET /
+--- response_body
+GET / HTTP/1.1
+X-Real-IP: 127.0.0.1
+Host: echo
+--- error_code: 200
+--- udp_listen random_port env: $TEST_NGINX_RANDOM_PORT
+--- udp_query eval: qr{\[lua\] phase_logger.lua:\d+: running phase: rewrite}
+--- udp_reply


### PR DESCRIPTION
Part of https://github.com/3scale/apicast/issues/712
Fixes issue introduced by https://github.com/3scale/apicast/pull/857

Log path starting with `syslog:` or `memory:` is not relative path, but
has to be passed to nginx unchanged.

For how to configure syslog see nginx documentation: http://nginx.org/en/docs/syslog.html