### PR TITLE
Change the display name of some policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `init` and `init_worker` phases are executed on the policy module, not the instance of a policy with a configuration [PR #770](https://github.com/3scale/apicast/pull/770)
 - `timer_resolution` set only in development environment [PR #815](https://github.com/3scale/apicast/pull/815)
 - The rate-limit policy, when `redis_url` is empty, now applies per-gateway limits instead of trying to use a localhost Redis [PR #842](https://github.com/3scale/apicast/pull/842)
+- Changed the display name of some policies. This only affects how the name shows in the UI [THREESCALE-1232](https://issues.jboss.org/browse/THREESCALE-1232)
 
 ### Fixed
 

--- a/gateway/src/apicast/policy/apicast/apicast-policy.json
+++ b/gateway/src/apicast/policy/apicast/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
-  "name": "APIcast",
+  "name": "3scale APIcast",
   "summary": "Main functionality of APIcast to work with the 3scale API manager.",
   "description":
     ["Main functionality of APIcast to work with the 3scale API ",

--- a/gateway/src/apicast/policy/caching/apicast-policy.json
+++ b/gateway/src/apicast/policy/caching/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
-  "name": "Caching",
+  "name": "3scale auth caching",
   "summary": "Controls how to cache authorizations returned by the 3scale backend.",
   "description":
     ["Configures a cache for the authentication calls against the 3scale ",

--- a/gateway/src/apicast/policy/conditional/apicast-policy.json
+++ b/gateway/src/apicast/policy/conditional/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
-  "name": "Conditional",
+  "name": "Conditional policy",
   "summary": "Executes a policy chain conditionally",
   "description": [
     "Evaluates a condition, and when it's true, it calls its policy chain."

--- a/gateway/src/apicast/policy/default_credentials/apicast-policy.json
+++ b/gateway/src/apicast/policy/default_credentials/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
-  "name": "Default credentials",
+  "name": "Anonymous access",
   "summary": "Provides default credentials for unauthenticated requests",
   "description":
     ["This policy allows to expose a service without authentication. ",

--- a/gateway/src/apicast/policy/headers/apicast-policy.json
+++ b/gateway/src/apicast/policy/headers/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
-  "name": "Headers",
+  "name": "Header modification",
   "summary": "Allows to include custom headers.",
   "description":
     ["This policy allows to include custom headers that will be sent to the ",

--- a/gateway/src/apicast/policy/keycloak_role_check/apicast-policy.json
+++ b/gateway/src/apicast/policy/keycloak_role_check/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
-  "name": "Keycloak Role Check",
+  "name": "RH-SSO/Keycloak role check",
   "summary": "Adds role check with Keycloak.",
   "description": [
     "This policy adds role check with Keycloak.\n",

--- a/gateway/src/apicast/policy/rate_limit/apicast-policy.json
+++ b/gateway/src/apicast/policy/rate_limit/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
-  "name": "Rate Limit",
+  "name": "Edge limiting",
   "summary": "Adds rate limit.",
   "description": ["This policy adds rate limit."],
   "version": "builtin",

--- a/gateway/src/apicast/policy/rewrite_url_captures/apicast-policy.json
+++ b/gateway/src/apicast/policy/rewrite_url_captures/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
-  "name": "Rewrite URL captures",
+  "name": "URL rewriting with captures",
   "summary": "Captures arguments in a URL and rewrites the URL using them",
   "description":
     ["Captures arguments in a URL and rewrites the URL using those arguments. ",


### PR DESCRIPTION
Changes the display name of some policies as per @MarkCheshire 's suggestions.
Notice that this does not break compatibility. It only affects how the name is shown in the UI.

Ref: https://issues.jboss.org/browse/THREESCALE-1232