### PR TITLE
[oidc] JWT validation according to the RFC 7523

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Fixed
+
+- Correct JWT validation according to [RFC 7523 Section 3](https://tools.ietf.org/html/rfc7523#section-3). Like not required `nbf` claim. [THREESCALE-583](https://issues.jboss.org/browse/THREESCALE-583)
+
 ## [3.3.0-beta1] - 2018-08-31
 
 ### Added

--- a/t/apicast-oidc.t
+++ b/t/apicast-oidc.t
@@ -52,7 +52,7 @@ to_json({
 use Crypt::JWT qw(encode_jwt);
 my $jwt = encode_jwt(payload => {
   aud => 'appid',
-  nbf => 0,
+  sub => 'someone',
   iss => 'https://example.com/auth/realms/apicast',
   exp => time + 3600 }, key => \$::private_key, alg => 'RS256', extra_headers => { kid => 'somekid' });
 "Authorization: Bearer $jwt"
@@ -107,7 +107,7 @@ to_json({
 use Crypt::JWT qw(encode_jwt);
 my $jwt = encode_jwt(payload => {
   aud => 'appid',
-  nbf => 0,
+  sub => 'someone',
   iss => 'https://example.com/auth/realms/apicast',
   exp => time + 3600 }, key => \$::private_key, alg => 'RS256', extra_headers => { kid => 'somekid' });
 ["Authorization: Bearer $jwt", "Authorization: Bearer $jwt"]

--- a/t/apicast-policy-headers.t
+++ b/t/apicast-policy-headers.t
@@ -593,7 +593,7 @@ GET /
 use Crypt::JWT qw(encode_jwt);
 my $jwt = encode_jwt(payload => {
   aud => 'the_token_audience',
-  nbf => 0,
+  sub => 'someone',
   iss => 'https://example.com/auth/realms/apicast',
   exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers=>{ kid => 'somekid' });
 "Authorization: Bearer $jwt"

--- a/t/apicast-policy-keycloak-role-check.t
+++ b/t/apicast-policy-keycloak-role-check.t
@@ -9,7 +9,7 @@ sub authorization_bearer_jwt (@) {
 
     my $jwt = encode_jwt(payload => {
         aud => $aud,
-        nbf => 0,
+        sub => 'someone',
         iss => 'https://example.com/auth/realms/apicast',
         exp => time + 3600,
         %$payload,

--- a/t/apicast-policy-rate-limit.t
+++ b/t/apicast-policy-rate-limit.t
@@ -1077,12 +1077,12 @@ so only the third call returns 429.
 use Crypt::JWT qw(encode_jwt);
 my $jwt1 = encode_jwt(payload => {
   aud => 'test17_1',
-  nbf => 0,
+  sub => 'someone',
   iss => 'https://example.com/auth/realms/apicast',
   exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers => { kid => 'somekid' });
 my $jwt2 = encode_jwt(payload => {
   aud => 'test17_2',
-  nbf => 0,
+  sub => 'someone',
   iss => 'https://example.com/auth/realms/apicast',
   exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers => { kid => 'somekid' });
 ["Authorization: Bearer $jwt1", "Authorization: Bearer $jwt1", "Authorization: Bearer $jwt2", "Authorization: Bearer $jwt1"]

--- a/t/apicast-policy-token-introspection.t
+++ b/t/apicast-policy-token-introspection.t
@@ -332,7 +332,7 @@ GET /echo
 use Crypt::JWT qw(encode_jwt);
 my $jwt = encode_jwt(payload => {
   aud => 'the_token_audience',
-  nbf => 0,
+  sub => 'someone',
   iss => 'https://example.com/auth/realms/apicast',
   exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers => { kid => 'somekid' });
 "Authorization: Bearer $jwt"


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7523#section-3

So for example, `nbf` is not required. Neither is `iat`. On the other hand `sub` claim is required now.
Discovered in https://issues.jboss.org/browse/THREESCALE-583?focusedCommentId=13627302&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13627302