### PR TITLE
[cli] do not crash when listing unaccessible directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Fixed
+
+- Capture permission errors when searching for files on filesystem [PR #865](https://github.com/3scale/apicast/pull/865)
+
 ## [3.3.0-beta1] - 2018-08-31
 
 ### Added

--- a/gateway/src/apicast/cli/filesystem.lua
+++ b/gateway/src/apicast/cli/filesystem.lua
@@ -13,6 +13,8 @@ local co_yield = coroutine.yield
 local co_create = coroutine.create
 local co_resume = coroutine.resume
 
+local noop = function () end
+
 --- Safely try to get directory iterator
 local function ldir(dir)
   local ok, iter, state = pcall(pl_path_dir, dir)
@@ -20,7 +22,8 @@ local function ldir(dir)
   if ok then
     return iter, state
   else
-    return nil, iter
+    ngx.log(ngx.DEBUG, 'error listing directory: ', dir, ' err: ', iter)
+    return noop
   end
 end
 


### PR DESCRIPTION
When the directory is not accessible, instead of crash like:

```
lua coroutine: runtime error: /opt/app-root/src/src/apicast/cli/filesystem.lua:50: attempt to call a nil value
```

Get a debug log like:
```
 /usr/local/share/lua/5.1/lfs.lua:513: cannot open /usr/local/openresty/nginx/fastcgi_temp : Permission denied
```