### PR TITLE
[oidc] always get issuer/iss from the OIDC Discovery endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Set default errlog level when `APICAST_LOG_LEVEL` is empty [PR #868](https://github.com/3scale/apicast/pull/868)
 - Correct JWT validation according to [RFC 7523 Section 3](https://tools.ietf.org/html/rfc7523#section-3). Like not required `nbf` claim. [THREESCALE-583](https://issues.jboss.org/browse/THREESCALE-583)
+- Mismatch in OIDC issuer when loading configuration through a configuration file [PR #872](https://github.com/3scale/apicast/pull/872)
 
 ## [3.3.0-beta2] - 2018-09-03
 

--- a/gateway/src/apicast/configuration_loader/oidc.lua
+++ b/gateway/src/apicast/configuration_loader/oidc.lua
@@ -19,17 +19,10 @@ end
 
 _M.discovery = require('resty.oidc.discovery').new()
 
-local function load_oidc(issuer)
-    local config = _M.discovery:openid_configuration(issuer)
-    local keys = _M.discovery:jwks(config)
-
-    return { issuer = issuer, config = config, keys = keys }
-end
-
 local function load_service(service)
     if not service or not service.proxy then return nil end
 
-    return load_oidc(service.proxy.oidc_issuer_endpoint)
+    return _M.discovery:call(service.proxy.oidc_issuer_endpoint)
 end
 
 function _M.call(...)

--- a/gateway/src/apicast/configuration_loader/remote_v2.lua
+++ b/gateway/src/apicast/configuration_loader/remote_v2.lua
@@ -238,15 +238,7 @@ function _M:services()
 end
 
 function _M:oidc_issuer_configuration(service)
-  local config = oidc_discovery.openid_configuration(self, service.oidc.issuer)
-
-  if config then
-    return {
-      config = config,
-      issuer = config.issuer,
-      keys = oidc_discovery.jwks(self, config)
-    }
-  end
+  return oidc_discovery.call(self, service.oidc.issuer)
 end
 
 function _M:config(service, environment, version)

--- a/gateway/src/resty/oidc/discovery.lua
+++ b/gateway/src/resty/oidc/discovery.lua
@@ -107,4 +107,20 @@ function _M:jwks(configuration)
     end
 end
 
+--- Fetch whole OIDC configuration through OIDC Discovery.
+-- @tparam string issuer URL to the Issuer (without the .well-known/openid-configuration)
+-- @treturn table
+function _M:call(issuer)
+    local http_client = self.http_client
+
+    if not http_client then
+        return nil, 'not initialized'
+    end
+
+    local config, err = _M.openid_configuration(self, issuer)
+    if not config then return nil, err end
+
+    return { config = config, issuer = config.issuer, keys = _M.jwks(self, config) }
+end
+
 return _M

--- a/spec/configuration_loader/oidc_spec.lua
+++ b/spec/configuration_loader/oidc_spec.lua
@@ -31,7 +31,7 @@ describe('OIDC Configuration loader', function()
     it('gets openid configuration', function()
       local config = {
         services = {
-          { id = 21, proxy = { oidc_issuer_endpoint = 'https://example.com' } },
+          { id = 21, proxy = { oidc_issuer_endpoint = 'https://user:pass@example.com' } },
         }
       }
 
@@ -40,7 +40,7 @@ describe('OIDC Configuration loader', function()
         .respond_with{
           status = 200,
           headers = { content_type = 'application/json' },
-          body = [[{"jwks_uri":"http://example.com/jwks"}]],
+          body = [[{"jwks_uri":"http://example.com/jwks","issuer":"https://example.com"}]],
         }
 
       test_backend
@@ -52,7 +52,7 @@ describe('OIDC Configuration loader', function()
         }
       local oidc = loader.call(cjson.encode(config))
 
-      assert.same([[{"services":[{"id":21,"proxy":{"oidc_issuer_endpoint":"https:\/\/example.com"}}],"oidc":[{"issuer":"https:\/\/example.com","config":{"jwks_uri":"http:\/\/example.com\/jwks"},"keys":{}}]}]], oidc)
+      assert.same([[{"services":[{"id":21,"proxy":{"oidc_issuer_endpoint":"https:\/\/user:pass@example.com"}}],"oidc":[{"issuer":"https:\/\/example.com","config":{"jwks_uri":"http:\/\/example.com\/jwks","issuer":"https:\/\/example.com"},"keys":{}}]}]], oidc)
     end)
   end)
 end)

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -177,7 +177,7 @@ describe('Configuration Remote Loader V2', function()
                   environment = 'sandbox',
                   content = {
                     id = 42, backend_version = 1,
-                    proxy = { oidc_issuer_endpoint = 'http://idp.example.com/auth/realms/foo/' }
+                    proxy = { oidc_issuer_endpoint = 'http://user:pass@idp.example.com/auth/realms/foo/' }
                   }
                 }
               }


### PR DESCRIPTION
So later when the token is verified it can be an exact match.
Before the URL could be different due to some reverse proxies or
credentials embedded in the URL.

/cc @mayorova 