### PR TITLE
Add a log message when token introspection finds that the token is not active

### DIFF
--- a/gateway/src/apicast/policy/token_introspection/token_introspection.lua
+++ b/gateway/src/apicast/policy/token_introspection/token_introspection.lua
@@ -103,6 +103,7 @@ function _M:access(context)
     --- Introspection Response must have an "active" boolean value.
     -- https://tools.ietf.org/html/rfc7662#section-2.2
     if not introspect_token(self, access_token).active == true then
+      ngx.log(ngx.INFO, 'token introspection for access token ', access_token, ': token not active')
       ngx.status = context.service.auth_failed_status
       ngx.say(context.service.error_auth_failed)
       return ngx.exit(ngx.status)

--- a/t/apicast-policy-token-introspection.t
+++ b/t/apicast-policy-token-introspection.t
@@ -111,6 +111,9 @@ Authorization: Bearer testaccesstoken
 --- error_code: 403
 --- no_error_log
 [error]
+--- error_log: token introspection for access token testaccesstoken: token not active
+
+
 
 === TEST 3: Token introspection request is failed due to IdP error
 Token introspection policy return "403 Unauthorized" if IdP response error status.


### PR DESCRIPTION
This is to facilitate troubleshooting when you get a "Authentication failed" with Token Introspection policy enabled.