### PR TITLE
Improve policy descriptions

### DIFF
--- a/gateway/src/apicast/policy/3scale_referrer/apicast-policy.json
+++ b/gateway/src/apicast/policy/3scale_referrer/apicast-policy.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
   "name": "3scale Referrer",
-  "summary": "Sends the 'Referer' to 3scale backend so it can be validated",
+  "summary": "Sends the 'Referer' to 3scale backend so it can be validated.",
   "description": "Sends the 'Referer' to 3scale backend so it can be validated",
   "version": "builtin",
   "configuration": {

--- a/gateway/src/apicast/policy/conditional/apicast-policy.json
+++ b/gateway/src/apicast/policy/conditional/apicast-policy.json
@@ -3,7 +3,8 @@
   "name": "Conditional policy",
   "summary": "Executes a policy chain conditionally.",
   "description": [
-    "Evaluates a condition, and when it's true, it calls its policy chain."
+    "Evaluates a condition, and when it's true, it calls its policy chain. ",
+    "This policy cannot be configured from the 3scale UI."
   ],
   "version": "builtin",
   "configuration": {

--- a/gateway/src/apicast/policy/conditional/apicast-policy.json
+++ b/gateway/src/apicast/policy/conditional/apicast-policy.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
   "name": "Conditional policy",
-  "summary": "Executes a policy chain conditionally",
+  "summary": "Executes a policy chain conditionally.",
   "description": [
     "Evaluates a condition, and when it's true, it calls its policy chain."
   ],

--- a/gateway/src/apicast/policy/default_credentials/apicast-policy.json
+++ b/gateway/src/apicast/policy/default_credentials/apicast-policy.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
   "name": "Anonymous access",
-  "summary": "Provides default credentials for unauthenticated requests",
+  "summary": "Provides default credentials for unauthenticated requests.",
   "description":
     ["This policy allows to expose a service without authentication. ",
      "It can be useful, for example, for legacy apps that cannot be adapted to ",

--- a/gateway/src/apicast/policy/logging/apicast-policy.json
+++ b/gateway/src/apicast/policy/logging/apicast-policy.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
   "name": "Logging",
-  "summary": "Controls logging",
+  "summary": "Controls logging.",
   "description": [
     "Controls logging. It allows to enable and disable access logs per ",
     "service."

--- a/gateway/src/apicast/policy/rewrite_url_captures/apicast-policy.json
+++ b/gateway/src/apicast/policy/rewrite_url_captures/apicast-policy.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
   "name": "URL rewriting with captures",
-  "summary": "Captures arguments in a URL and rewrites the URL using them",
+  "summary": "Captures arguments in a URL and rewrites the URL using them.",
   "description":
     ["Captures arguments in a URL and rewrites the URL using those arguments. ",
      "For example, we can specify a matching rule with arguments like ",


### PR DESCRIPTION
2 minor changes:
- Make sure all the summaries end with a '.'. Just for consistency in the UI.
- Clarify that the conditional policy cannot be configured in the UI.