### PR TITLE
Add Prometheus metrics for the 3scale batching policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Prometheus metrics for the 3scale batching policy [PR #902](https://github.com/3scale/apicast/pull/902)
+
 ## [3.3.0-cr1] - 2018-09-14
 
 ### Fixed

--- a/gateway/src/apicast/policy/3scale_batcher/metrics.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/metrics.lua
@@ -1,0 +1,34 @@
+local prometheus = require('apicast.prometheus')
+
+local _M = {}
+
+local auth_cache_hits = prometheus(
+  'counter',
+  'batching_policy_auths_cache_hits',
+  'Hits in the auths cache of the 3scale batching policy'
+)
+
+local auth_cache_misses = prometheus(
+  'counter',
+  'batching_policy_auths_cache_misses',
+  "Misses in the auths cache of the 3scale batching policy"
+)
+
+local function inc_auth_cache_hits()
+  return auth_cache_hits and auth_cache_hits:inc()
+end
+
+local function inc_auth_cache_misses()
+  return auth_cache_misses and auth_cache_misses:inc()
+end
+
+local func_update_counters = {
+  [true] = inc_auth_cache_hits,
+  [false] = inc_auth_cache_misses
+}
+
+function _M.update_cache_counters(cache_hit)
+  func_update_counters[cache_hit]()
+end
+
+return _M


### PR DESCRIPTION
This PR adds a couple of metrics for the 3scale batching policy:

```
# HELP batching_policy_auths_cache_hits Hits in the auths cache of the 3scale batching policy
# TYPE batching_policy_auths_cache_hits counter
batching_policy_auths_cache_hits 2
# HELP batching_policy_auths_cache_misses Misses in the auths cache of the 3scale batching policy
# TYPE batching_policy_auths_cache_misses counter
batching_policy_auths_cache_misses 1
```

Part of #745 