### PR TITLE
metrics: rename backend_response to threescale_backend_response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Prometheus metrics for the 3scale batching policy [PR #902](https://github.com/3scale/apicast/pull/902)
 - Support for path in the upstream URL [PR #905](https://github.com/3scale/apicast/pull/905)
 
+### Changed
+
+- Renamed the `backend_response` Prometheus metric to `threescale_backend_response` to avoid confusion with the upstream response [PR #917](https://github.com/3scale/apicast/pull/917)
+
 ## [3.3.0-cr2] - 2018-09-25
 
 ### Fixed

--- a/gateway/src/apicast/metrics/3scale_backend_status.lua
+++ b/gateway/src/apicast/metrics/3scale_backend_status.lua
@@ -7,7 +7,7 @@ local _M = {}
 
 local backend_response_metric = prometheus(
   'counter',
-  'backend_response',
+  'threescale_backend_response',
   "Response status codes from 3scale's backend",
   { 'status' }
 )

--- a/t/prometheus-metrics.t
+++ b/t/prometheus-metrics.t
@@ -108,13 +108,13 @@ that does not include the nginx metrics (tested in the previous test).
 --- response_body eval
 [ "yay, api backend\x{0a}", "yay, api backend\x{0a}", "Authentication failed", "Authentication failed",
 <<'METRICS_OUTPUT'
-# HELP backend_response Response status codes from 3scale's backend
-# TYPE backend_response counter
-backend_response{status="2xx"} 2
-backend_response{status="4xx"} 2
 # HELP nginx_metric_errors_total Number of nginx-lua-prometheus errors
 # TYPE nginx_metric_errors_total counter
 nginx_metric_errors_total 0
+# HELP threescale_backend_response Response status codes from 3scale's backend
+# TYPE threescale_backend_response counter
+threescale_backend_response{status="2xx"} 2
+threescale_backend_response{status="4xx"} 2
 METRICS_OUTPUT
 ]
 --- no_error_log
@@ -174,9 +174,6 @@ We use and env file without the nginx metrics to simplify the output of the
 --- response_body eval
 [ "yay, api backend\x{0a}", "yay, api backend\x{0a}", "yay, api backend\x{0a}",
 <<'METRICS_OUTPUT'
-# HELP backend_response Response status codes from 3scale's backend
-# TYPE backend_response counter
-backend_response{status="2xx"} 1
 # HELP batching_policy_auths_cache_hits Hits in the auths cache of the 3scale batching policy
 # TYPE batching_policy_auths_cache_hits counter
 batching_policy_auths_cache_hits 2
@@ -186,6 +183,9 @@ batching_policy_auths_cache_misses 1
 # HELP nginx_metric_errors_total Number of nginx-lua-prometheus errors
 # TYPE nginx_metric_errors_total counter
 nginx_metric_errors_total 0
+# HELP threescale_backend_response Response status codes from 3scale's backend
+# TYPE threescale_backend_response counter
+threescale_backend_response{status="2xx"} 1
 METRICS_OUTPUT
 ]
 --- no_error_log


### PR DESCRIPTION
To clearly distinguish it from the upstream API as suggested in https://github.com/3scale/apicast/issues/745#issuecomment-419365339