### PR TITLE
Add missing semicolon in proxy SSL settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `APICAST_PROXY_HTTPS_PASSWORD_FILE` and `APICAST_PROXY_HTTPS_SESSION_REUSE` parameters for Mutual SSL [PR #927](https://github.com/3scale/apicast/pull/927)
+
 ### Added
 
 - Prometheus metrics for: the 3scale batching policy and the upstream API [PR #902](https://github.com/3scale/apicast/pull/902), [PR #918](https://github.com/3scale/apicast/pull/918)

--- a/gateway/conf.d/apicast.conf
+++ b/gateway/conf.d/apicast.conf
@@ -102,14 +102,14 @@ location @upstream {
   #
   #   {% if proxy_ssl_password_file != empty %}
   #     {% capture proxy_ssl %}
-  #{#}   proxy_ssl_password_file {{ proxy_ssl_password_file }}
+  #{#}   proxy_ssl_password_file {{ proxy_ssl_password_file }};
   #     {% endcapture %}
   #   {{ proxy_ssl | replace: "#{#}", "" }}
   #   {% endif %}
   #
   #   {% if proxy_ssl_session_reuse != empty %}
   #     {% capture proxy_ssl %}
-  #{#}   proxy_ssl_session_reuse {{ proxy_ssl_session_reuse }}
+  #{#}   proxy_ssl_session_reuse {{ proxy_ssl_session_reuse }};
   #     {% endcapture %}
   #   {{ proxy_ssl | replace: "#{#}", "" }}
   #   {% endif %}

--- a/t/mutual-ssl.t
+++ b/t/mutual-ssl.t
@@ -4,118 +4,15 @@ use Test::APIcast::Blackbox 'no_plan';
 env_to_apicast(
     'APICAST_PROXY_HTTPS_CERTIFICATE' => "$Test::Nginx::Util::ServRoot/html/client.crt",
     'APICAST_PROXY_HTTPS_CERTIFICATE_KEY' => "$Test::Nginx::Util::ServRoot/html/client.key",
+    'APICAST_PROXY_HTTPS_PASSWORD_FILE' => "$Test::Nginx::Util::ServRoot/html/passwords.file",
+    'APICAST_PROXY_HTTPS_SESSION_REUSE' => 'on',
 );
 
 run_tests();
 
 __DATA__
-=== TEST 1: mutual SSL
---- ssl random_port
---- configuration
-{
-  "services": [
-    {
-      "id": 42,
-      "backend_version":  1,
-      "backend_authentication_type": "service_token",
-      "backend_authentication_value": "token-value",
-      "proxy": {
-        "api_backend": "https://test:$TEST_NGINX_RANDOM_PORT/",
-        "proxy_rules": [
-          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
-        ]
-      }
-    }
-  ]
-}
---- backend
-  location /transactions/authrep.xml {
-    content_by_lua_block {
-        ngx.exit(200)
-    }
-  }
---- upstream env
-  listen $TEST_NGINX_RANDOM_PORT ssl;
 
-  ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
-  ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
-
-  ssl_client_certificate $TEST_NGINX_SERVER_ROOT/html/client.crt;
-  ssl_verify_client on;
-
-  location / {
-     echo 'ssl_client_s_dn: $ssl_client_s_dn';
-     echo 'ssl_client_i_dn: $ssl_client_i_dn';
-  }
---- request
-GET /?user_key=uk
---- response_body
-ssl_client_s_dn: O=Internet Widgits Pty Ltd,ST=Some-State,C=AU
-ssl_client_i_dn: O=Internet Widgits Pty Ltd,ST=Some-State,C=AU
---- error_code: 200
---- no_error_log
-[error]
---- user_files
->>> server.crt
------BEGIN CERTIFICATE-----
-MIIB0DCCAXegAwIBAgIJAISY+WDXX2w5MAoGCCqGSM49BAMCMEUxCzAJBgNVBAYT
-AkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRn
-aXRzIFB0eSBMdGQwHhcNMTYxMjIzMDg1MDExWhcNMjYxMjIxMDg1MDExWjBFMQsw
-CQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJu
-ZXQgV2lkZ2l0cyBQdHkgTHRkMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhkmo
-6Xp/9W9cGaoGFU7TaBFXOUkZxYbGXQfxyZZucIQPt89+4r1cbx0wVEzbYK5wRb7U
-iWhvvvYDltIzsD75vqNQME4wHQYDVR0OBBYEFOBBS7ZF8Km2wGuLNoXFAcj0Tz1D
-MB8GA1UdIwQYMBaAFOBBS7ZF8Km2wGuLNoXFAcj0Tz1DMAwGA1UdEwQFMAMBAf8w
-CgYIKoZIzj0EAwIDRwAwRAIgZ54vooA5Eb91XmhsIBbp12u7cg1qYXNuSh8zih2g
-QWUCIGTHhoBXUzsEbVh302fg7bfRKPCi/mcPfpFICwrmoooh
------END CERTIFICATE-----
->>> server.key
------BEGIN EC PARAMETERS-----
-BggqhkjOPQMBBw==
------END EC PARAMETERS-----
------BEGIN EC PRIVATE KEY-----
-MHcCAQEEIFCV3VwLEFKz9+yTR5vzonmLPYO/fUvZiMVU1Hb11nN8oAoGCCqGSM49
-AwEHoUQDQgAEhkmo6Xp/9W9cGaoGFU7TaBFXOUkZxYbGXQfxyZZucIQPt89+4r1c
-bx0wVEzbYK5wRb7UiWhvvvYDltIzsD75vg==
------END EC PRIVATE KEY-----
->>> client.crt
------BEGIN CERTIFICATE-----
-MIICWDCCAcGgAwIBAgIJAN52KeMKGGq9MA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
-BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
-aWRnaXRzIFB0eSBMdGQwHhcNMTgwMjE5MTQ0MzE4WhcNMTkwMjE5MTQ0MzE4WjBF
-MQswCQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50
-ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKB
-gQC7b4gs1UsUI1akyeUdCF8RMHQhjf9XKMwGTc85RML+cLEl5MASYCOC5iE5/9Rv
-hLcgcRdJr1A/blLhK1NZOPVzI9fYFn5zTjxG94Pv11kIcvYLoJeZT1zlvCBsz2Ak
-tzK31QRXvkpn3ZikUQVflV5ArzFrIdxPNelVDMk1dwBejwIDAQABo1AwTjAdBgNV
-HQ4EFgQUoZwBPUe+E0r8/UTPJtJzntVvx44wHwYDVR0jBBgwFoAUoZwBPUe+E0r8
-/UTPJtJzntVvx44wDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOBgQBjVV6h
-fhZCNpzu9odus6uXiTGjAm2FJlpncxPw9lseKLljy2hm4dq94GYr1gFoMR7KmE+k
-Bp1RMO59vZd7TtrQ4d2t898mif04CCiQz1BeJ3cSvE+vhHJLmL+ImHh9uKFdmcg6
-MT5sX28flpZvErxsqjJ/bhKyd2R+WVuYWaoyfw==
------END CERTIFICATE-----
->>> client.key
------BEGIN RSA PRIVATE KEY-----
-MIICXgIBAAKBgQC7b4gs1UsUI1akyeUdCF8RMHQhjf9XKMwGTc85RML+cLEl5MAS
-YCOC5iE5/9RvhLcgcRdJr1A/blLhK1NZOPVzI9fYFn5zTjxG94Pv11kIcvYLoJeZ
-T1zlvCBsz2AktzK31QRXvkpn3ZikUQVflV5ArzFrIdxPNelVDMk1dwBejwIDAQAB
-AoGBALZHctDW5NrCuyIqzct8NqfKzUVMiINEw5Vl2h7BhjhXc498dGXqZN6J2spC
-x19kW4sLMDCSc6IcMjGUJsxgHiGecloLHYnFz4faJpgNMjpu0vmz66qy/QnCy5Rf
-/g5mtQUhEkpivi9q4Thqxc2v8Y3g95D4boYYX7qNRq9jX52BAkEA6EMZOErUGIot
-vOAYSSOtkqE6di3gVqVaSk2kHjujO5AMcjhTiNv5bMrPUEOfR+JQE97XSqymfWdg
-TT7YvDt1bwJBAM6XmHA56qE7wpL9SwERlXOX/4fiTRzWDXEL+htoErMPYs/aPume
-NJBXLoTfgUghAKvhsUyMSCv/EHenGl+gWOECQQCII3xO4J19XND+WqQhisYcomBw
-EOfkIbvQvb2q8u305bRF5vofyEBlImNt+pUMP30MiJvM63ITI1rxLBtCCeAFAkA2
-Fk5co20gRUsNvK7UWswr9VF7O+5AbHIcdKxIXJj4tECEdnkeJMNSPuD4/KMWRT2t
-wmruxZNnoWGoUeF/w7VBAkEAz02rLKfeCShkbJd5f0qx0cubG/2lznrMvSBoI2ix
-itRV3G/wOHrsK9k06jx2L/+/YTUWcyzTm8B7Y34CTHGaHQ==
------END RSA PRIVATE KEY-----
-
-=== TEST 2: Mutual SSL with password file
---- env eval
-(
-  'APICAST_PROXY_HTTPS_PASSWORD_FILE' => "$Test::Nginx::Util::ServRoot/html/passwords.file"
-)
+=== TEST 1: Mutual SSL with password file
 --- ssl random_port
 --- configuration
 {

--- a/t/mutual-ssl.t
+++ b/t/mutual-ssl.t
@@ -110,3 +110,112 @@ Fk5co20gRUsNvK7UWswr9VF7O+5AbHIcdKxIXJj4tECEdnkeJMNSPuD4/KMWRT2t
 wmruxZNnoWGoUeF/w7VBAkEAz02rLKfeCShkbJd5f0qx0cubG/2lznrMvSBoI2ix
 itRV3G/wOHrsK9k06jx2L/+/YTUWcyzTm8B7Y34CTHGaHQ==
 -----END RSA PRIVATE KEY-----
+
+=== TEST 2: Mutual SSL with password file
+--- env eval
+(
+  'APICAST_PROXY_HTTPS_PASSWORD_FILE' => "$Test::Nginx::Util::ServRoot/html/passwords.file"
+)
+--- ssl random_port
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "https://test:$TEST_NGINX_RANDOM_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+        ngx.exit(200)
+    }
+  }
+--- upstream env
+  listen $TEST_NGINX_RANDOM_PORT ssl;
+
+  ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+  ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+  ssl_client_certificate $TEST_NGINX_SERVER_ROOT/html/client.crt;
+  ssl_verify_client on;
+
+  location / {
+     echo 'ssl_client_s_dn: $ssl_client_s_dn';
+     echo 'ssl_client_i_dn: $ssl_client_i_dn';
+  }
+--- request
+GET /?user_key=uk
+--- response_body
+ssl_client_s_dn: O=Internet Widgits Pty Ltd,ST=Some-State,C=AU
+ssl_client_i_dn: O=Internet Widgits Pty Ltd,ST=Some-State,C=AU
+--- error_code: 200
+--- no_error_log
+[error]
+--- user_files
+>>> server.crt
+-----BEGIN CERTIFICATE-----
+MIIB0DCCAXegAwIBAgIJAISY+WDXX2w5MAoGCCqGSM49BAMCMEUxCzAJBgNVBAYT
+AkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRn
+aXRzIFB0eSBMdGQwHhcNMTYxMjIzMDg1MDExWhcNMjYxMjIxMDg1MDExWjBFMQsw
+CQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJu
+ZXQgV2lkZ2l0cyBQdHkgTHRkMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhkmo
+6Xp/9W9cGaoGFU7TaBFXOUkZxYbGXQfxyZZucIQPt89+4r1cbx0wVEzbYK5wRb7U
+iWhvvvYDltIzsD75vqNQME4wHQYDVR0OBBYEFOBBS7ZF8Km2wGuLNoXFAcj0Tz1D
+MB8GA1UdIwQYMBaAFOBBS7ZF8Km2wGuLNoXFAcj0Tz1DMAwGA1UdEwQFMAMBAf8w
+CgYIKoZIzj0EAwIDRwAwRAIgZ54vooA5Eb91XmhsIBbp12u7cg1qYXNuSh8zih2g
+QWUCIGTHhoBXUzsEbVh302fg7bfRKPCi/mcPfpFICwrmoooh
+-----END CERTIFICATE-----
+>>> server.key
+-----BEGIN EC PARAMETERS-----
+BggqhkjOPQMBBw==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIFCV3VwLEFKz9+yTR5vzonmLPYO/fUvZiMVU1Hb11nN8oAoGCCqGSM49
+AwEHoUQDQgAEhkmo6Xp/9W9cGaoGFU7TaBFXOUkZxYbGXQfxyZZucIQPt89+4r1c
+bx0wVEzbYK5wRb7UiWhvvvYDltIzsD75vg==
+-----END EC PRIVATE KEY-----
+>>> client.crt
+-----BEGIN CERTIFICATE-----
+MIICATCCAWoCCQCoHzh0BKl/SzANBgkqhkiG9w0BAQsFADBFMQswCQYDVQQGEwJB
+VTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJuZXQgV2lkZ2l0
+cyBQdHkgTHRkMB4XDTE4MTAwNzIxMjIwNFoXDTE4MTEwNjIxMjIwNFowRTELMAkG
+A1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoMGEludGVybmV0
+IFdpZGdpdHMgUHR5IEx0ZDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEArV2H
+7BjV1lmnLDhr64H7Gd5Ui3GtHgmPF4iMuQq82VWNY/CZV+ZHAWNcemszqTmsoFOA
+hYuyax8LnkygeNPyURptunfTTRU9NMcSdFSQRUmrrr5deo6jW2wxqhcFG8yEVKRm
+88lu7NIiu33wpao+pt6PeOTEatHFi3YfvVHq0oECAwEAATANBgkqhkiG9w0BAQsF
+AAOBgQDHGkUXUMbugBe81LsvfHeqOCxyGZKyTlgjIj2lFp30tBz6V7sn+jMfwXj4
+GhZVbFEGydm0JWjW75qZUMfn1bL91rpMgP0bi3VyTLDZsd2aElilHPrY6mURTAIJ
+BXfZnEfbCHituhhhsiPwmTmX/1Eot8oJK2CcZyVsmxlhCzMogQ==
+-----END CERTIFICATE-----
+>>> client.key
+-----BEGIN RSA PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: DES-EDE3-CBC,53539C1EC3FAFCA8
+
+OOnYq1xGINyVT8IKN/soLSPsXIf4fzHPiXe44cVw3NY0G+WG5BmEoHTCNufwRxer
+iCaOBa5vAkNmpAxLp2zHUHagEiL0YiWPFKYtE8r1hVxeMX80Ki7OIvX/4ts6fnfs
+YN5zjy2GEas4Hoz8XHafHwroC+GknqJi8qbf1PeG/liRCdZAJsF98OjH2CUqhC1y
+0dxG8HujUXmheaTLlWqTO175AKvIvarBO9FuyVZVe4qiTbciT0KwWmddM0XCnLOB
+vSfExf1yD4klblx14DrvqhR1OO/vGVnecCQZXz0VLBNCBST1aGB50gXJjPiIFx9L
+cEEOA0QEV8gN/aQ9J0+Pd4aYbvVXu9gaoGkJUTFHg5W/iUbH3luOe34FMdRzwR0i
+bYq9fQ2074c3zYOcI4WzmShVv6qzFDSz2KiStqGriS63s/5FenQgWEjHK4ImmQ81
+G0lFs9pnbD8sGjYkJSX5um3z+9OoW0KZnFKrCpILDnpexmkitwgDr6KWU4YTZ05p
+FWBqCd6pjxuNbdg3sJsofjWPwbPU954ksloajVXRrHHDNjnyB80ZCdtavLl2ZFO/
+p8KYIrMBD1zNZtR1p2+W0mrGk9cE1fjOhwEznxsPw8FvSdC8KflYtjiGcihcHxS5
+Nq/j/ftw3ptIenOsGw7pCE5FJHFdxGefkJCSx03/OIzuoVn5mMXDkvt7jmE2rOuJ
+DNuuQcnqN7YovLuLuwI/6DBxhd5nUWCBIDNo3sEUPXZY7Q0zmGHUPrBNFnKEXkKi
+aQ6jARTSQ8kxNlhq0qwVE0oq9eFfZLm6ANpwr6U/+dQ=
+-----END RSA PRIVATE KEY-----
+>>> passwords.file
+password


### PR DESCRIPTION
Starting APIcast with `APICAST_PROXY_HTTPS_PASSWORD_FILE` was failing with:
~~~
nginx: [emerg] invalid number of arguments in "proxy_ssl_password_file" directive in /tmp/lua_At34WX:455
~~~

Apparently, it's because of the missing `;` in the end of the directive.

The same for `proxy_ssl_session_reuse`, although I didn't really try it.
