### PR TITLE
Add "Retry-After" header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - OIDC Authentication policy (only usable directly by the configuration file) [PR #904](https://github.com/3scale/apicast/pull/904)
 - IP check policy. This policy allows to accept or deny requests based on the IP [PR #907](https://github.com/3scale/apicast/pull/907), [PR #923](https://github.com/3scale/apicast/pull/923), [THREESCALE-1353](https://issues.jboss.org/browse/THREESCALE-1353)
 - Delete operation in the headers policy [PR #928](https://github.com/3scale/apicast/pull/928), [THREESCALE-1354](https://issues.jboss.org/browse/THREESCALE-1354)
+- "Retry-After" header in the response when rate-limited by the 3scale backend [PR #929](https://github.com/3scale/apicast/pull/929), [THREESCALE-1380](https://issues.jboss.org/browse/THREESCALE-1380)
 
 ### Changed
 

--- a/gateway/src/apicast/backend_client.lua
+++ b/gateway/src/apicast/backend_client.lua
@@ -158,15 +158,21 @@ local function create_token_path(service_id)
 end
 
 -- Returns the authorize options that 3scale backend accepts. Those options
--- are specified via headers. Right now there are 2:
+-- are specified via headers:
 --  - rejection_reason_header: asks backend to return why a call is denied
 --    (limits exceeded, application key invalid, etc.)
---  - no_nody: when enabled, backend will not return a response body. The
+--  - no_body: when enabled, backend will not return a response body. The
 --    body has many information like metrics, limits, etc. This information is
 --    parsed only when using oauth. By enabling this option will save some work
 --    to the 3scale backend and reduce network traffic.
+--  - limit_headers: when enabled and the request is rate-limited, backend
+--    returns the number of seconds remaining until the limit expires. It
+--    returns -1 when there are no limits. With this header, backend returns
+--    more information but we do not need it for now.
+-- For the complete specs check:
+-- https://github.com/3scale/apisonator/blob/master/docs/extensions.md
 local function authorize_options(using_oauth)
-  local headers = { ['3scale-options'] = 'rejection_reason_header=1' }
+  local headers = { ['3scale-options'] = 'rejection_reason_header=1&limit_headers=1' }
 
   if not using_oauth then
     headers['3scale-options'] = headers['3scale-options'] .. '&no_body=1'

--- a/gateway/src/apicast/errors.lua
+++ b/gateway/src/apicast/errors.lua
@@ -22,9 +22,14 @@ function _M.authorization_failed(service)
   return exit()
 end
 
-function _M.limits_exceeded(service)
+function _M.limits_exceeded(service, retry_after)
   ngx.log(ngx.INFO, 'limits exceeded for service ', service.id)
   ngx.var.cached_key = nil
+
+  if retry_after then
+    ngx.header['Retry-After'] = retry_after
+  end
+
   ngx.status = service.limits_exceeded_status
   ngx.header.content_type = service.limits_exceeded_headers
   ngx.print(service.error_limits_exceeded)

--- a/spec/backend_client_spec.lua
+++ b/spec/backend_client_spec.lua
@@ -7,8 +7,8 @@ local backend_calls_metrics = require 'apicast.metrics.3scale_backend_calls'
 describe('backend client', function()
 
   local test_backend
-  local options_header_oauth = 'rejection_reason_header=1'
-  local options_header_no_oauth = 'rejection_reason_header=1&no_body=1'
+  local options_header_oauth = 'rejection_reason_header=1&limit_headers=1'
+  local options_header_no_oauth = 'rejection_reason_header=1&limit_headers=1&no_body=1'
 
   before_each(function()
     test_backend = http_ng.backend()

--- a/spec/errors_spec.lua
+++ b/spec/errors_spec.lua
@@ -1,0 +1,27 @@
+local errors = require 'apicast.errors'
+local Service = require 'apicast.configuration.service'
+
+describe('Errors', function()
+  describe('.limits_exceeded', function()
+    before_each(function()
+      ngx.var = {}
+      ngx.header = {}
+    end)
+
+    local test_service = Service.new({ id = 1 })
+
+    it('sets the Retry-After header when a value for it is received', function()
+      local retry_after = 60
+
+      errors.limits_exceeded(test_service, retry_after)
+
+      assert.equals(retry_after, ngx.header['Retry-After'])
+    end)
+
+    it('does not set the Retry-After header when a value for it is not received', function()
+      errors.limits_exceeded(test_service)
+
+      assert.is_nil(ngx.header['Retry-After'])
+    end)
+  end)
+end)


### PR DESCRIPTION
Part of #335 

This PR introduces a "Retry-After" header in the APIcast response.
When rate-limited by the 3scale backend, APIcast returns the number of seconds that the caller needs to wait before it's authorized again in the "Retry-After" header.