### PR TITLE
[THREESCALE-1396] Fix "allow" mode of the caching policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix `APICAST_PROXY_HTTPS_PASSWORD_FILE` and `APICAST_PROXY_HTTPS_SESSION_REUSE` parameters for Mutual SSL [PR #927](https://github.com/3scale/apicast/pull/927)
+- The "allow" mode of the caching policy now accepts the request when it's authorization is not cached [PR #934](https://github.com/3scale/apicast/pull/934), [THREESCALE-1396](https://issues.jboss.org/browse/THREESCALE-1396)
 
 ### Added
 

--- a/t/apicast-policy-caching.t
+++ b/t/apicast-policy-caching.t
@@ -179,9 +179,8 @@ auth error in the odd ones.
 [ 200, 403, 200, 403 ]
 
 === TEST 4: Caching policy configured as 'allow' with unseen request
-When the cache is configured as 'allow', all requests after the first one will
-be authorized when backend returns a 5XX if they do not have a 'denied' entry
-in the cache.
+When the cache is configured as 'allow', all requests are authorized when
+backend returns a 5XX if they do not have a 'denied' entry in the cache.
 --- configuration
 {
   "services": [
@@ -221,9 +220,9 @@ in the cache.
 --- request eval
 ["GET /?user_key=uk1", "GET /?user_key=uk1", "GET /?user_key=uk1"]
 --- response_body eval
-["Authentication failed", "yay, api backend\x{0a}", "yay, api backend\x{0a}"]
+["yay, api backend\x{0a}", "yay, api backend\x{0a}", "yay, api backend\x{0a}"]
 --- error_code eval
-[403, 200, 200]
+[200, 200, 200]
 
 === TEST 5: Caching policy configured as 'allow' with previously denied request
 When the cache is configured as 'allow', requests will be denied if the last


### PR DESCRIPTION
The behavior of the "allow" mode is a bit counterintuitive.

The issue is that when a request is not cached, APIcast returns an authentication failed error. Subsequent requests are cached and are authorized. We'd expect the policy to accept the non-cached request too.

This PR fixes the issue.

For more information: https://issues.jboss.org/browse/THREESCALE-1396
