### PR TITLE
Remove 'experimental' label from path routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,8 @@ expressed might change in future releases.
 
 ## [3.2.1] - 2018-06-26
 
+- Path routing feature enabled by the `APICAST_PATH_ROUTING` environment variable is not considered experimental anymore.
+
 ### Fixed
 
 - Reporting only 50% calls to 3scale backend when using OIDC [PR #779](https://github.com/3scale/apicast/pull/779)

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -110,8 +110,6 @@ When configured to authenticate using OAuth, this param specifies the TTL (in se
 - `true` or `1` for _true_
 - `false`, `0` or empty for _false_
 
-**Experimental:** Path routing might cause increased load and change totally in the future.  
-
 When this parameter is set to _true_, the gateway will use path-based routing in addition to the default host-based routing. The API request will be routed to the first service that has a matching mapping rule, from the list of services for which the value of the `Host` header of the request matches the _Public Base URL_.
 
 ### `APICAST_POLICY_LOAD_PATH`

--- a/gateway/src/apicast/policy/find_service/find_service.lua
+++ b/gateway/src/apicast/policy/find_service/find_service.lua
@@ -61,7 +61,7 @@ function _M.new(...)
   local self = new(...)
 
   if configuration_store.path_routing then
-    ngx.log(ngx.WARN, 'apicast experimental path routing enabled')
+    ngx.log(ngx.WARN, 'apicast path routing enabled')
     self.find_service = find_service_cascade
   else
     self.find_service = find_service_strict


### PR DESCRIPTION
This is a supported feature since `3.2.1`