### PR TITLE
perf: replace varargs in hot paths to make the code jittable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - The `threescale_backend_calls` Prometheus metric now includes the response (used to be in `backend_response`) and also the kind of call (auth, authrep, report) [PR #919](https://github.com/3scale/apicast/pull/919), [THREESCALE-1383](https://issues.jboss.org/browse/THREESCALE-1383)
+- Performance improvement: replaced some varargs in hot paths [PR #937](https://github.com/3scale/apicast/pull/937)
 
 ## [3.3.0] - 2018-10-05
 

--- a/gateway/src/apicast/executor.lua
+++ b/gateway/src/apicast/executor.lua
@@ -21,9 +21,9 @@ local mt = { __index = _M }
 
 -- forward all policy methods to the policy chain
 for _,phase in Policy.phases() do
-    _M[phase] = function(self, ...)
+    _M[phase] = function(self)
         ngx.log(ngx.DEBUG, 'executor phase: ', phase)
-        return self.policy_chain[phase](self.policy_chain, self:context(phase), ...)
+        return self.policy_chain[phase](self.policy_chain, self:context(phase))
     end
 end
 

--- a/gateway/src/apicast/policy_chain.lua
+++ b/gateway/src/apicast/policy_chain.lua
@@ -157,10 +157,10 @@ function _M:insert(policy, position)
 end
 
 local function call_chain(phase_name)
-    return function(self, ...)
+    return function(self, context)
         for i=1, #self do
             ngx.log(ngx.DEBUG, 'policy chain execute phase: ', phase_name, ', policy: ', self[i]._NAME, ', i: ', i)
-            self[i][phase_name](self[i], ...)
+            self[i][phase_name](self[i], context)
         end
 
         return ipairs(self)


### PR DESCRIPTION
This has been done to improve performance by making more code jittable.

The problem is that varags (...) cannot be compiled. The executor and the policy chain do not need varargs anyway because the policies accept just one parameter, the context, in their phases.

I ran some basic tests. Absolute numbers are not important, let's focus on percentages.

Configuration: Default, except for APICAST_WORKERS=1.

I used a minimal configuration that just redirects all the requests to the echo endpoint of a different APIcast running on the same host. internal echo endpoint:

```
{
  "services": [
    {
      "proxy": {
        "policy_chain": [
          { "name": "apicast.policy.upstream",
            "configuration": {
              "rules": [{
                "regex": "/",
                "url": "http://127.0.0.1:8888" (different apicast)
              }]
            }
          }
        ]
      }
    }
  ]
}

```

By making this simple change:
- Almost all of the requests use compiled traces now. Almost none of the requests were before the change.
- The code spends ~35% of the time on compiled on the code. Before, it was ~29%.

As a result, we get a bump on the rps (~10%).

Here's all the data:

### BEFORE:

[centos@ip ~]$ wrk -c 10 -t 10 -d 180 http://localhost:8080
Running 3m test @ http://localhost:8080
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.45ms  694.51us  13.70ms   88.64%
    Req/Sec   291.27     10.31   550.00     69.74%
  522264 requests in 3.00m, 112.04MB read
**Requests/sec:   2899.90**
Transfer/sec:    637.04KB

[root@ip centos]# lj-vm-states.sxx -x 11288 --arg time=180
Found exact match for libluajit:
/usr/local/openresty-debug/luajit/lib/libluajit-5.1.so.2.1.0
Start tracing 11288 (/usr/local/openresty-debug/nginx/sbin/nginx)
Please wait for 180 seconds...

Observed 179985 Lua-running samples and ignored 7 unrelated samples.
C Code (by interpreted Lua): 50% (91228 samples)
**Compiled: 29% (52321 samples)**
Interpreted: 12% (23121 samples)
Garbage Collector (not compiled): 5% (10249 samples)
Garbage Collector (compiled): 1% (3052 samples)
Trace exiting: 0% (14 samples)

[root@ip centos]# ngx-lj-trace-exits.sxx -x 11288 --arg time=180
Found exact match for libluajit:
/usr/local/openresty-debug/luajit/lib/libluajit-5.1.so.2.1.0
Start tracing process 11288
(/usr/local/openresty-debug/nginx/sbin/nginx)...
Please wait for 180 seconds...

**5163 out of 425470 requests used compiled traces generated by LuaJIT.**
Distribution of LuaJIT trace exit times per request for 5163 sample(s):
(min/avg/max: 1/1/3)
value |-------------------------------------------------- count
    0 |                                                      0
    1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ 4250
    2 |@@@@@@@@@@                                          913
    4 |                                                      0
    8 |                                                      0


### AFTER:

[centos@ip ~]$ wrk -c 10 -t 10 -d 180 http://localhost:8080
Running 3m test @ http://localhost:8080
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.15ms  680.08us  19.21ms   89.11%
    Req/Sec   318.66     12.30   484.00     75.28%
  571127 requests in 3.00m, 122.52MB read
**Requests/sec:   3171.40**
Transfer/sec:    696.69KB

[root@ip centos]# lj-vm-states.sxx -x 11647 --arg time=180
Found exact match for libluajit:
/usr/local/openresty-debug/luajit/lib/libluajit-5.1.so.2.1.0
Start tracing 11647 (/usr/local/openresty-debug/nginx/sbin/nginx)
Please wait for 180 seconds...

Observed 179985 Lua-running samples and ignored 11 unrelated samples.
C Code (by interpreted Lua): 49% (89646 samples)
**Compiled: 35% (64491 samples)**
Interpreted: 6% (11829 samples)
Garbage Collector (not compiled): 5% (10214 samples)
Garbage Collector (compiled): 1% (3447 samples)
Trace exiting: 0% (355 samples)
JIT Compiler: 0% (3 samples)

[root@ip centos]# ngx-lj-trace-exits.sxx -x 11647 --arg time=180
Found exact match for libluajit:
/usr/local/openresty-debug/luajit/lib/libluajit-5.1.so.2.1.0
Start tracing process 11647
(/usr/local/openresty-debug/nginx/sbin/nginx)...
Please wait for 180 seconds...

**454691 out of 454697 requests used compiled traces generated by LuaJIT.**
Distribution of LuaJIT trace exit times per request for 454691
sample(s):
(min/avg/max: 1/1/4)
value |-------------------------------------------------- count
    0 |                                                        0
    1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@  450767
    2 |                                                     3883
    4 |                                                       41
    8 |                                                        0
   16 |                                                        0