### PR TITLE
[THREESCALE-1430] Avoid trying to use path-based routing when using HTTPS

### DIFF
--- a/gateway/src/apicast/policy/find_service/find_service.lua
+++ b/gateway/src/apicast/policy/find_service/find_service.lua
@@ -29,8 +29,18 @@ end
 
 _M.rewrite = find_service
 
--- ssl_certiticate is the first phase executed when request arrives on HTTPS
--- therefore it needs to find a service to build a policy chain
-_M.ssl_certificate = find_service
+-- ssl_certificate is the first phase executed when request arrives on HTTPS
+-- therefore it needs to find a service to build a policy chain.
+-- The method and the path are not available in the ssl_certificate phase, so
+-- path-based routing does not work. It should always find the service by host.
+function _M:ssl_certificate(context)
+  if self.find_service ~= host_based_finder.find_service then
+    ngx.log(ngx.WARN, 'Configured to do path-based routing, but it is not',
+                      'compatible with TLS. Falling back to routing by host.')
+  end
+
+  context.service = context.service or
+                    host_based_finder.find_service(context.configuration, context.host)
+end
 
 return _M

--- a/gateway/src/apicast/policy/find_service/find_service.lua
+++ b/gateway/src/apicast/policy/find_service/find_service.lua
@@ -1,70 +1,23 @@
+local configuration_store = require 'apicast.configuration_store'
+local host_based_finder = require('apicast.policy.find_service.host_based_finder')
+local path_based_finder = require('apicast.policy.find_service.path_based_finder')
+
 local Policy = require('apicast.policy')
 local _M = Policy.new('Find Service Policy')
-local configuration_store = require 'apicast.configuration_store'
-local mapping_rules_matcher = require 'apicast.mapping_rules_matcher'
+
 local new = _M.new
-
-local function find_service_strict(configuration, host)
-  local found
-  local services = configuration:find_by_host(host)
-
-  for s=1, #services do
-    local service = services[s]
-    local hosts = service.hosts or {}
-
-    for h=1, #hosts do
-      if hosts[h] == host and service == configuration:find_by_id(service.id) then
-        found = service
-        break
-      end
-    end
-    if found then break end
-  end
-
-  return found or ngx.log(ngx.WARN, 'service not found for host ', host)
-end
-
-local function find_service_cascade(configuration, host)
-  local found
-  local services = configuration:find_by_host(host)
-  local method = ngx.req.get_method()
-  local uri = ngx.var.uri
-
-  for s=1, #services do
-    local service = services[s]
-    local hosts = service.hosts or {}
-
-    for h=1, #hosts do
-      if hosts[h] == host then
-        local name = service.system_name or service.id
-        ngx.log(ngx.DEBUG, 'service ', name, ' matched host ', hosts[h])
-
-        local matches = mapping_rules_matcher.matches(method, uri, {}, service.rules)
-        -- matches() also returns the index of the first rule that matched.
-        -- As a future optimization, in the part of the code that calculates
-        -- the usage, we could use this to avoid trying to match again all the
-        -- rules before the one that matched.
-
-        if matches then
-          found = service
-          break
-        end
-      end
-    end
-    if found then break end
-  end
-
-  return found or find_service_strict(configuration, host)
-end
 
 function _M.new(...)
   local self = new(...)
 
   if configuration_store.path_routing then
     ngx.log(ngx.WARN, 'apicast path routing enabled')
-    self.find_service = find_service_cascade
+    self.find_service = function(configuration, host)
+      return path_based_finder.find_service(configuration, host) or
+             host_based_finder.find_service(configuration, host)
+    end
   else
-    self.find_service = find_service_strict
+    self.find_service = host_based_finder.find_service
   end
 
   return self

--- a/gateway/src/apicast/policy/find_service/host_based_finder.lua
+++ b/gateway/src/apicast/policy/find_service/host_based_finder.lua
@@ -1,0 +1,23 @@
+local _M = {}
+
+function _M.find_service(config_store, host)
+  local found
+  local services = config_store:find_by_host(host)
+
+  for s=1, #services do
+    local service = services[s]
+    local hosts = service.hosts or {}
+
+    for h=1, #hosts do
+      if hosts[h] == host and service == config_store:find_by_id(service.id) then
+        found = service
+        break
+      end
+    end
+    if found then break end
+  end
+
+  return found or ngx.log(ngx.WARN, 'service not found for host ', host)
+end
+
+return _M

--- a/gateway/src/apicast/policy/find_service/path_based_finder.lua
+++ b/gateway/src/apicast/policy/find_service/path_based_finder.lua
@@ -1,0 +1,37 @@
+local mapping_rules_matcher = require 'apicast.mapping_rules_matcher'
+
+local _M = {}
+
+function _M.find_service(config_store, host)
+  local found
+  local services = config_store:find_by_host(host)
+  local method = ngx.req.get_method()
+  local uri = ngx.var.uri
+
+  for s=1, #services do
+    local service = services[s]
+    local hosts = service.hosts or {}
+
+    for h=1, #hosts do
+      if hosts[h] == host then
+        local name = service.system_name or service.id
+        ngx.log(ngx.DEBUG, 'service ', name, ' matched host ', hosts[h])
+        local matches = mapping_rules_matcher.matches(method, uri, {}, service.rules)
+        -- matches() also returns the index of the first rule that matched.
+        -- As a future optimization, in the part of the code that calculates
+        -- the usage, we could use this to avoid trying to match again all the
+        -- rules before the one that matched.
+
+        if matches then
+          found = service
+          break
+        end
+      end
+    end
+    if found then break end
+  end
+
+  return found
+end
+
+return _M

--- a/spec/policy/find_service/find_service_spec.lua
+++ b/spec/policy/find_service/find_service_spec.lua
@@ -1,10 +1,12 @@
+local FindService = require('apicast.policy.find_service')
+local ConfigurationStore = require('apicast.configuration_store')
 local configuration = require('apicast.configuration')
 
 describe('find_service', function()
   describe('.rewrite', function()
     describe('when path routing is enabled', function()
       it('finds the service by matching rules and stores it in the given context', function()
-        require('apicast.configuration_store').path_routing = true
+        ConfigurationStore.path_routing = true
 
         -- We access ngx.var.uri, ngx.req.get_method, and ngx.req.get_uri_args
         -- directly in the code, so we need to mock them. We should probably
@@ -13,7 +15,7 @@ describe('find_service', function()
         stub(ngx.req, 'get_uri_args', function() return {} end)
         stub(ngx.req, 'get_method', function() return 'GET' end)
 
-        local find_service_policy = require('apicast.policy.find_service').new()
+        local find_service_policy = FindService.new()
         local host = 'example.com'
 
         local service_1 = configuration.parse_service({
@@ -43,7 +45,7 @@ describe('find_service', function()
           }
         })
 
-        local configuration_store = require('apicast.configuration_store').new()
+        local configuration_store = ConfigurationStore.new()
         configuration_store:store(
           { services = { service_1, service_2, service_3 } })
 
@@ -55,14 +57,14 @@ describe('find_service', function()
 
       describe('and no rules are matched', function()
         it('finds a service for the host in the context and stores the service there', function()
-          require('apicast.configuration_store').path_routing = true
+          ConfigurationStore.path_routing = true
           ngx.var = { uri = '/abc' }
 
           stub(ngx.req, 'get_uri_args', function() return {} end)
           stub(ngx.req, 'get_method', function() return 'GET' end)
 
           local host = 'example.com'
-          local find_service_policy = require('apicast.policy.find_service').new()
+          local find_service_policy = FindService.new()
 
           local service = configuration.parse_service({
             id = 42,
@@ -73,7 +75,7 @@ describe('find_service', function()
             }
           })
 
-          local configuration_store = require('apicast.configuration_store').new()
+          local configuration_store = ConfigurationStore.new()
           configuration_store:add(service)
 
           local context = { host = host, configuration = configuration_store }
@@ -85,13 +87,13 @@ describe('find_service', function()
 
       describe('and no rules are matched and there is not a service for the host', function()
         it('stores nil in the service field of the given context', function()
-          require('apicast.configuration_store').path_routing = true
+          ConfigurationStore.path_routing = true
           ngx.var = { uri = '/abc' }
           stub(ngx.req, 'get_uri_args', function() return {} end)
           stub(ngx.req, 'get_method', function() return 'GET' end)
 
-          local find_service_policy = require('apicast.policy.find_service').new()
-          local configuration_store = require('apicast.configuration_store').new()
+          local find_service_policy = FindService.new()
+          local configuration_store = ConfigurationStore.new()
 
           local context = {
             host = 'example.com',
@@ -105,10 +107,10 @@ describe('find_service', function()
     end)
 
     describe('when path routing is disabled', function()
-      require('apicast.configuration_store').path_routing = false
+      ConfigurationStore.path_routing = false
 
       it('finds the service of the host in the given context and stores it there', function()
-        local find_service_policy = require('apicast.policy.find_service').new()
+        local find_service_policy = FindService.new()
 
         local host = 'example.com'
         local service = configuration.parse_service({
@@ -119,7 +121,7 @@ describe('find_service', function()
                               metric_system_name = 'hits', delta = 1 } }
           }
         })
-        local configuration_store = require('apicast.configuration_store').new()
+        local configuration_store = ConfigurationStore.new()
         configuration_store:add(service)
 
         local context = { host = host, configuration = configuration_store }
@@ -129,8 +131,8 @@ describe('find_service', function()
 
       describe('and there is not a service for the host', function()
         it('stores nil in the service field of the given context', function()
-          local find_service_policy = require('apicast.policy.find_service').new()
-          local configuration_store = require('apicast.configuration_store').new()
+          local find_service_policy = FindService.new()
+          local configuration_store = ConfigurationStore.new()
 
           local context = {
             host = 'example.com',

--- a/spec/policy/find_service/find_service_spec.lua
+++ b/spec/policy/find_service/find_service_spec.lua
@@ -1,147 +1,93 @@
 local FindService = require('apicast.policy.find_service')
+local HostBasedFinder = require('apicast.policy.find_service.host_based_finder')
+local PathBasedFinder = require('apicast.policy.find_service.path_based_finder')
 local ConfigurationStore = require('apicast.configuration_store')
-local configuration = require('apicast.configuration')
 
 describe('find_service', function()
   describe('.rewrite', function()
     describe('when path routing is enabled', function()
-      it('finds the service by matching rules and stores it in the given context', function()
-        ConfigurationStore.path_routing = true
-
-        -- We access ngx.var.uri, ngx.req.get_method, and ngx.req.get_uri_args
-        -- directly in the code, so we need to mock them. We should probably
-        -- try to avoid this kind of coupling.
-        ngx.var = { uri = '/def' }
-        stub(ngx.req, 'get_uri_args', function() return {} end)
-        stub(ngx.req, 'get_method', function() return 'GET' end)
-
-        local find_service_policy = FindService.new()
-        local host = 'example.com'
-
-        local service_1 = configuration.parse_service({
-          id = 42,
-          proxy = {
-            hosts = { host },
-            proxy_rules = { { pattern = '/abc', http_method = 'GET',
-                              metric_system_name = 'hits', delta = 1 } }
-          }
-        })
-
-        local service_2 = configuration.parse_service({
-          id = 43,
-          proxy = {
-            hosts = { host },
-            proxy_rules = { { pattern = '/def', http_method = 'GET',
-                              metric_system_name = 'hits', delta = 2 } }
-          }
-        })
-
-        local service_3 = configuration.parse_service({
-          id = 44,
-          proxy = {
-            hosts = { host },
-            proxy_rules = { { pattern = '/ghi', http_method = 'GET',
-                              metric_system_name = 'hits', delta = 3 } }
-          }
-        })
-
-        local configuration_store = ConfigurationStore.new()
-        configuration_store:store(
-          { services = { service_1, service_2, service_3 } })
-
-        local context = { host = host, configuration = configuration_store }
-        find_service_policy:rewrite(context)
-
-        assert.equal(service_2, context.service)
-      end)
-
-      describe('and no rules are matched', function()
-        it('finds a service for the host in the context and stores the service there', function()
+      describe('and there is a service with a matching path', function()
+        it('stores that service in the context', function()
           ConfigurationStore.path_routing = true
-          ngx.var = { uri = '/abc' }
+          local service = { id = '1' }
+          local context = { configuration = ConfigurationStore.new(), host = 'example.com' }
+          stub(PathBasedFinder, 'find_service', function(config_store, host)
+            if config_store == context.configuration and host == context.host then
+              return service
+            end
+          end)
+          stub(HostBasedFinder, 'find_service')
+          local find_service = FindService.new()
 
-          stub(ngx.req, 'get_uri_args', function() return {} end)
-          stub(ngx.req, 'get_method', function() return 'GET' end)
+          find_service:rewrite(context)
 
-          local host = 'example.com'
-          local find_service_policy = FindService.new()
-
-          local service = configuration.parse_service({
-            id = 42,
-            proxy = {
-              hosts = { host },
-              proxy_rules = { { pattern = '/', http_method = 'GET',
-                                metric_system_name = 'hits', delta = 1 } }
-            }
-          })
-
-          local configuration_store = ConfigurationStore.new()
-          configuration_store:add(service)
-
-          local context = { host = host, configuration = configuration_store }
-
-          find_service_policy:rewrite(context)
-          assert.same(service, context.service)
+          assert.stub(HostBasedFinder.find_service).was_not_called()
+          assert.equals(service, context.service)
         end)
       end)
 
-      describe('and no rules are matched and there is not a service for the host', function()
-        it('stores nil in the service field of the given context', function()
+      describe('and there is not a service with a matching path', function()
+        it('fallbacks to find a service by host and stores it in the context', function()
           ConfigurationStore.path_routing = true
-          ngx.var = { uri = '/abc' }
-          stub(ngx.req, 'get_uri_args', function() return {} end)
-          stub(ngx.req, 'get_method', function() return 'GET' end)
+          local service = { id = '1' }
+          local context = { configuration = ConfigurationStore.new(), host = 'example.com' }
+          stub(PathBasedFinder, 'find_service', function() return nil end)
+          stub(HostBasedFinder, 'find_service', function(config_store, host)
+            if config_store == context.configuration and host == context.host then
+              return service
+            end
+          end)
 
-          local find_service_policy = FindService.new()
-          local configuration_store = ConfigurationStore.new()
+          local find_service = FindService.new()
 
-          local context = {
-            host = 'example.com',
-            configuration = configuration_store
-          }
+          find_service:rewrite(context)
 
-          find_service_policy:rewrite(context)
+          assert.equals(service, context.service)
+        end)
+
+        it('stores nil in the context if there is not a service for the host', function()
+          ConfigurationStore.path_routing = true
+          local context = { }
+          stub(PathBasedFinder, 'find_service', function() return nil end)
+          stub(HostBasedFinder, 'find_service', function() return nil end)
+
+          local find_service = FindService.new()
+
+          find_service:rewrite(context)
+
           assert.is_nil(context.service)
         end)
       end)
     end)
 
     describe('when path routing is disabled', function()
-      ConfigurationStore.path_routing = false
+      it('finds the service by host and stores it in the context', function()
+        ConfigurationStore.path_routing = false
+        local service = { id = '1' }
+        local context = { configuration = ConfigurationStore.new(), host = 'example.com' }
+        stub(HostBasedFinder, 'find_service', function(config_store, host)
+          if config_store == context.configuration and host == context.host then
+            return service
+          end
+        end)
+        stub(PathBasedFinder, 'find_service')
+        local find_service = FindService.new()
 
-      it('finds the service of the host in the given context and stores it there', function()
-        local find_service_policy = FindService.new()
+        find_service:rewrite(context)
 
-        local host = 'example.com'
-        local service = configuration.parse_service({
-          id = 42,
-          proxy = {
-            hosts = { host },
-            proxy_rules = { { pattern = '/', http_method = 'GET',
-                              metric_system_name = 'hits', delta = 1 } }
-          }
-        })
-        local configuration_store = ConfigurationStore.new()
-        configuration_store:add(service)
-
-        local context = { host = host, configuration = configuration_store }
-        find_service_policy:rewrite(context)
-        assert.same(service, context.service)
+        assert.stub(PathBasedFinder.find_service).was_not_called()
+        assert.equals(service, context.service)
       end)
 
-      describe('and there is not a service for the host', function()
-        it('stores nil in the service field of the given context', function()
-          local find_service_policy = FindService.new()
-          local configuration_store = ConfigurationStore.new()
+      it('stores nil in the context if there is not a service for the host', function()
+        ConfigurationStore.path_routing = false
+        local context = { }
+        stub(HostBasedFinder, 'find_service', function() return nil end)
+        local find_service = FindService.new()
 
-          local context = {
-            host = 'example.com',
-            configuration = configuration_store
-          }
+        find_service:rewrite(context)
 
-          find_service_policy:rewrite(context)
-          assert.is_nil(context.service)
-        end)
+        assert.is_nil(context.service)
       end)
     end)
   end)

--- a/spec/policy/find_service/host_based_finder_spec.lua
+++ b/spec/policy/find_service/host_based_finder_spec.lua
@@ -1,0 +1,57 @@
+local HostBasedFinder = require('apicast.policy.find_service.host_based_finder')
+local ConfigurationStore = require('apicast.configuration_store')
+local Configuration = require('apicast.configuration')
+
+describe('HostBasedFinder', function()
+  describe('.find_service', function()
+    it('returns the service in the config for the given host', function()
+      local host = 'example.com'
+
+      local service_for_host = Configuration.parse_service({
+        id = 1,
+        proxy = {
+          hosts = { host },
+          proxy_rules = { { pattern = '/', http_method = 'GET',
+                            metric_system_name = 'hits', delta = 1 } }
+        }
+      })
+
+      local service_different_host = Configuration.parse_service({
+        id = 2,
+        proxy = {
+          hosts = { 'different_host.something' },
+          proxy_rules = { { pattern = '/', http_method = 'GET',
+                            metric_system_name = 'hits', delta = 1 } }
+        }
+      })
+
+      local services = { service_for_host, service_different_host }
+      local config_store = ConfigurationStore.new()
+      config_store:store({ services = services })
+
+      local found_service = HostBasedFinder.find_service(config_store, host)
+
+      assert.same(service_for_host, found_service)
+    end)
+
+    it('returns nil if there is not a service for the host', function()
+      local host = 'example.com'
+
+      local service_different_host = Configuration.parse_service({
+        id = 1,
+        proxy = {
+          hosts = { 'different_host.something' },
+          proxy_rules = { { pattern = '/', http_method = 'GET',
+                            metric_system_name = 'hits', delta = 1 } }
+        }
+      })
+
+      local config_store = ConfigurationStore.new()
+      config_store:store({ services = { service_different_host } })
+
+      local found_service = HostBasedFinder.find_service(config_store, host)
+
+      assert.is_nil(found_service)
+    end)
+  end)
+end)

--- a/spec/policy/find_service/path_based_finder_spec.lua
+++ b/spec/policy/find_service/path_based_finder_spec.lua
@@ -1,0 +1,104 @@
+local PathBasedFinder = require('apicast.policy.find_service.path_based_finder')
+local Configuration = require('apicast.configuration')
+local ConfigurationStore = require('apicast.configuration_store')
+
+describe('PathBasedFinder', function()
+  -- The config_store depends on the path routing setting.
+  local config_store_opts = { path_routing = true }
+
+  describe('.find_service', function()
+    it('returns the service for the host that has a rule that matches the request path', function()
+      -- We access ngx.var.uri, ngx.req.get_method, and ngx.req.get_uri_args
+      -- directly in the code, so we need to mock them. We should probably
+      -- try to avoid this kind of coupling.
+      ngx.var = { uri = '/def' }
+      stub(ngx.req, 'get_uri_args', function() return {} end)
+      stub(ngx.req, 'get_method', function() return 'GET' end)
+
+      local host = 'example.com'
+
+      local service_not_matching_1 = Configuration.parse_service({
+        id = 1,
+        proxy = {
+          hosts = { host },
+          proxy_rules = { { pattern = '/abc', http_method = 'GET',
+                            metric_system_name = 'hits', delta = 1 } }
+        }
+      })
+
+      local service_matching = Configuration.parse_service({
+        id = 2,
+        proxy = {
+          hosts = { host },
+          proxy_rules = { { pattern = '/def', http_method = 'GET',
+                            metric_system_name = 'hits', delta = 2 } }
+        }
+      })
+
+      local service_not_matching_2 = Configuration.parse_service({
+        id = 3,
+        proxy = {
+          hosts = { host },
+          proxy_rules = { { pattern = '/ghi', http_method = 'GET',
+                            metric_system_name = 'hits', delta = 3 } }
+        }
+      })
+
+      local services = { service_not_matching_1, service_matching, service_not_matching_2 }
+      local config_store = ConfigurationStore.new(nil, config_store_opts)
+      config_store:store({ services = services })
+
+      local service_found = PathBasedFinder.find_service(config_store, host)
+
+      assert.equal(service_matching, service_found)
+    end)
+
+    it('does not return a service if it matches the path but not the host', function()
+      ngx.var = { uri = '/' }
+      stub(ngx.req, 'get_uri_args', function() return {} end)
+      stub(ngx.req, 'get_method', function() return 'GET' end)
+
+      local host = 'example.com'
+
+      local service_matching_path = Configuration.parse_service({
+        id = 1,
+        proxy = {
+          hosts = { 'another_host.something' },
+          proxy_rules = { { pattern = '/', http_method = 'GET',
+                            metric_system_name = 'hits', delta = 2 } }
+        }
+      })
+
+      local config_store = ConfigurationStore.new(nil, config_store_opts)
+      config_store:store({ services = { service_matching_path } })
+
+      local service_found = PathBasedFinder.find_service(config_store, host)
+
+      assert.is_nil(service_found)
+    end)
+
+    it('does not return a service if it does not match neither the path nor the host', function()
+      ngx.var = { uri = '/abc' }
+      stub(ngx.req, 'get_uri_args', function() return {} end)
+      stub(ngx.req, 'get_method', function() return 'GET' end)
+
+      local host = 'example.com'
+
+      local service = Configuration.parse_service({
+        id = 1,
+        proxy = {
+          hosts = { 'another_host.something' },
+          proxy_rules = { { pattern = '/dont_match', http_method = 'GET',
+                            metric_system_name = 'hits', delta = 2 } }
+        }
+      })
+
+      local config_store = ConfigurationStore.new(nil, config_store_opts)
+      config_store:store({ services = { service } })
+
+      local service_found = PathBasedFinder.find_service(config_store, host)
+
+      assert.is_nil(service_found)
+    end)
+  end)
+end)

--- a/t/listen-https.t
+++ b/t/listen-https.t
@@ -125,3 +125,68 @@ CWxvY2FsaG9zdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABI3IZUvpJsaQbiLy
 VZ5Wr10wCgYIKoZIzj0EAwIDSAAwRQIhAPRkfbxowt0H7p5xZYpwoMKanUXz9eKQ
 0sGkOw+TqqGXAiAMKJRqtjnCF2LIjGygHG6BlgjM4NgIMDHteZPEr4qEmw==
 -----END CERTIFICATE-----
+
+=== TEST 3: Listen on HTTPS with path-based routing enabled
+Regression test. APIcast was crashing because path-based routing needs the http
+method and the path. However, those are not available when trying to find the
+service in the ssl_certificate phase.
+This test checks that APIcast falls back to finding the service by host.
+--- env eval
+(
+    'APICAST_HTTPS_PORT' => "$Test::Nginx::Util::ServerPortForClient",
+    'APICAST_HTTPS_CERTIFICATE' => "$Test::Nginx::Util::ServRoot/html/server.crt",
+    'APICAST_HTTPS_CERTIFICATE_KEY' => "$Test::Nginx::Util::ServRoot/html/server.key",
+    'APICAST_PATH_ROUTING' => "true",
+)
+--- configuration fixture=echo.json
+--- test env
+lua_ssl_trusted_certificate $TEST_NGINX_HTML_DIR/server.crt;
+content_by_lua_block {
+    local sock = ngx.socket.tcp()
+    sock:settimeout(2000)
+
+    local ok, err = sock:connect(ngx.var.server_addr, ngx.var.apicast_port)
+    if not ok then
+        ngx.say("failed to connect: ", err)
+        return
+    end
+
+    ngx.say("connected: ", ok)
+
+    local sess, err = sock:sslhandshake(nil, "localhost", true)
+    if not sess then
+        ngx.say("failed to do SSL handshake: ", err)
+        return
+    end
+
+    ngx.say("ssl handshake: ", type(sess))
+}
+--- response_body
+connected: 1
+ssl handshake: userdata
+--- error_code: 200
+--- grep_error_log eval: qr/Falling back to routing by host/
+--- grep_error_log_out
+Falling back to routing by host
+--- no_error_log
+[error]
+--- user_files
+>>> server.crt
+-----BEGIN CERTIFICATE-----
+MIIBRzCB7gIJAPHi8uNGM8wDMAoGCCqGSM49BAMCMCwxFjAUBgNVBAoMDVRlc3Q6
+OkFQSWNhc3QxEjAQBgNVBAMMCWxvY2FsaG9zdDAeFw0xODA2MDUwOTQ0MjRaFw0y
+ODA2MDIwOTQ0MjRaMCwxFjAUBgNVBAoMDVRlc3Q6OkFQSWNhc3QxEjAQBgNVBAMM
+CWxvY2FsaG9zdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABI3IZUvpJsaQbiLy
+/yfthJDd/+BIaKzAbgMAimth4ePOi3a/YICwsHyq6sBxbgvMeTwxNJIHpe3td4tB
+VZ5Wr10wCgYIKoZIzj0EAwIDSAAwRQIhAPRkfbxowt0H7p5xZYpwoMKanUXz9eKQ
+0sGkOw+TqqGXAiAMKJRqtjnCF2LIjGygHG6BlgjM4NgIMDHteZPEr4qEmw==
+-----END CERTIFICATE-----
+>>> server.key
+-----BEGIN EC PARAMETERS-----
+BggqhkjOPQMBBw==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIH22v43xtXcHWJyH3BEB9N30ahrCOLripkoSWW/WujUxoAoGCCqGSM49
+AwEHoUQDQgAEjchlS+kmxpBuIvL/J+2EkN3/4EhorMBuAwCKa2Hh486Ldr9ggLCw
+fKrqwHFuC8x5PDE0kgel7e13i0FVnlavXQ==
+-----END EC PRIVATE KEY-----


### PR DESCRIPTION
When APICAST_HTTPS_ env vars are used to configure SSL certs, enabling path routing does not work. The reason is that when those envs are configured, the `find_service` policy runs in the `ssl_certificate` phase which does not have access to the http method nor the path, needed for the path-based routing.

Apart from fixing the issue, this PR refactors the `find_service` by extracting a couple of classes and reorganizing the tests. I think that properly testing the `ssl_certiticate` phase without this refactor would have needed lots of duplicated tests.

Ref: https://issues.jboss.org/browse/THREESCALE-1430