### PR TITLE
Fix 'nil' being added to path when using proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - When using SSL certs with path-based routing enabled, now APIcast falls backs to host-based routing instead of crashing [PR #938](https://github.com/3scale/apicast/pull/938), [THREESCALE-1430](https://issues.jboss.org/browse/THREESCALE-1430)
 - Fixed error that happened when loading certain configurations that use OIDC [PR #940](https://github.com/3scale/apicast/pull/940), [THREESCALE-1289](https://issues.jboss.org/browse/THREESCALE-1289)
 - The port is now included in the Host header when the request is proxied [PR #942](https://github.com/3scale/apicast/pull/942)
+- Fix "nil" being added to the end of URL Path in some cases when using http_proxy [PR #946](https://github.com/3scale/apicast/pull/946)
 
 ### Added
 

--- a/gateway/src/apicast/http_proxy.lua
+++ b/gateway/src/apicast/http_proxy.lua
@@ -81,7 +81,7 @@ local function absolute_url(uri)
 end
 
 local function current_path(uri)
-    return format('%s%s%s', uri.path or ngx.var.uri, ngx.var.is_args, ngx.var.query_string)
+    return format('%s%s%s', uri.path or ngx.var.uri, ngx.var.is_args, ngx.var.query_string or '')
 end
 
 local function forward_https_request(proxy_uri, uri)


### PR DESCRIPTION
When there isn't any query parameters the ngx.var.query_string
variable will be nil, which causes the format statement to add the
lireral string nil at the end of the request path.

This happens for https APIs when settings the http(s)_proxy environment
variable for apicast.