### PR TITLE
[THREESCALE-1547] Fix default creds policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed 
+
+- Fix bug in the Default credentials policy. It was using the default credentials in some cases where it should not [PR #954](https://github.com/3scale/apicast/pull/954), [THREESCALE-1547](https://issues.jboss.org/browse/THREESCALE-1547)
+
 ## [3.4.0-rc1] - 2018-11-13
 
 ### Fixed

--- a/gateway/src/apicast/policy/default_credentials/apicast-policy.json
+++ b/gateway/src/apicast/policy/default_credentials/apicast-policy.json
@@ -3,12 +3,13 @@
   "name": "Anonymous access",
   "summary": "Provides default credentials for unauthenticated requests.",
   "description":
-    ["This policy allows to expose a service without authentication. ",
+    ["This policy allows to expose a service without authentication. \n",
      "It can be useful, for example, for legacy apps that cannot be adapted to ",
-     "send the auth params. ",
+     "send the auth params. \n",
      "When the credentials are not provided in the request, this policy ",
-     "provides the default ones configured. ",
-     "An app_id + app_key or a user_key should be configured."],
+     "provides the default ones configured. \n",
+     "An app_id + app_key or a user_key should be configured. \n",
+     "Note: this policy should be placed before the APIcast policy in the chain."],
   "version": "builtin",
   "configuration": {
     "type":"object",

--- a/gateway/src/apicast/policy/default_credentials/default_credentials.lua
+++ b/gateway/src/apicast/policy/default_credentials/default_credentials.lua
@@ -36,10 +36,10 @@ local function creds_missing(service)
   end
 end
 
-local function provide_creds_for_version_1(service, default_creds)
+local function provide_creds_for_version_1(context, default_creds)
   if default_creds.user_key then
     -- follows same format as Service.extract_credentials()
-    service.extracted_credentials = {
+    context.extracted_credentials = {
       default_creds.user_key,
       user_key = default_creds.user_key
     }
@@ -50,10 +50,10 @@ local function provide_creds_for_version_1(service, default_creds)
   end
 end
 
-local function provide_creds_for_version_2(service, default_creds)
+local function provide_creds_for_version_2(context, default_creds)
   if default_creds.app_id and default_creds.app_key then
     -- follows same format as Service.extract_credentials()
-    service.extracted_credentials = {
+    context.extracted_credentials = {
       default_creds.app_id,
       default_creds.app_key,
       app_id = default_creds.app_id,
@@ -75,9 +75,8 @@ local function backend_version_is_supported(backend_version)
   return creds_provider[backend_version] ~= nil
 end
 
-local function provide_creds(service, default_creds)
-  local backend_version = tostring(service.backend_version)
-  creds_provider[backend_version](service, default_creds)
+local function provide_creds(context, backend_version, default_creds)
+  creds_provider[tostring(backend_version)](context, default_creds)
 end
 
 function _M:rewrite(context)
@@ -95,7 +94,7 @@ function _M:rewrite(context)
   end
 
   if creds_missing(service) then
-    provide_creds(service, self.default_credentials)
+    provide_creds(context, service.backend_version, self.default_credentials)
   end
 end
 

--- a/gateway/src/apicast/proxy.lua
+++ b/gateway/src/apicast/proxy.lua
@@ -228,7 +228,7 @@ function _M:rewrite(service, context)
   ngx.var.secret_token = service.secret_token
 
   -- Another policy might have already extracted the creds.
-  local credentials = service.extracted_credentials
+  local credentials =  context.extracted_credentials
 
   local err
   if not credentials then

--- a/spec/policy/default_credentials/default_credentials_spec.lua
+++ b/spec/policy/default_credentials/default_credentials_spec.lua
@@ -81,45 +81,45 @@ describe('Default credentials policy', function()
     describe('when the service in the context has backend_version = 1', function()
       describe('and the request includes a user key', function()
         describe('and there is a default user key defined', function()
-          it('does not set a user key in the service creds', function()
+          it('does not set any credentials in the context', function()
             local context = { service = service_with_user_key_in_req() }
 
             policy_with_default_user_key():rewrite(context)
 
-            assert.is_nil(context.service.extracted_credentials)
+            assert.is_nil(context.extracted_credentials)
           end)
         end)
 
         describe('and there is not a default user key defined', function()
-          it('does not set a user key in the service creds', function()
+          it('does not set any credentials in the context', function()
             local context = { service = service_with_user_key_in_req() }
 
             policy_with_default_app_id_and_key():rewrite(context)
 
-            assert.is_nil(context.service.extracted_credentials)
+            assert.is_nil(context.extracted_credentials)
           end)
         end)
       end)
 
       describe('and the request does not include a user key', function()
         describe('and there is a default user key defined', function()
-          it('sets the default user key in the service creds', function()
+          it('sets the default user key in the context', function()
             local context = { service = service_without_user_key_in_req() }
 
             policy_with_default_user_key():rewrite(context)
 
             assert.same({ policy_user_key, user_key = policy_user_key },
-                        context.service.extracted_credentials)
+                        context.extracted_credentials)
           end)
         end)
 
         describe('and there is not a default user key defined', function()
-          it('does not set a user key in the service creds', function()
+          it('does not set any credentials in the context', function()
             local context = { service = service_without_user_key_in_req() }
 
             policy_with_default_app_id_and_key():rewrite(context)
 
-            assert.is_nil(context.service.extracted_credentials)
+            assert.is_nil(context.extracted_credentials)
           end)
         end)
       end)
@@ -128,73 +128,73 @@ describe('Default credentials policy', function()
     describe('when the service in the context has backend_version = 2', function()
       describe('and the request includes an app id and an app key', function()
         describe('and there is a default app id and key defined', function()
-          it('does not set app id and key in the service creds', function()
+          it('does not set any credentials in the context', function()
             local context = { service = service_with_app_id_and_key_in_req() }
 
             policy_with_default_app_id_and_key():rewrite(context)
 
-            assert.is_nil(context.service.extracted_credentials)
+            assert.is_nil(context.extracted_credentials)
           end)
         end)
 
         describe('and there is not a default app and key defined', function()
-          it('does not set app id and key in the service creds', function()
+          it('does not set any credentials in the context', function()
             local context = { service = service_with_app_id_and_key_in_req() }
 
             policy_with_default_user_key():rewrite(context)
 
-            assert.is_nil(context.service.extracted_credentials)
+            assert.is_nil(context.extracted_credentials)
           end)
         end)
       end)
 
       describe('and the request includes an app id but no app key', function()
         describe('and there is a default app id and key defined', function()
-          it('does not set app id and key in the service creds', function()
+          it('does not set any credentials in the context', function()
             local context = { service = service_with_app_id_in_req() }
 
             policy_with_default_app_id_and_key():rewrite(context)
 
-            assert.is_nil(context.service.extracted_credentials)
+            assert.is_nil(context.extracted_credentials)
           end)
         end)
 
         describe('and there is not a default app and key defined', function()
-          it('does not set app id and key in the service creds', function()
+          it('does not set any credentials in the context', function()
             local context = { service = service_with_app_id_in_req() }
 
             policy_with_default_user_key():rewrite(context)
 
-            assert.is_nil(context.service.extracted_credentials)
+            assert.is_nil(context.extracted_credentials)
           end)
         end)
       end)
 
       describe('and the request includes an app key but not an app id', function()
         describe('and there is a default app id and key defined', function()
-          it('does not set app id and key in the service creds', function()
+          it('does not set any credentials in the context', function()
             local context = { service = service_with_app_key_in_req() }
 
             policy_with_default_app_id_and_key():rewrite(context)
 
-            assert.is_nil(context.service.extracted_credentials)
+            assert.is_nil(context.extracted_credentials)
           end)
         end)
 
         describe('and there is not a default app and key defined', function()
-          it('does not set app id and key in the service creds', function()
+          it('does not set any credentials in the context', function()
             local context = { service = service_with_app_key_in_req() }
 
             policy_with_default_user_key():rewrite(context)
 
-            assert.is_nil(context.service.extracted_credentials)
+            assert.is_nil(context.extracted_credentials)
           end)
         end)
       end)
 
       describe('and the request does not include an app key nor an app id', function()
         describe('and there is a default app id and key defined', function()
-          it('sets the app and key in the service creds', function()
+          it('sets the app and key in the context', function()
             local context = { service = service_without_app_id_nor_key_in_req() }
 
             policy_with_default_app_id_and_key():rewrite(context)
@@ -202,25 +202,25 @@ describe('Default credentials policy', function()
             assert.same(
               { policy_app_id, policy_app_key,
                 app_id = policy_app_id, app_key = policy_app_key },
-              context.service.extracted_credentials
+              context.extracted_credentials
             )
           end)
         end)
 
         describe('and there is not a default app and key defined', function()
-          it('does not set app id and key in the service creds', function()
+          it('does not set any credentials in the context', function()
             local context = { service = service_without_app_id_nor_key_in_req() }
 
             policy_with_default_user_key():rewrite(context)
 
-            assert.is_nil(context.service.extracted_credentials)
+            assert.is_nil(context.extracted_credentials)
           end)
         end)
       end)
     end)
 
     describe('when the service in the context has backend_version != 1 and != 2', function()
-      it('does not set app id and key in the service creds', function()
+      it('does not set any credentials in the context', function()
         local context = { service = { backend_version = 'oauth' } }
 
         local policies = {
@@ -230,7 +230,7 @@ describe('Default credentials policy', function()
 
         for _, policy in ipairs(policies) do
           policy:rewrite(context)
-          assert.is_nil(context.service.extracted_credentials)
+          assert.is_nil(context.extracted_credentials)
         end
       end)
     end)

--- a/spec/proxy_spec.lua
+++ b/spec/proxy_spec.lua
@@ -38,7 +38,8 @@ describe('Proxy', function()
       service.credentials = { location = 'headers' }
       service.backend_version = 2
       ngx.var.http_app_key = 'key'
-      assert.falsy(proxy:rewrite(service))
+      local context = {}
+      assert.falsy(proxy:rewrite(service, context))
     end)
   end)
 

--- a/t/apicast-policy-default-credentials.t
+++ b/t/apicast-policy-default-credentials.t
@@ -202,3 +202,115 @@ yay, api backend
 --- error_code: 200
 --- no_error_log
 [error]
+
+=== TEST 5: does not reuse default user key in subsequent requests
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.default_credentials",
+            "configuration": {
+              "auth_type": "user_key",
+              "user_key": "default_user_key"
+            }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      if ngx.var['arg_user_key'] == 'default_user_key' then
+        local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=default_user_key"
+        require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+        ngx.exit(200)
+      else
+        -- Reject the rest of the keys
+        ngx.exit(403)
+      end
+    }
+  }
+--- upstream
+  location / {
+     echo 'yay, api backend';
+  }
+--- request eval
+["GET /", "GET /?user_key=some_invalid_key", "GET /?user_key=another_invalid_key"]
+--- response_body eval
+["yay, api backend\x{0a}", "Authentication failed", "Authentication failed"]
+--- error_code eval
+[ 200, 403, 403 ]
+--- no_error_log
+[error]
+
+=== TEST 6: does not reuse default app_id+app_key in subsequent requests
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  2,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.default_credentials",
+            "configuration": {
+              "auth_type": "app_id_and_app_key",
+              "app_id": "default_app_id",
+              "app_key": "default_app_key"
+            }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      if ngx.var['arg_app_key'] == 'default_app_key' and ngx.var['arg_app_id'] == 'default_app_id' then
+        local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&app_id=default_app_id&app_key=default_app_key"
+        require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+        ngx.exit(200)
+      else
+        ngx.exit(403)
+      end
+    }
+  }
+--- upstream
+  location / {
+     echo 'yay, api backend';
+  }
+--- request eval
+["GET /", "GET /?app_id=some_invalid_id&app_key=some_invalid_key", "GET /?app_id=some_invalid_id&app_key=some_invalid_key"]
+--- response_body eval
+["yay, api backend\x{0a}", "Authentication failed", "Authentication failed"]
+--- error_code eval
+[ 200, 403, 403 ]
+--- no_error_log
+[error]


### PR DESCRIPTION
The default credentials policy was not working correctly because it stored the default credentials in the service instead of the policies context.
Ref: https://issues.jboss.org/browse/THREESCALE-1547