### PR TITLE
version: bump to 3.5.0-master

### DIFF
--- a/gateway/src/apicast/version.lua
+++ b/gateway/src/apicast/version.lua
@@ -1,1 +1,1 @@
-return "3.4.0"
+return "3.5.0-master"


### PR DESCRIPTION
Everything merged to master from now on will be part of the next release, so we need to change the version.