### PR TITLE
circleci: use already installed deps in the profiling task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,7 @@ jobs:
   profile:
     machine: true
     steps:
-      - checkout
+      - attach-workspace
       - run: sudo --preserve-env script/install/circleci.sh
       - run: sudo --preserve-env script/install/utilities.sh
       - run: script/install/apicast.sh


### PR DESCRIPTION
The profiling task was installing the lua and perl dependencies already installed in previous tasks.