### PR TITLE
fixed description in CORS policy.

### DIFF
--- a/gateway/src/apicast/policy/cors/apicast-policy.json
+++ b/gateway/src/apicast/policy/cors/apicast-policy.json
@@ -38,7 +38,7 @@
         }
       },
       "allow_origin": {
-        "description": "Origins for which the response can be shared with",
+        "description": "Origin allowed for CORS requests. The field expects only one origin (e.g. https://example.com) or '*'. If left blank, the value of the 'Origin' request header will be used.",
         "type": "string"
       },
       "allow_credentials": {


### PR DESCRIPTION
I added further specification to the description of the field allow_origin in the CORS policy so that the users are aware that only one origin or '*' are allowed.