### PR TITLE
[THREESCALE-1709] Routing policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - "Matches" operation that can be used when defining conditionals [PR #975](https://github.com/3scale/apicast/pull/975)
+- New routing policy that selects an upstream based on the request path, a header, a query argument, or a jwt claim [PR #976](https://github.com/3scale/apicast/pull/976), [THREESCALE-1709](https://issues.jboss.org/browse/THREESCALE-1709)
 
 ### Changed
 

--- a/gateway/src/apicast/policy/routing/README.md
+++ b/gateway/src/apicast/policy/routing/README.md
@@ -1,0 +1,316 @@
+# Routing policy
+
+- [**Description**](#description)
+- [**Rule that uses the request path**](#rule-that-uses-the-request-path)
+- [**Rule that uses a header**](#rule-that-uses-a-header)
+- [**Rule that uses a query argument**](#rule-that-uses-a-query-argument)
+- [**Rule that uses a jwt claim**](#rule-that-uses-a-jwt-claim)
+- [**Rule with several operations**](#rule-with-several-operations)
+- [**Combining rules**](#combining-rules)
+- [**Supported operations**](#supported-operations)
+- [**Liquid templating**](#liquid-templating)
+
+## Description
+
+This policy allows to modify the upstream (scheme, host, and port) of a request
+based on:
+
+- The request path
+- A header
+- A query argument
+- A jwt claim
+
+## Rule that uses the request path
+
+This is a configuration that routes to `http://example.com` when the path is
+`/accounts`:
+
+```json
+  {
+    "name": "routing",
+    "version": "builtin",
+    "configuration": {
+      "rules": [
+        {
+          "url": "http://example.com",
+          "condition": {
+            "operations": [
+              {
+                "thing_to_match": "path",
+                "op": "==",
+                "value": "/accounts"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+```
+
+## Rule that uses a header
+
+This is a configuration that routes to `http://example.com` when the value of
+the header `Test-Header` is `123`:
+
+```json
+  {
+    "name": "routing",
+    "version": "builtin",
+    "configuration": {
+      "rules": [
+        {
+          "url": "http://example.com",
+          "condition": {
+            "operations": [
+              {
+                "thing_to_match": "header",
+                "header_name": "Test-Header",
+                "op": "==",
+                "value": "123"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+```
+
+## Rule that uses a query argument
+
+This is a configuration that routes to `http://example.com` when the value of
+the query argument `test_query_arg` is `123`:
+
+```json
+  {
+    "name": "routing",
+    "version": "builtin",
+    "configuration": {
+      "rules": [
+        {
+          "url": "http://example.com",
+          "condition": {
+            "operations": [
+              {
+                "thing_to_match": "query_arg",
+                "query_arg_name": "test_query_arg",
+                "op": "==",
+                "value": "123"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+```
+
+## Rule that uses a jwt claim
+
+In order to be able to route based on the value of a jwt claim, there needs to
+be a policy in the chain that validates the jwt and stores it in the context
+that the policies share.
+
+This is a configuration that routes to `http://example.com` when the value of
+the jwt claim `test_claim` is `123`:
+
+```json
+  {
+    "name": "routing",
+    "version": "builtin",
+    "configuration": {
+      "rules": [
+        {
+          "url": "http://example.com",
+          "condition": {
+            "operations": [
+              {
+                "thing_to_match": "jwt_claim",
+                "jwt_claim_name": "test_claim",
+                "op": "==",
+                "value": "123"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+```
+
+## Rule with several operations
+
+Rules can have several operations and route to the given upstream only when all
+of them evaluate to true (using the 'and' `combine_op`), or when at least one of
+them evaluates to true (using the 'or' `combine_op`). The default value of
+`combine_op` is 'and'.
+
+This is a configuration that routes to `http://example.com` when the path of the
+request is `/accounts` and when the value of the header `Test-Header` is `123`:
+
+```json
+  {
+    "name": "routing",
+    "version": "builtin",
+    "configuration": {
+      "rules": [
+        {
+          "url": "http://example.com",
+          "condition": {
+            "combine_op": "and",
+            "operations": [
+              {
+                "thing_to_match": "path",
+                "op": "==",
+                "value": "/accounts"
+              },
+              {
+                "thing_to_match": "header",
+                "header_name": "Test-Header",
+                "op": "==",
+                "value": "123"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+```
+
+This is a configuration that routes to `http://example.com` when the path of the
+request is `/accounts` or when the value of the header `Test-Header` is `123`:
+
+```json
+  {
+    "name": "routing",
+    "version": "builtin",
+    "configuration": {
+      "rules": [
+        {
+          "url": "http://example.com",
+          "condition": {
+            "combine_op": "or",
+            "operations": [
+              {
+                "thing_to_match": "path",
+                "op": "==",
+                "value": "/accounts"
+              },
+              {
+                "thing_to_match": "header",
+                "header_name": "Test-Header",
+                "op": "==",
+                "value": "123"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+```
+
+## Combining rules
+
+Rules can be combined. When there are several of them, the upstream selected is
+the one of the first rule that evaluates to true.
+
+This is a configuration with several rules:
+```json
+  {
+    "name": "routing",
+    "version": "builtin",
+    "configuration": {
+      "rules": [
+        {
+          "url": "http://some_upstream.com",
+          "condition": {
+            "operations": [
+              {
+                "thing_to_match": "path",
+                "op": "==",
+                "value": "/accounts"
+              }
+            ]
+          }
+        },
+        {
+          "url": "http://another_upstream.com",
+          "condition": {
+            "operations": [
+              {
+                "thing_to_match": "path",
+                "op": "==",
+                "value": "/users"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+```
+
+## Supported operations
+
+The supported operations are `==`, `!=`, and `matches`. The latter matches a
+string with a regular expression and it is implemented using
+[ngx.re.match](https://github.com/openresty/lua-nginx-module#ngxrematch)
+
+This is a configuration that uses `!=`. It routes to `http://example.com` when
+the path is not `/accounts`:
+```json
+  {
+    "name": "routing",
+    "version": "builtin",
+    "configuration": {
+      "rules": [
+        {
+          "url": "http://example.com",
+          "condition": {
+            "operations": [
+              {
+                "thing_to_match": "path",
+                "op": "!=",
+                "value": "/accounts"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+```
+
+## Liquid templating
+
+It is possible to use liquid templating for the values of the configuration.
+This allows to define rules with dynamic values. Suppose that a policy in the
+chain stores the key `my_var` in the context. As an example, this is a
+configuration that uses that value to route the request:
+```json
+  {
+    "name": "routing",
+    "version": "builtin",
+    "configuration": {
+      "rules": [
+        {
+          "url": "http://example.com",
+          "condition": {
+            "operations": [
+              {
+                "thing_to_match": "header",
+                "header_name": "Test-Header",
+                "op": "==",
+                "value": "{{ my_var }}",
+                "value_type": "liquid"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+```

--- a/gateway/src/apicast/policy/routing/README.md
+++ b/gateway/src/apicast/policy/routing/README.md
@@ -36,7 +36,7 @@ This is a configuration that routes to `http://example.com` when the path is
           "condition": {
             "operations": [
               {
-                "thing_to_match": "path",
+                "match": "path",
                 "op": "==",
                 "value": "/accounts"
               }
@@ -64,7 +64,7 @@ the header `Test-Header` is `123`:
           "condition": {
             "operations": [
               {
-                "thing_to_match": "header",
+                "match": "header",
                 "header_name": "Test-Header",
                 "op": "==",
                 "value": "123"
@@ -93,7 +93,7 @@ the query argument `test_query_arg` is `123`:
           "condition": {
             "operations": [
               {
-                "thing_to_match": "query_arg",
+                "match": "query_arg",
                 "query_arg_name": "test_query_arg",
                 "op": "==",
                 "value": "123"
@@ -126,7 +126,7 @@ the jwt claim `test_claim` is `123`:
           "condition": {
             "operations": [
               {
-                "thing_to_match": "jwt_claim",
+                "match": "jwt_claim",
                 "jwt_claim_name": "test_claim",
                 "op": "==",
                 "value": "123"
@@ -161,12 +161,12 @@ request is `/accounts` and when the value of the header `Test-Header` is `123`:
             "combine_op": "and",
             "operations": [
               {
-                "thing_to_match": "path",
+                "match": "path",
                 "op": "==",
                 "value": "/accounts"
               },
               {
-                "thing_to_match": "header",
+                "match": "header",
                 "header_name": "Test-Header",
                 "op": "==",
                 "value": "123"
@@ -194,12 +194,12 @@ request is `/accounts` or when the value of the header `Test-Header` is `123`:
             "combine_op": "or",
             "operations": [
               {
-                "thing_to_match": "path",
+                "match": "path",
                 "op": "==",
                 "value": "/accounts"
               },
               {
-                "thing_to_match": "header",
+                "match": "header",
                 "header_name": "Test-Header",
                 "op": "==",
                 "value": "123"
@@ -229,7 +229,7 @@ This is a configuration with several rules:
           "condition": {
             "operations": [
               {
-                "thing_to_match": "path",
+                "match": "path",
                 "op": "==",
                 "value": "/accounts"
               }
@@ -241,7 +241,7 @@ This is a configuration with several rules:
           "condition": {
             "operations": [
               {
-                "thing_to_match": "path",
+                "match": "path",
                 "op": "==",
                 "value": "/users"
               }
@@ -272,7 +272,7 @@ the path is not `/accounts`:
           "condition": {
             "operations": [
               {
-                "thing_to_match": "path",
+                "match": "path",
                 "op": "!=",
                 "value": "/accounts"
               }
@@ -301,7 +301,7 @@ configuration that uses that value to route the request:
           "condition": {
             "operations": [
               {
-                "thing_to_match": "header",
+                "match": "header",
                 "header_name": "Test-Header",
                 "op": "==",
                 "value": "{{ my_var }}",

--- a/gateway/src/apicast/policy/routing/apicast-policy.json
+++ b/gateway/src/apicast/policy/routing/apicast-policy.json
@@ -116,9 +116,19 @@
               "type": "string"
             },
             "condition": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/operation"
+              "type": "object",
+              "properties": {
+                "operations": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/operation"
+                  }
+                },
+                "combine_op": {
+                  "type": "string",
+                  "enum": ["and", "or"],
+                  "default": "and"
+                }
               }
             }
           }

--- a/gateway/src/apicast/policy/routing/apicast-policy.json
+++ b/gateway/src/apicast/policy/routing/apicast-policy.json
@@ -36,6 +36,21 @@
           },
           "value": {
             "type": "string"
+          },
+          "value_type": {
+            "description": "How to evaluate 'type'",
+            "type": "string",
+            "default": "plain",
+            "oneOf": [
+              {
+                "enum": ["plain"],
+                "title": "Evaluate 'value' as plain text."
+              },
+              {
+                "enum": ["liquid"],
+                "title": "Evaluate 'value' as liquid."
+              }
+            ]
           }
         },
         "required": [

--- a/gateway/src/apicast/policy/routing/apicast-policy.json
+++ b/gateway/src/apicast/policy/routing/apicast-policy.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "Routing",
+  "summary": "Allows to modify the upstream URL of the request.",
+  "description": [
+    "This policy allows to modify the upstream URL (scheme, host and port) of ",
+    "the request based on its path, its query arguments, a header, or a JWT ",
+    "claim. \n",
+    "When combined with the APIcast policy, the upstream policy should be ",
+    "placed before it in the policy chain."
+  ],
+  "version": "builtin",
+  "configuration": {
+    "type": "object",
+    "definitions": {
+      "operation": {
+        "type": "object",
+        "$id": "#/definitions/operation",
+        "properties": {
+          "thing_to_match": {
+            "type": "string",
+            "enum": [
+              "path",
+              "header",
+              "query_arg",
+              "jwt_claim"
+            ]
+          },
+          "op": {
+            "type": "string",
+            "enum": [
+              "==",
+              "!=",
+              "matches"
+            ]
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "thing_to_match",
+          "op",
+          "value"
+        ],
+        "dependencies": {
+          "thing_to_match": {
+            "oneOf": [
+              {
+                "properties": {
+                  "thing_to_match": {
+                    "enum": [
+                      "header"
+                    ]
+                  },
+                  "header_name" : {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "header_name"
+                ]
+              },
+              {
+                "properties": {
+                  "thing_to_match": {
+                    "enum": [
+                      "query_arg"
+                    ]
+                  },
+                  "query_arg_name" : {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "query_arg_name"
+                ]
+              },
+              {
+                "properties": {
+                  "thing_to_match": {
+                    "enum": [
+                      "jwt_claim"
+                    ]
+                  },
+                  "jwt_claim_name" : {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "jwt_claim_name"
+                ]
+              },
+              {
+                "properties": {
+                  "thing_to_match": {
+                    "enum": [
+                      "path"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "properties": {
+      "rules": {
+        "description": "list of rules to be applied",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string"
+            },
+            "condition": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/operation"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/gateway/src/apicast/policy/routing/apicast-policy.json
+++ b/gateway/src/apicast/policy/routing/apicast-policy.json
@@ -17,7 +17,7 @@
         "type": "object",
         "$id": "#/definitions/operation",
         "properties": {
-          "thing_to_match": {
+          "match": {
             "type": "string",
             "enum": [
               "path",
@@ -54,16 +54,16 @@
           }
         },
         "required": [
-          "thing_to_match",
+          "match",
           "op",
           "value"
         ],
         "dependencies": {
-          "thing_to_match": {
+          "match": {
             "oneOf": [
               {
                 "properties": {
-                  "thing_to_match": {
+                  "match": {
                     "enum": [
                       "header"
                     ]
@@ -78,7 +78,7 @@
               },
               {
                 "properties": {
-                  "thing_to_match": {
+                  "match": {
                     "enum": [
                       "query_arg"
                     ]
@@ -93,7 +93,7 @@
               },
               {
                 "properties": {
-                  "thing_to_match": {
+                  "match": {
                     "enum": [
                       "jwt_claim"
                     ]
@@ -108,7 +108,7 @@
               },
               {
                 "properties": {
-                  "thing_to_match": {
+                  "match": {
                     "enum": [
                       "path"
                     ]

--- a/gateway/src/apicast/policy/routing/init.lua
+++ b/gateway/src/apicast/policy/routing/init.lua
@@ -1,0 +1,1 @@
+return require('routing')

--- a/gateway/src/apicast/policy/routing/request.lua
+++ b/gateway/src/apicast/policy/routing/request.lua
@@ -1,0 +1,35 @@
+local setmetatable = setmetatable
+
+local _M = {}
+
+local mt = { __index = _M }
+
+function _M.new()
+  local self = setmetatable({}, mt)
+  return self
+end
+
+function _M:get_uri()
+  self.uri = self.uri or ngx.var.uri
+  return self.uri
+end
+
+function _M:get_header(name)
+  self.headers = self.headers or ngx.req.get_headers()
+  return self.headers[name]
+end
+
+function _M:get_uri_arg(name)
+  self.query_args = self.query_args or ngx.req.get_uri_args()
+  return self.query_args[name]
+end
+
+function _M:set_validated_jwt(jwt)
+  self.jwt = jwt
+end
+
+function _M:get_validated_jwt()
+  return self.jwt
+end
+
+return _M

--- a/gateway/src/apicast/policy/routing/routing.lua
+++ b/gateway/src/apicast/policy/routing/routing.lua
@@ -1,0 +1,59 @@
+local ipairs = ipairs
+local tab_insert = table.insert
+local tab_new = require('resty.core.base').new_tab
+
+local balancer = require('apicast.balancer')
+local UpstreamSelector = require('upstream_selector')
+local Request = require('request')
+local Rule = require('rule')
+
+local _M = require('apicast.policy').new('Routing policy')
+
+local new = _M.new
+
+local function init_rules(config)
+  if not config or not config.rules then return tab_new(0, 0) end
+
+  local res = tab_new(#config.rules, 0)
+
+  for _, config_rule in ipairs(config.rules) do
+    local rule, err = Rule.new_from_config_rule(config_rule)
+
+    if rule then
+      tab_insert(res, rule)
+    else
+      ngx.log(ngx.WARN, err)
+    end
+  end
+
+  return res
+end
+
+function _M.new(config)
+  local self = new(config)
+  self.upstream_selector = UpstreamSelector.new()
+  self.rules = init_rules(config)
+  return self
+end
+
+function _M:content(context)
+  -- This should be moved to the place where the context is started, so other
+  -- policies can use it.
+  context.request = context.request or Request.new()
+
+  -- Once request is in the context, we should move this to wherever the jwt is
+  -- validated.
+  context.request:set_validated_jwt(context.jwt)
+
+  local upstream = self.upstream_selector:select(self.rules, context)
+
+  if upstream then
+    upstream:call(context)
+  else
+    return nil, 'no upstream'
+  end
+end
+
+_M.balancer = balancer.call
+
+return _M

--- a/gateway/src/apicast/policy/routing/routing_operation.lua
+++ b/gateway/src/apicast/policy/routing/routing_operation.lua
@@ -1,0 +1,65 @@
+--- RoutingOperation
+-- This module is based on the Operation one. The only difference is that
+-- operations for the routing policy check request information that is not
+-- available when the operation is instantiated, like headers, query arguments,
+-- etc. That is the reason why in instances of this module, there are functions
+-- to get the left operand instead of the operand itself.
+
+local setmetatable = setmetatable
+local Operation = require('apicast.conditions.operation')
+
+local _M = {}
+
+local mt = { __index = _M }
+
+local function new(evaluate_left_side_func, op, value)
+  local self = setmetatable({}, mt)
+
+  self.evaluate_left_side_func = evaluate_left_side_func
+  self.op = op
+  self.value = value
+
+  return self
+end
+
+function _M.new_op_with_path(op, value)
+  local eval_left_func = function(request) return request:get_uri() end
+  return new(eval_left_func, op, value)
+end
+
+function _M.new_op_with_header(header_name, op, value)
+  local eval_left_func = function(request)
+    return request:get_header(header_name)
+  end
+
+  return new(eval_left_func, op, value)
+end
+
+function _M.new_op_with_query_arg(query_arg_name, op, value)
+  local eval_left_func = function(request)
+    return request:get_uri_arg(query_arg_name)
+  end
+
+  return new(eval_left_func, op, value)
+end
+
+function _M.new_op_with_jwt_claim(jwt_claim_name, op, value)
+  local eval_left_func = function(request)
+    local jwt = request:get_validated_jwt()
+    return (jwt and jwt[jwt_claim_name]) or nil
+  end
+
+  return new(eval_left_func, op, value)
+end
+
+function _M:evaluate(context)
+  local left_operand_val = self.evaluate_left_side_func(context.request)
+
+  local op = Operation.new(
+    left_operand_val, 'plain', self.op, self.value, 'plain'
+  )
+
+  return op:evaluate(context)
+end
+
+return _M

--- a/gateway/src/apicast/policy/routing/routing_operation.lua
+++ b/gateway/src/apicast/policy/routing/routing_operation.lua
@@ -12,51 +12,52 @@ local _M = {}
 
 local mt = { __index = _M }
 
-local function new(evaluate_left_side_func, op, value)
+local function new(evaluate_left_side_func, op, value, value_type)
   local self = setmetatable({}, mt)
 
   self.evaluate_left_side_func = evaluate_left_side_func
   self.op = op
   self.value = value
+  self.value_type = value_type
 
   return self
 end
 
-function _M.new_op_with_path(op, value)
+function _M.new_op_with_path(op, value, value_type)
   local eval_left_func = function(request) return request:get_uri() end
-  return new(eval_left_func, op, value)
+  return new(eval_left_func, op, value, value_type)
 end
 
-function _M.new_op_with_header(header_name, op, value)
+function _M.new_op_with_header(header_name, op, value, value_type)
   local eval_left_func = function(request)
     return request:get_header(header_name)
   end
 
-  return new(eval_left_func, op, value)
+  return new(eval_left_func, op, value, value_type)
 end
 
-function _M.new_op_with_query_arg(query_arg_name, op, value)
+function _M.new_op_with_query_arg(query_arg_name, op, value, value_type)
   local eval_left_func = function(request)
     return request:get_uri_arg(query_arg_name)
   end
 
-  return new(eval_left_func, op, value)
+  return new(eval_left_func, op, value, value_type)
 end
 
-function _M.new_op_with_jwt_claim(jwt_claim_name, op, value)
+function _M.new_op_with_jwt_claim(jwt_claim_name, op, value, value_type)
   local eval_left_func = function(request)
     local jwt = request:get_validated_jwt()
     return (jwt and jwt[jwt_claim_name]) or nil
   end
 
-  return new(eval_left_func, op, value)
+  return new(eval_left_func, op, value, value_type)
 end
 
 function _M:evaluate(context)
   local left_operand_val = self.evaluate_left_side_func(context.request)
 
   local op = Operation.new(
-    left_operand_val, 'plain', self.op, self.value, 'plain'
+    left_operand_val, 'plain', self.op, self.value, self.value_type
   )
 
   return op:evaluate(context)

--- a/gateway/src/apicast/policy/routing/rule.lua
+++ b/gateway/src/apicast/policy/routing/rule.lua
@@ -24,15 +24,16 @@ local function init_operation(config_operation)
   local thing_to_match_val = value_of_thing_to_match(thing_to_match, config_operation)
   local op = config_operation.op
   local value = config_operation.value
+  local value_type = config_operation.value_type
 
   if thing_to_match == 'path' then
-    return RoutingOperation.new_op_with_path(op, value)
+    return RoutingOperation.new_op_with_path(op, value, value_type)
   elseif thing_to_match == 'header' then
-    return RoutingOperation.new_op_with_header(thing_to_match_val, op, value)
+    return RoutingOperation.new_op_with_header(thing_to_match_val, op, value, value_type)
   elseif thing_to_match == 'query_arg' then
-    return RoutingOperation.new_op_with_query_arg(thing_to_match_val, op, value)
+    return RoutingOperation.new_op_with_query_arg(thing_to_match_val, op, value, value_type)
   elseif thing_to_match == 'jwt_claim' then
-    return RoutingOperation.new_op_with_jwt_claim(thing_to_match_val, op, value)
+    return RoutingOperation.new_op_with_jwt_claim(thing_to_match_val, op, value, value_type)
   else
     error('Thing to be matched not supported: ' .. thing_to_match)
   end

--- a/gateway/src/apicast/policy/routing/rule.lua
+++ b/gateway/src/apicast/policy/routing/rule.lua
@@ -1,0 +1,68 @@
+local setmetatable = setmetatable
+local ipairs = ipairs
+local tab_insert = table.insert
+local tab_new = require('resty.core.base').new_tab
+local error = error
+
+local RoutingOperation = require('apicast.policy.routing.routing_operation')
+local Condition = require('apicast.conditions.condition')
+local Upstream = require('apicast.upstream')
+
+local _M = {}
+
+local mt = { __index = _M }
+
+local function value_of_thing_to_match(thing_to_be_matched, config_condition)
+  return (thing_to_be_matched == 'header' and config_condition.header_name) or
+    (thing_to_be_matched == 'query_arg' and config_condition.query_arg_name) or
+    (thing_to_be_matched == 'jwt_claim' and config_condition.jwt_claim_name) or
+    nil
+end
+
+local function init_operation(config_operation)
+  local thing_to_match = config_operation.thing_to_match
+  local thing_to_match_val = value_of_thing_to_match(thing_to_match, config_operation)
+  local op = config_operation.op
+  local value = config_operation.value
+
+  if thing_to_match == 'path' then
+    return RoutingOperation.new_op_with_path(op, value)
+  elseif thing_to_match == 'header' then
+    return RoutingOperation.new_op_with_header(thing_to_match_val, op, value)
+  elseif thing_to_match == 'query_arg' then
+    return RoutingOperation.new_op_with_query_arg(thing_to_match_val, op, value)
+  elseif thing_to_match == 'jwt_claim' then
+    return RoutingOperation.new_op_with_jwt_claim(thing_to_match_val, op, value)
+  else
+    error('Thing to be matched not supported: ' .. thing_to_match)
+  end
+end
+
+local function init_condition(config_operations)
+  local operations = tab_new(#config_operations, 0)
+
+  for _, operation in ipairs(config_operations) do
+    tab_insert(operations, init_operation(operation))
+  end
+
+  return Condition.new(operations, 'and')
+end
+
+-- config_rule is a rule as defined in the Routing policy
+function _M.new_from_config_rule(config_rule)
+  local self = setmetatable({}, mt)
+
+  -- Validate the upstream to avoid creating invalid rules
+  local upstream, err = Upstream.new(config_rule.url)
+
+  if upstream then
+    self.url = config_rule.url
+    self.condition = init_condition(config_rule.condition)
+    return self
+  else
+    return nil, 'failed to initialize upstream from url: ',
+                config_rule.url, ' err: ', err
+  end
+end
+
+return _M

--- a/gateway/src/apicast/policy/routing/rule.lua
+++ b/gateway/src/apicast/policy/routing/rule.lua
@@ -12,7 +12,7 @@ local _M = {}
 
 local mt = { __index = _M }
 
-local function value_of_thing_to_match(thing_to_be_matched, config_condition)
+local function value_of_match(thing_to_be_matched, config_condition)
   return (thing_to_be_matched == 'header' and config_condition.header_name) or
     (thing_to_be_matched == 'query_arg' and config_condition.query_arg_name) or
     (thing_to_be_matched == 'jwt_claim' and config_condition.jwt_claim_name) or
@@ -20,22 +20,22 @@ local function value_of_thing_to_match(thing_to_be_matched, config_condition)
 end
 
 local function init_operation(config_operation)
-  local thing_to_match = config_operation.thing_to_match
-  local thing_to_match_val = value_of_thing_to_match(thing_to_match, config_operation)
+  local match = config_operation.match
+  local match_val = value_of_match(match, config_operation)
   local op = config_operation.op
   local value = config_operation.value
   local value_type = config_operation.value_type
 
-  if thing_to_match == 'path' then
+  if match == 'path' then
     return RoutingOperation.new_op_with_path(op, value, value_type)
-  elseif thing_to_match == 'header' then
-    return RoutingOperation.new_op_with_header(thing_to_match_val, op, value, value_type)
-  elseif thing_to_match == 'query_arg' then
-    return RoutingOperation.new_op_with_query_arg(thing_to_match_val, op, value, value_type)
-  elseif thing_to_match == 'jwt_claim' then
-    return RoutingOperation.new_op_with_jwt_claim(thing_to_match_val, op, value, value_type)
+  elseif match == 'header' then
+    return RoutingOperation.new_op_with_header(match_val, op, value, value_type)
+  elseif match == 'query_arg' then
+    return RoutingOperation.new_op_with_query_arg(match_val, op, value, value_type)
+  elseif match == 'jwt_claim' then
+    return RoutingOperation.new_op_with_jwt_claim(match_val, op, value, value_type)
   else
-    error('Thing to be matched not supported: ' .. thing_to_match)
+    error('Thing to be matched not supported: ' .. match)
   end
 end
 

--- a/gateway/src/apicast/policy/routing/rule.lua
+++ b/gateway/src/apicast/policy/routing/rule.lua
@@ -38,14 +38,14 @@ local function init_operation(config_operation)
   end
 end
 
-local function init_condition(config_operations)
-  local operations = tab_new(#config_operations, 0)
+local function init_condition(config_condition)
+  local operations = tab_new(#config_condition.operations, 0)
 
-  for _, operation in ipairs(config_operations) do
+  for _, operation in ipairs(config_condition.operations) do
     tab_insert(operations, init_operation(operation))
   end
 
-  return Condition.new(operations, 'and')
+  return Condition.new(operations, config_condition.combine_op)
 end
 
 -- config_rule is a rule as defined in the Routing policy

--- a/gateway/src/apicast/policy/routing/upstream_selector.lua
+++ b/gateway/src/apicast/policy/routing/upstream_selector.lua
@@ -1,0 +1,35 @@
+local ipairs = ipairs
+local setmetatable = setmetatable
+
+local Upstream = require('apicast.upstream')
+
+local _M = {}
+
+local mt = { __index = _M }
+
+function _M.new()
+  local self = setmetatable({}, mt)
+  return self
+end
+
+--- Selects an upstream based on a list of rules.
+-- @tparam rules table Table with instances of Rule
+-- @tparam context table Context used to evaluate the conditions
+-- @treturn Upstream Returns an instance of Upstream initialized with the url
+--   of the first rule whose condition evaluates to true. If there are no rules
+--   or none of them evaluate to true, this method returns nil.
+function _M.select(_, rules, context)
+  if not rules then return nil end
+
+  for _, rule in ipairs(rules) do
+    local cond_is_true = rule.condition:evaluate(context)
+
+    if cond_is_true then
+      return Upstream.new(rule.url)
+    end
+  end
+
+  return nil
+end
+
+return _M

--- a/spec/policy/routing/request_spec.lua
+++ b/spec/policy/routing/request_spec.lua
@@ -1,0 +1,124 @@
+local Request = require('apicast.policy.routing.request')
+
+describe('Request', function()
+  describe('.get_uri', function()
+    it('returns the uri', function()
+      ngx.var = { uri = 'test_path' }
+      local request = Request.new()
+
+      local uri = request:get_uri()
+
+      assert.equals(ngx.var.uri, uri)
+    end)
+
+    it('caches the uri', function()
+      ngx.var = { uri = 'test_path' }
+      local request = Request.new()
+
+      request:get_uri() -- cached after this
+      local uri = request:get_uri()
+
+      assert.equals(ngx.var.uri, uri)
+    end)
+  end)
+
+  describe('.get_header', function()
+    it('returns the value of the header', function()
+      local header_name = 'test_header'
+      local header_val = 'some_value'
+      stub(ngx.req, 'get_headers',
+        function() return { [header_name] = header_val }
+      end)
+      local request = Request.new()
+
+      local res = request:get_header(header_name)
+
+      assert.equals(header_val, res)
+    end)
+
+    it('caches the value of the header', function()
+      local header_name = 'test_header'
+      local header_val = 'some_value'
+      stub(ngx.req, 'get_headers',
+        function() return { [header_name] = header_val }
+        end)
+      local request = Request.new()
+
+      request:get_header(header_name) -- cached after this
+      local res = request:get_header(header_name)
+
+      assert.stub(ngx.req.get_headers).was_called(1)
+      assert.equals(header_val, res)
+    end)
+
+    it('returns nil when the header is not set', function()
+      local header_name = 'test_header'
+      stub(ngx.req, 'get_headers', function()
+        return { [header_name] = nil }
+      end)
+      local request = Request.new()
+
+      local res = request:get_header(header_name)
+
+      assert.is_nil(res)
+    end)
+  end)
+
+  describe('.get_uri_arg', function()
+    it('returns the value of the query arg', function()
+      local query_arg_name = 'test_query_arg'
+      local query_arg_val = 'some_value'
+      stub(ngx.req, 'get_uri_args', function()
+        return { [query_arg_name] = query_arg_val }
+      end)
+      local request = Request.new()
+
+      local res = request:get_uri_arg(query_arg_name)
+
+      assert.equals(query_arg_val, res)
+    end)
+
+    it('caches the value of the query arg', function()
+      local query_arg_name = 'test_query_arg'
+      local query_arg_val = 'some_value'
+      stub(ngx.req, 'get_uri_args', function()
+        return { [query_arg_name] = query_arg_val }
+      end)
+      local request = Request.new()
+
+      request:get_uri_arg(query_arg_name) -- cached after this
+      local res = request:get_uri_arg(query_arg_name)
+
+      assert.stub(ngx.req.get_uri_args).was_called(1)
+      assert.equals(query_arg_val, res)
+    end)
+
+    it('returns nil when he query arg is not set', function()
+      local query_arg_name = 'test_query_arg'
+      stub(ngx.req, 'get_uri_args', function()
+        return { [query_arg_name] = nil }
+      end)
+      local request = Request.new()
+
+      local res = request:get_uri_arg(query_arg_name)
+
+      assert.is_nil(res)
+    end)
+  end)
+
+  describe('.get_validated_jwt', function()
+    it('returns the jwt when it has been set', function()
+      local request = Request.new()
+      local test_jwt = { some_claim = 'some_val' }
+      request:set_validated_jwt(test_jwt)
+
+      assert.equals(test_jwt, request:get_validated_jwt())
+    end)
+
+    it('returns nil when the jwt has not been set', function()
+      local request = Request.new()
+
+      assert.is_nil(request:get_validated_jwt())
+    end)
+  end)
+end)

--- a/spec/policy/routing/routing_operation_spec.lua
+++ b/spec/policy/routing/routing_operation_spec.lua
@@ -1,4 +1,5 @@
 local RoutingOperation = require('apicast.policy.routing.routing_operation')
+local ngx_variable = require 'apicast.policy.ngx_variable'
 
 describe('RoutingOperation', function()
   describe('.evaluate', function()
@@ -212,6 +213,28 @@ describe('RoutingOperation', function()
 
         assert.is_false(operation:evaluate(context))
       end)
+    end)
+
+    it('can evaluate the right operand as liquid', function()
+      -- Stub the available context to avoid depending on ngx.var.*
+      stub(ngx_variable, 'available_context', function(context) return context end)
+
+      local path = '/a_path'
+
+      local operation = RoutingOperation.new_op_with_path(
+        '==', '{{ value_in_liquid_ctx }}', 'liquid'
+      )
+
+      local request_with_matching_path = {
+        get_uri = function() return path end
+      }
+
+      local context = {
+        request = request_with_matching_path,
+        value_in_liquid_ctx = path
+      }
+
+      assert.is_true(operation:evaluate(context))
     end)
   end)
 end)

--- a/spec/policy/routing/routing_operation_spec.lua
+++ b/spec/policy/routing/routing_operation_spec.lua
@@ -1,0 +1,217 @@
+local RoutingOperation = require('apicast.policy.routing.routing_operation')
+
+describe('RoutingOperation', function()
+  describe('.evaluate', function()
+    describe('when the operation involves the path', function()
+      it('evaluates true conditions correctly', function()
+        local path = '/some_path'
+
+        local operation = RoutingOperation.new_op_with_path('==', path)
+
+        local request_with_matching_path = {
+          get_uri = function() return path end
+        }
+
+        local context = { request = request_with_matching_path }
+
+        assert.is_true(operation:evaluate(context))
+      end)
+
+      it('evaluates false conditions correctly', function()
+        local path = '/some_path'
+
+        local operation = RoutingOperation.new_op_with_path('==', path)
+
+        local request_with_different_path = {
+          get_uri = function() return path .. 'some_diff' end
+        }
+
+        local context = { request = request_with_different_path }
+
+        assert.is_false(operation:evaluate(context))
+      end)
+    end)
+
+    describe('when the operation involves a header', function()
+      it('evaluates true conditions correctly', function()
+        local header_name = 'Test-Header'
+        local header_val = 'some_value'
+
+        local operation = RoutingOperation.new_op_with_header(
+          header_name, '==', header_val
+        )
+
+        local request_with_matching_header = {
+          get_header = function(_, header)
+            if header == header_name then return header_val end
+          end
+        }
+
+        local context = { request = request_with_matching_header }
+
+        assert.is_true(operation:evaluate(context))
+      end)
+
+      it('evaluates false conditions correctly', function()
+        local header_name = 'Test-Header'
+        local header_val = 'some_value'
+
+        local operation = RoutingOperation.new_op_with_header(
+          header_name, '==', header_val
+        )
+
+        local request_with_diff_header_val = {
+          get_header = function(_, header)
+            if header == header_name then return header_val .. 'some_diff' end
+          end
+        }
+
+        local context = { request = request_with_diff_header_val }
+
+        assert.is_false(operation:evaluate(context))
+      end)
+
+      it('returns false when the header is not set', function()
+        local operation = RoutingOperation.new_op_with_header(
+          'some_header', '==', 'some_val'
+        )
+
+        local request_without_headers = {
+          get_header = function() return nil end
+        }
+
+        local context = { request = request_without_headers }
+
+        assert.is_false(operation:evaluate(context))
+      end)
+    end)
+
+    describe('when the operation involves a query argument', function()
+      it('evaluates true conditions correctly', function()
+        local query_arg_name = 'test_query_arg'
+        local query_arg_val = 'some_value'
+
+        local operation = RoutingOperation.new_op_with_query_arg(
+          query_arg_name, '==', query_arg_val
+        )
+
+        local request_with_matching_query_arg = {
+          get_uri_arg = function(_, query_arg)
+            if query_arg == query_arg_name then return query_arg_val end
+          end
+        }
+
+        local context = { request = request_with_matching_query_arg }
+
+        assert.is_true(operation:evaluate(context))
+      end)
+
+      it('evaluates false conditions correctly', function()
+        local query_arg_name = 'test_query_arg'
+        local query_arg_val = 'some_value'
+
+        local operation = RoutingOperation.new_op_with_query_arg(
+          query_arg_name, '==', query_arg_val
+        )
+
+        local request_with_diff_query_arg = {
+          get_uri_arg = function(_, query_arg)
+            if query_arg == query_arg_name then
+              return query_arg_val .. 'some_diff'
+            end
+          end
+        }
+
+        local context = { request = request_with_diff_query_arg }
+
+        assert.is_false(operation:evaluate(context))
+      end)
+
+      it('returns false when the query arg is not set', function()
+        local operation = RoutingOperation.new_op_with_query_arg(
+          'test_query_arg', '==', 'some_val'
+        )
+
+        local request_without_query_args = {
+          get_uri_arg = function() return nil end
+        }
+
+        local context = { request = request_without_query_args }
+
+        assert.is_false(operation:evaluate(context))
+      end)
+    end)
+
+    describe('when the operation involves a jwt claim', function()
+      it('evaluates true conditions correctly', function()
+        local jwt_claim_name = 'test_claim'
+        local jwt_claim_val = 'some_value'
+
+        local operation = RoutingOperation.new_op_with_jwt_claim(
+          jwt_claim_name, '==', jwt_claim_val
+        )
+
+        local request_with_matching_claim = {
+          get_validated_jwt = function()
+            return { [jwt_claim_name] = jwt_claim_val }
+          end
+        }
+
+        local context = { request = request_with_matching_claim }
+
+        assert.is_true(operation:evaluate(context))
+      end)
+
+      it('evaluates false conditions correctly', function()
+        local jwt_claim_name = 'test_claim'
+        local jwt_claim_val = 'some_value'
+
+        local operation = RoutingOperation.new_op_with_jwt_claim(
+          jwt_claim_name, '==', jwt_claim_val
+        )
+
+        local request_with_diff_claim_val = {
+          get_validated_jwt = function()
+            return { [jwt_claim_name] = jwt_claim_val .. 'some_diff' }
+          end
+        }
+
+        local context = { request = request_with_diff_claim_val }
+
+        assert.is_false(operation:evaluate(context))
+      end)
+
+      it('returns false when the jwt is not set', function()
+        local operation = RoutingOperation.new_op_with_jwt_claim(
+          'test_claim', '==', 'some_value'
+        )
+
+        local request_without_jwt = {
+          get_validated_jwt = function()
+            return nil
+          end
+        }
+
+        local context = { request = request_without_jwt }
+
+        assert.is_false(operation:evaluate(context))
+      end)
+
+      it('returns false when the jwt is set but does not have the claim', function()
+        local operation = RoutingOperation.new_op_with_jwt_claim(
+          'test_claim', '==', 'some_value'
+        )
+
+        local request_without_the_claim = {
+          get_validated_jwt = function()
+            return { some_different_claim = 'something' }
+          end
+        }
+
+        local context = { request = request_without_the_claim }
+
+        assert.is_false(operation:evaluate(context))
+      end)
+    end)
+  end)
+end)

--- a/spec/policy/routing/routing_spec.lua
+++ b/spec/policy/routing/routing_spec.lua
@@ -1,0 +1,55 @@
+local RoutingPolicy = require('apicast.policy.routing')
+local UpstreamSelector = require('apicast.policy.routing.upstream_selector')
+local Request = require('apicast.policy.routing.request')
+local Upstream = require('apicast.upstream')
+
+describe('Routing policy', function()
+  describe('.content', function()
+    describe('when there is an upstream that matches', function()
+      local upstream_that_matches = Upstream.new('http://localhost')
+      stub(upstream_that_matches, 'call')
+
+      local upstream_selector = UpstreamSelector.new()
+      stub(upstream_selector, 'select').returns(upstream_that_matches)
+
+      local request = Request.new()
+      local context = { request = request }
+
+      it('calls call() on the upstream passing the context as param', function()
+        local routing = RoutingPolicy.new()
+        routing.upstream_selector = upstream_selector
+
+        routing:content(context)
+
+        assert.stub(upstream_selector.select).was_called_with(
+          upstream_selector, routing.rules, context
+        )
+
+        assert.stub(upstream_that_matches.call).was_called_with(
+          upstream_that_matches, context
+        )
+      end)
+    end)
+
+    describe('when there is not an upstream that matches', function()
+      local upstream_selector = UpstreamSelector.new()
+      stub(upstream_selector, 'select').returns(nil)
+
+      local request = Request.new()
+      local context = { request = request }
+
+      it('returns nil and the msg "no upstream"', function()
+        local routing = RoutingPolicy.new()
+        routing.upstream_selector = upstream_selector
+
+        local res, err = routing:content(context)
+
+        assert.stub(upstream_selector.select).was_called_with(
+          upstream_selector, routing.rules, context
+        )
+        assert.is_nil(res)
+        assert.equals('no upstream', err)
+      end)
+    end)
+  end)
+end)

--- a/spec/policy/routing/upstream_selector_spec.lua
+++ b/spec/policy/routing/upstream_selector_spec.lua
@@ -1,0 +1,105 @@
+local UpstreamSelector = require('apicast.policy.routing.upstream_selector')
+local Operation = require('apicast.conditions.operation')
+local Condition = require('apicast.conditions.condition')
+
+describe('UpstreamSelector', function()
+  local true_condition = Condition.new(
+    { Operation.new('1', 'plain', '==', '1', 'plain') },
+    'and'
+  )
+
+  local false_condition = Condition.new(
+    { Operation.new('1', 'plain', '!=', '1', 'plain') },
+    'and'
+  )
+
+  describe('.select', function()
+    describe('when there is only one rule', function()
+      it('returns its upstream if the condition is true', function()
+        local rules = {
+          {
+            url = 'http://example.com',
+            condition = true_condition
+          }
+        }
+
+        local upstream_selector = UpstreamSelector.new()
+        local upstream = upstream_selector:select(rules, {})
+
+        assert.equals('http', upstream.uri.scheme)
+        assert.equals('example.com', upstream.uri.host)
+      end)
+
+      it('returns nil if the condition is false', function()
+        local rules = {
+          {
+            url = 'http://example.com',
+            condition = false_condition
+          }
+        }
+
+        local upstream_selector = UpstreamSelector.new()
+        local upstream = upstream_selector:select(rules, {})
+
+        assert.is_nil(upstream)
+      end)
+    end)
+
+    describe('when there are several rules', function()
+      it('returns the upstream of the first rule that matches', function()
+        local rules = {
+          {
+            url = 'http://example.com',
+            condition = true_condition
+          },
+          {
+            url = 'http://localhost',
+            condition = true_condition
+          }
+        }
+
+        local upstream_selector = UpstreamSelector.new()
+        local upstream = upstream_selector:select(rules, {})
+
+        assert.equals('http', upstream.uri.scheme)
+        assert.equals('example.com', upstream.uri.host)
+      end)
+
+      it('returns nil if none of them match', function()
+        local rules = {
+          {
+            url = 'http://example.com',
+            condition = false_condition
+          },
+          {
+            url = 'http://localhost',
+            condition = false_condition
+          }
+        }
+
+        local upstream_selector = UpstreamSelector.new()
+        local upstream = upstream_selector:select(rules, {})
+
+        assert.is_nil(upstream)
+      end)
+    end)
+
+    describe('when there are no rules', function()
+      it('returns nil', function()
+        local upstream_selector = UpstreamSelector.new()
+        local upstream = upstream_selector:select({}, {})
+
+        assert.is_nil(upstream)
+      end)
+    end)
+
+    describe('when rules is nil', function()
+      it('returns nil', function()
+        local upstream_selector = UpstreamSelector.new()
+        local upstream = upstream_selector:select(nil, {})
+
+        assert.is_nil(upstream)
+      end)
+    end)
+  end)
+end)

--- a/t/apicast-policy-routing.t
+++ b/t/apicast-policy-routing.t
@@ -1,0 +1,1787 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+our $rsa = `cat t/fixtures/rsa.pem`;
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: the rule matches the path using "==" and the condition is true
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "path",
+                      "op": "==",
+                      "value": "/a_path"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /a_path
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 2: the rule matches the path using "==" and the condition is false
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "path",
+                      "op": "==",
+                      "value": "/"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /i_dont_match
+--- response_body
+GET /i_dont_match HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 3: the rule matches the path using "!=" and the condition is true
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "path",
+                      "op": "!=",
+                      "value": "/"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /i_dont_match {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /i_dont_match
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 4: the rule matches the path using "!=" and the condition is false
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "path",
+                      "op": "!=",
+                      "value": "/a_path"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /a_path
+--- response_body
+GET /a_path HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 5: the rule matches the path using "matches" and the condition is true
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "path",
+                      "op": "matches",
+                      "value": ".*123.*"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /something_123_something
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 6: the rule matches the path using "matches" and the condition is false
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "path",
+                      "op": "matches",
+                      "value": "^123$"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /something_123_something
+--- response_body
+GET /something_123_something HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 7: the rule matches a header using "==" and the condition is true
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "header",
+                      "header_name": "Test-Header",
+                      "op": "==",
+                      "value": "some_value"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /
+--- more_headers
+Test-Header: some_value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 8: the rule matches a header using "==" and the condition is false
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "header",
+                      "header_name": "Test-Header",
+                      "op": "==",
+                      "value": "some_value"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /
+--- more_headers
+Test-Header: i_dont_match
+--- response_body
+GET / HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 9: the rule matches a header using "!=" and the condition is true
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "header",
+                      "header_name": "Test-Header",
+                      "op": "!=",
+                      "value": "some_value"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /
+--- more_headers
+Test-Header: i_dont_match
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 10: the rule matches a header using "!=" and the condition is false
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "header",
+                      "header_name": "Test-Header",
+                      "op": "!=",
+                      "value": "some_value"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /
+--- more_headers
+Test-Header: some_value
+--- response_body
+GET / HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 11: the rule matches a header using "matches" and the condition is true
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "header",
+                      "header_name": "Test-Header",
+                      "op": "matches",
+                      "value": ".*123.*"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /
+--- more_headers
+Test-Header: something_123_something
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 12: the rule matches a header using "matches" and the condition is false
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "header",
+                      "header_name": "Test-Header",
+                      "op": "matches",
+                      "value": ".*123.*"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /
+--- more_headers
+Test-Header: i_dont_match
+--- response_body
+GET / HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 13: the rule matches a query arg using "==" and the condition is true
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "query_arg",
+                      "query_arg_name": "test_arg",
+                      "op": "==",
+                      "value": "some_value"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /a_path?test_arg=some_value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 14: the rule matches a query arg using "==" and the condition is false
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "query_arg",
+                      "query_arg_name": "test_arg",
+                      "op": "==",
+                      "value": "some_value"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /a_path?test_arg=i_dont_match
+--- response_body
+GET /a_path?test_arg=i_dont_match HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 15: the rule matches a query arg using "!=" and the condition is true
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "query_arg",
+                      "query_arg_name": "test_arg",
+                      "op": "!=",
+                      "value": "some_value"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /a_path?test_arg=i_dont_match
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 16: the rule matches a query arg using "!=" and the condition is false
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "query_arg",
+                      "query_arg_name": "test_arg",
+                      "op": "!=",
+                      "value": "some_value"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /a_path?test_arg=some_value
+--- response_body
+GET /a_path?test_arg=some_value HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 17: the rule matches a query arg using "matches" and the condition is true
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "query_arg",
+                      "query_arg_name": "test_arg",
+                      "op": "matches",
+                      "value": ".*123.*"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /a_path?test_arg=something_123_something
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 18: the rule matches a query arg using "matches" and the condition is false
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "query_arg",
+                      "query_arg_name": "test_arg",
+                      "op": "matches",
+                      "value": ".*123.*"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /a_path?test_arg=i_dont_match
+--- response_body
+GET /a_path?test_arg=i_dont_match HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 19: the rule matches a jwt claim using "==" and the condition is true
+--- backend
+   location /transactions/oauth_authrep.xml {
+     content_by_lua_block {
+       ngx.exit(200)
+     }
+   }
+--- configuration
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": {
+        "id_token_signing_alg_values_supported": [
+          "RS256"
+        ]
+      },
+      "keys": {
+        "somekid": {
+          "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----"
+        }
+      }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
+        "api_backend": "http://example.com:80/",
+        "proxy_rules": [
+          {
+            "pattern": "/",
+            "http_method": "GET",
+            "metric_system_name": "hits",
+            "delta": 2
+          }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "jwt_claim",
+                      "jwt_claim_name": "test_jwt_claim",
+                      "op": "==",
+                      "value": "some_value"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /
+--- more_headers eval
+use Crypt::JWT qw(encode_jwt);
+my $jwt = encode_jwt(payload => {
+test_jwt_claim => 'some_value',
+aud => 'the_token_audience',
+sub => 'someone',
+iss => 'https://example.com/auth/realms/apicast',
+exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers=>{ kid => 'somekid' });
+"Authorization: Bearer $jwt"
+--- error_code: 200
+--- response_body
+yay, api backend
+--- no_error_log
+[error]
+
+=== TEST 20: the rule matches a jwt claim using "==" and the condition is false
+--- backend
+   location /transactions/oauth_authrep.xml {
+     content_by_lua_block {
+       ngx.exit(200)
+     }
+   }
+--- configuration
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": {
+        "id_token_signing_alg_values_supported": [
+          "RS256"
+        ]
+      },
+      "keys": {
+        "somekid": {
+          "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----"
+        }
+      }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
+        "api_backend": "http://example.com:80/",
+        "proxy_rules": [
+          {
+            "pattern": "/",
+            "http_method": "GET",
+            "metric_system_name": "hits",
+            "delta": 2
+          }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "jwt_claim",
+                      "jwt_claim_name": "test_jwt_claim",
+                      "op": "==",
+                      "value": "some_value"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /
+--- more_headers eval
+use Crypt::JWT qw(encode_jwt);
+my $jwt = encode_jwt(payload => {
+test_jwt_claim => 'i_dont_match',
+aud => 'the_token_audience',
+sub => 'someone',
+iss => 'https://example.com/auth/realms/apicast',
+exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers=>{ kid => 'somekid' });
+"Authorization: Bearer $jwt"
+--- error_code: 200
+--- response_body
+GET / HTTP/1.1
+--- no_error_log
+[error]
+
+=== TEST 21: the rule matches a jwt claim using "!=" and the condition is true
+--- backend
+   location /transactions/oauth_authrep.xml {
+     content_by_lua_block {
+       ngx.exit(200)
+     }
+   }
+--- configuration
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": {
+        "id_token_signing_alg_values_supported": [
+          "RS256"
+        ]
+      },
+      "keys": {
+        "somekid": {
+          "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----"
+        }
+      }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
+        "api_backend": "http://example.com:80/",
+        "proxy_rules": [
+          {
+            "pattern": "/",
+            "http_method": "GET",
+            "metric_system_name": "hits",
+            "delta": 2
+          }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "jwt_claim",
+                      "jwt_claim_name": "test_jwt_claim",
+                      "op": "!=",
+                      "value": "some_value"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /
+--- more_headers eval
+use Crypt::JWT qw(encode_jwt);
+my $jwt = encode_jwt(payload => {
+test_jwt_claim => 'i_dont_match',
+aud => 'the_token_audience',
+sub => 'someone',
+iss => 'https://example.com/auth/realms/apicast',
+exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers=>{ kid => 'somekid' });
+"Authorization: Bearer $jwt"
+--- error_code: 200
+--- response_body
+yay, api backend
+--- no_error_log
+[error]
+
+=== TEST 22: the rule matches a jwt claim using "!=" and the condition is false
+--- backend
+   location /transactions/oauth_authrep.xml {
+     content_by_lua_block {
+       ngx.exit(200)
+     }
+   }
+--- configuration
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": {
+        "id_token_signing_alg_values_supported": [
+          "RS256"
+        ]
+      },
+      "keys": {
+        "somekid": {
+          "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----"
+        }
+      }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
+        "api_backend": "http://example.com:80/",
+        "proxy_rules": [
+          {
+            "pattern": "/",
+            "http_method": "GET",
+            "metric_system_name": "hits",
+            "delta": 2
+          }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "jwt_claim",
+                      "jwt_claim_name": "test_jwt_claim",
+                      "op": "!=",
+                      "value": "some_value"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /
+--- more_headers eval
+use Crypt::JWT qw(encode_jwt);
+my $jwt = encode_jwt(payload => {
+test_jwt_claim => 'some_value',
+aud => 'the_token_audience',
+sub => 'someone',
+iss => 'https://example.com/auth/realms/apicast',
+exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers=>{ kid => 'somekid' });
+"Authorization: Bearer $jwt"
+--- error_code: 200
+--- response_body
+GET / HTTP/1.1
+--- no_error_log
+[error]
+
+=== TEST 23: the rule matches a jwt claim using "matches" and the condition is true
+--- backend
+   location /transactions/oauth_authrep.xml {
+     content_by_lua_block {
+       ngx.exit(200)
+     }
+   }
+--- configuration
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": {
+        "id_token_signing_alg_values_supported": [
+          "RS256"
+        ]
+      },
+      "keys": {
+        "somekid": {
+          "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----"
+        }
+      }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
+        "api_backend": "http://example.com:80/",
+        "proxy_rules": [
+          {
+            "pattern": "/",
+            "http_method": "GET",
+            "metric_system_name": "hits",
+            "delta": 2
+          }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "jwt_claim",
+                      "jwt_claim_name": "test_jwt_claim",
+                      "op": "matches",
+                      "value": ".*123.*"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /
+--- more_headers eval
+use Crypt::JWT qw(encode_jwt);
+my $jwt = encode_jwt(payload => {
+test_jwt_claim => 'something_123_something',
+aud => 'the_token_audience',
+sub => 'someone',
+iss => 'https://example.com/auth/realms/apicast',
+exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers=>{ kid => 'somekid' });
+"Authorization: Bearer $jwt"
+--- error_code: 200
+--- response_body
+yay, api backend
+--- no_error_log
+[error]
+
+=== TEST 24: the rule matches a jwt claim using "matches" and the condition is false
+--- backend
+   location /transactions/oauth_authrep.xml {
+     content_by_lua_block {
+       ngx.exit(200)
+     }
+   }
+--- configuration
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": {
+        "id_token_signing_alg_values_supported": [
+          "RS256"
+        ]
+      },
+      "keys": {
+        "somekid": {
+          "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----"
+        }
+      }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
+        "api_backend": "http://example.com:80/",
+        "proxy_rules": [
+          {
+            "pattern": "/",
+            "http_method": "GET",
+            "metric_system_name": "hits",
+            "delta": 2
+          }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "jwt_claim",
+                      "jwt_claim_name": "test_jwt_claim",
+                      "op": "matches",
+                      "value": ".*123.*"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /
+--- more_headers eval
+use Crypt::JWT qw(encode_jwt);
+my $jwt = encode_jwt(payload => {
+test_jwt_claim => 'i_dont_match',
+aud => 'the_token_audience',
+sub => 'someone',
+iss => 'https://example.com/auth/realms/apicast',
+exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers=>{ kid => 'somekid' });
+"Authorization: Bearer $jwt"
+--- error_code: 200
+--- response_body
+GET / HTTP/1.1
+--- no_error_log
+[error]
+
+=== TEST 25: several matching rules
+When there are several rules that match, the upstream selected is the one of
+the first rule that matches.
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "path",
+                      "op": "==",
+                      "value": "/a_path"
+                    }
+                  ]
+                },
+                {
+                  "url": "http://example.com",
+                  "condition": [
+                    {
+                      "thing_to_match": "path",
+                      "op": "==",
+                      "value": "/a_path"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /a_path
+--- more_headers
+Test-Header: a_value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 26: upstream with path
+The path of the upstream is appended to the path of the request.
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT/the_path_in_the_rule",
+                  "condition": [
+                    {
+                      "thing_to_match": "path",
+                      "op": "==",
+                      "value": "/the_request_path"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+    echo $request;
+  }
+--- request
+GET /the_request_path
+--- more_headers
+Test-Header: a_value
+--- response_body
+GET /the_path_in_the_rule/the_request_path HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 27: entities in the rules are not set
+This test checks that when the entities in the rules are not set, the program
+does not raise any errors and rules do not match.
+--- backend
+   location /transactions/oauth_authrep.xml {
+     content_by_lua_block {
+       ngx.exit(200)
+     }
+   }
+--- configuration
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": {
+        "id_token_signing_alg_values_supported": [
+          "RS256"
+        ]
+      },
+      "keys": {
+        "somekid": {
+          "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----"
+        }
+      }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
+        "api_backend": "http://example.com:80/",
+        "proxy_rules": [
+          {
+            "pattern": "/",
+            "http_method": "GET",
+            "metric_system_name": "hits",
+            "delta": 2
+          }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "header",
+                      "header_name": "header_not_in_the_request",
+                      "op": "==",
+                      "value": "some_value"
+                    }
+                  ]
+                },
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "query_arg",
+                      "query_arg_name": "arg_not_in_the_request",
+                      "op": "==",
+                      "value": "some_value"
+                    }
+                  ]
+                },
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "jwt_claim",
+                      "jwt_claim_name": "claim_not_in_the_request",
+                      "op": "==",
+                      "value": "some_value"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /
+--- more_headers eval
+use Crypt::JWT qw(encode_jwt);
+my $jwt = encode_jwt(payload => {
+test_jwt_claim => 'some_value',
+aud => 'the_token_audience',
+sub => 'someone',
+iss => 'https://example.com/auth/realms/apicast',
+exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers=>{ kid => 'somekid' });
+"Authorization: Bearer $jwt"
+--- error_code: 200
+--- response_body
+GET / HTTP/1.1
+--- no_error_log
+[error]
+
+=== TEST 28: upstream with several conditions and all of them are true
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "path",
+                      "op": "==",
+                      "value": "/a_path"
+                    },
+                    {
+                      "thing_to_match": "header",
+                      "header_name": "Test-Header",
+                      "op": "==",
+                      "value": "some_value"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /a_path
+--- more_headers
+Test-Header: some_value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 29: upstream with several conditions and some of them are false
+When one or more conditions are false, the request is not routed
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": [
+                    {
+                      "thing_to_match": "path",
+                      "op": "==",
+                      "value": "/a_path"
+                    },
+                    {
+                      "thing_to_match": "header",
+                      "header_name": "Test-Header",
+                      "op": "==",
+                      "value": "some_value"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /a_path {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /a_path
+--- more_headers
+Test-Header: i_dont_match
+--- response_body
+GET /a_path HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]

--- a/t/apicast-policy-routing.t
+++ b/t/apicast-policy-routing.t
@@ -24,7 +24,7 @@ __DATA__
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "path",
+                        "match": "path",
                         "op": "==",
                         "value": "/a_path"
                       }
@@ -73,7 +73,7 @@ yay, api backend
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "path",
+                        "match": "path",
                         "op": "==",
                         "value": "/"
                       }
@@ -122,7 +122,7 @@ GET /i_dont_match HTTP/1.1
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "path",
+                        "match": "path",
                         "op": "!=",
                         "value": "/"
                       }
@@ -171,7 +171,7 @@ yay, api backend
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "path",
+                        "match": "path",
                         "op": "!=",
                         "value": "/a_path"
                       }
@@ -220,7 +220,7 @@ GET /a_path HTTP/1.1
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "path",
+                        "match": "path",
                         "op": "matches",
                         "value": ".*123.*"
                       }
@@ -269,7 +269,7 @@ yay, api backend
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "path",
+                        "match": "path",
                         "op": "matches",
                         "value": "^123$"
                       }
@@ -318,7 +318,7 @@ GET /something_123_something HTTP/1.1
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "header",
+                        "match": "header",
                         "header_name": "Test-Header",
                         "op": "==",
                         "value": "some_value"
@@ -370,7 +370,7 @@ yay, api backend
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "header",
+                        "match": "header",
                         "header_name": "Test-Header",
                         "op": "==",
                         "value": "some_value"
@@ -422,7 +422,7 @@ GET / HTTP/1.1
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "header",
+                        "match": "header",
                         "header_name": "Test-Header",
                         "op": "!=",
                         "value": "some_value"
@@ -474,7 +474,7 @@ yay, api backend
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "header",
+                        "match": "header",
                         "header_name": "Test-Header",
                         "op": "!=",
                         "value": "some_value"
@@ -526,7 +526,7 @@ GET / HTTP/1.1
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "header",
+                        "match": "header",
                         "header_name": "Test-Header",
                         "op": "matches",
                         "value": ".*123.*"
@@ -578,7 +578,7 @@ yay, api backend
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "header",
+                        "match": "header",
                         "header_name": "Test-Header",
                         "op": "matches",
                         "value": ".*123.*"
@@ -630,7 +630,7 @@ GET / HTTP/1.1
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "query_arg",
+                        "match": "query_arg",
                         "query_arg_name": "test_arg",
                         "op": "==",
                         "value": "some_value"
@@ -680,7 +680,7 @@ yay, api backend
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "query_arg",
+                        "match": "query_arg",
                         "query_arg_name": "test_arg",
                         "op": "==",
                         "value": "some_value"
@@ -730,7 +730,7 @@ GET /a_path?test_arg=i_dont_match HTTP/1.1
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "query_arg",
+                        "match": "query_arg",
                         "query_arg_name": "test_arg",
                         "op": "!=",
                         "value": "some_value"
@@ -780,7 +780,7 @@ yay, api backend
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "query_arg",
+                        "match": "query_arg",
                         "query_arg_name": "test_arg",
                         "op": "!=",
                         "value": "some_value"
@@ -830,7 +830,7 @@ GET /a_path?test_arg=some_value HTTP/1.1
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "query_arg",
+                        "match": "query_arg",
                         "query_arg_name": "test_arg",
                         "op": "matches",
                         "value": ".*123.*"
@@ -880,7 +880,7 @@ yay, api backend
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "query_arg",
+                        "match": "query_arg",
                         "query_arg_name": "test_arg",
                         "op": "matches",
                         "value": ".*123.*"
@@ -965,7 +965,7 @@ GET /a_path?test_arg=i_dont_match HTTP/1.1
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "jwt_claim",
+                        "match": "jwt_claim",
                         "jwt_claim_name": "test_jwt_claim",
                         "op": "==",
                         "value": "some_value"
@@ -1062,7 +1062,7 @@ yay, api backend
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "jwt_claim",
+                        "match": "jwt_claim",
                         "jwt_claim_name": "test_jwt_claim",
                         "op": "==",
                         "value": "some_value"
@@ -1159,7 +1159,7 @@ GET / HTTP/1.1
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "jwt_claim",
+                        "match": "jwt_claim",
                         "jwt_claim_name": "test_jwt_claim",
                         "op": "!=",
                         "value": "some_value"
@@ -1256,7 +1256,7 @@ yay, api backend
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "jwt_claim",
+                        "match": "jwt_claim",
                         "jwt_claim_name": "test_jwt_claim",
                         "op": "!=",
                         "value": "some_value"
@@ -1353,7 +1353,7 @@ GET / HTTP/1.1
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "jwt_claim",
+                        "match": "jwt_claim",
                         "jwt_claim_name": "test_jwt_claim",
                         "op": "matches",
                         "value": ".*123.*"
@@ -1450,7 +1450,7 @@ yay, api backend
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "jwt_claim",
+                        "match": "jwt_claim",
                         "jwt_claim_name": "test_jwt_claim",
                         "op": "matches",
                         "value": ".*123.*"
@@ -1514,7 +1514,7 @@ the first rule that matches.
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "path",
+                        "match": "path",
                         "op": "==",
                         "value": "/a_path"
                       }
@@ -1526,7 +1526,7 @@ the first rule that matches.
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "path",
+                        "match": "path",
                         "op": "==",
                         "value": "/a_path"
                       }
@@ -1578,7 +1578,7 @@ The path of the upstream is appended to the path of the request.
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "path",
+                        "match": "path",
                         "op": "==",
                         "value": "/the_request_path"
                       }
@@ -1664,7 +1664,7 @@ does not raise any errors and rules do not match.
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "header",
+                        "match": "header",
                         "header_name": "header_not_in_the_request",
                         "op": "==",
                         "value": "some_value"
@@ -1677,7 +1677,7 @@ does not raise any errors and rules do not match.
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "query_arg",
+                        "match": "query_arg",
                         "query_arg_name": "arg_not_in_the_request",
                         "op": "==",
                         "value": "some_value"
@@ -1690,7 +1690,7 @@ does not raise any errors and rules do not match.
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "jwt_claim",
+                        "match": "jwt_claim",
                         "jwt_claim_name": "claim_not_in_the_request",
                         "op": "==",
                         "value": "some_value"
@@ -1755,12 +1755,12 @@ true as well.
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "path",
+                        "match": "path",
                         "op": "==",
                         "value": "/a_path"
                       },
                       {
-                        "thing_to_match": "header",
+                        "match": "header",
                         "header_name": "Test-Header",
                         "op": "==",
                         "value": "some_value"
@@ -1813,12 +1813,12 @@ When one or more conditions are false, the request is not routed
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "path",
+                        "match": "path",
                         "op": "==",
                         "value": "/a_path"
                       },
                       {
-                        "thing_to_match": "header",
+                        "match": "header",
                         "header_name": "Test-Header",
                         "op": "==",
                         "value": "some_value"
@@ -1875,12 +1875,12 @@ The test checks that the upstream selected is the one of the second rule.
                     "combine_op": "or",
                     "operations": [
                       {
-                        "thing_to_match": "path",
+                        "match": "path",
                         "op": "==",
                         "value": "/rule_path"
                       },
                       {
-                        "thing_to_match": "header",
+                        "match": "header",
                         "header_name": "Test-Header",
                         "op": "==",
                         "value": "rule_header_value"
@@ -1894,12 +1894,12 @@ The test checks that the upstream selected is the one of the second rule.
                     "combine_op": "or",
                     "operations": [
                       {
-                        "thing_to_match": "path",
+                        "match": "path",
                         "op": "==",
                         "value": "/rule_path"
                       },
                       {
-                        "thing_to_match": "query_arg",
+                        "match": "query_arg",
                         "query_arg_name": "test_arg",
                         "op": "==",
                         "value": "rule_arg_value"
@@ -1963,12 +1963,12 @@ The test checks that the upstream selected is the one of the second rule.
                     "combine_op": "and",
                     "operations": [
                       {
-                        "thing_to_match": "path",
+                        "match": "path",
                         "op": "==",
                         "value": "/rule_path"
                       },
                       {
-                        "thing_to_match": "header",
+                        "match": "header",
                         "header_name": "Test-Header",
                         "op": "==",
                         "value": "rule_header_value"
@@ -1982,12 +1982,12 @@ The test checks that the upstream selected is the one of the second rule.
                     "combine_op": "and",
                     "operations": [
                       {
-                        "thing_to_match": "path",
+                        "match": "path",
                         "op": "==",
                         "value": "/rule_path"
                       },
                       {
-                        "thing_to_match": "query_arg",
+                        "match": "query_arg",
                         "query_arg_name": "test_arg",
                         "op": "==",
                         "value": "rule_arg_value"
@@ -2046,7 +2046,7 @@ yay, api backend
                   "condition": {
                     "operations": [
                       {
-                        "thing_to_match": "header",
+                        "match": "header",
                         "header_name": "Service-Id",
                         "op": "==",
                         "value": "{{ service.id }}",

--- a/t/apicast-policy-routing.t
+++ b/t/apicast-policy-routing.t
@@ -7,7 +7,7 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: the rule matches the path using "==" and the condition is true
+=== TEST 1: the rule matches the path using "=="
 --- configuration
 {
   "services": [
@@ -56,56 +56,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 2: the rule matches the path using "==" and the condition is false
---- configuration
-{
-  "services": [
-    {
-      "id": 42,
-      "proxy": {
-        "policy_chain": [
-          {
-            "name": "apicast.policy.routing",
-            "configuration": {
-              "rules": [
-                {
-                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": {
-                    "operations": [
-                      {
-                        "match": "path",
-                        "op": "==",
-                        "value": "/"
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "apicast.policy.echo"
-          }
-        ]
-      }
-    }
-  ]
-}
---- upstream
-  location / {
-     content_by_lua_block {
-       ngx.say('yay, api backend');
-     }
-  }
---- request
-GET /i_dont_match
---- response_body
-GET /i_dont_match HTTP/1.1
---- error_code: 200
---- no_error_log
-[error]
-
-=== TEST 3: the rule matches the path using "!=" and the condition is true
+=== TEST 2: the rule matches the path using "!="
 --- configuration
 {
   "services": [
@@ -154,56 +105,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 4: the rule matches the path using "!=" and the condition is false
---- configuration
-{
-  "services": [
-    {
-      "id": 42,
-      "proxy": {
-        "policy_chain": [
-          {
-            "name": "apicast.policy.routing",
-            "configuration": {
-              "rules": [
-                {
-                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": {
-                    "operations": [
-                      {
-                        "match": "path",
-                        "op": "!=",
-                        "value": "/a_path"
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "apicast.policy.echo"
-          }
-        ]
-      }
-    }
-  ]
-}
---- upstream
-  location /a_path {
-     content_by_lua_block {
-       ngx.say('yay, api backend');
-     }
-  }
---- request
-GET /a_path
---- response_body
-GET /a_path HTTP/1.1
---- error_code: 200
---- no_error_log
-[error]
-
-=== TEST 5: the rule matches the path using "matches" and the condition is true
+=== TEST 3: the rule matches the path using "matches"
 --- configuration
 {
   "services": [
@@ -252,56 +154,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 6: the rule matches the path using "matches" and the condition is false
---- configuration
-{
-  "services": [
-    {
-      "id": 42,
-      "proxy": {
-        "policy_chain": [
-          {
-            "name": "apicast.policy.routing",
-            "configuration": {
-              "rules": [
-                {
-                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": {
-                    "operations": [
-                      {
-                        "match": "path",
-                        "op": "matches",
-                        "value": "^123$"
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "apicast.policy.echo"
-          }
-        ]
-      }
-    }
-  ]
-}
---- upstream
-  location / {
-     content_by_lua_block {
-       ngx.say('yay, api backend');
-     }
-  }
---- request
-GET /something_123_something
---- response_body
-GET /something_123_something HTTP/1.1
---- error_code: 200
---- no_error_log
-[error]
-
-=== TEST 7: the rule matches a header using "==" and the condition is true
+=== TEST 4: the rule matches a header using "=="
 --- configuration
 {
   "services": [
@@ -353,59 +206,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 8: the rule matches a header using "==" and the condition is false
---- configuration
-{
-  "services": [
-    {
-      "id": 42,
-      "proxy": {
-        "policy_chain": [
-          {
-            "name": "apicast.policy.routing",
-            "configuration": {
-              "rules": [
-                {
-                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": {
-                    "operations": [
-                      {
-                        "match": "header",
-                        "header_name": "Test-Header",
-                        "op": "==",
-                        "value": "some_value"
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "apicast.policy.echo"
-          }
-        ]
-      }
-    }
-  ]
-}
---- upstream
-  location / {
-     content_by_lua_block {
-       ngx.say('yay, api backend');
-     }
-  }
---- request
-GET /
---- more_headers
-Test-Header: i_dont_match
---- response_body
-GET / HTTP/1.1
---- error_code: 200
---- no_error_log
-[error]
-
-=== TEST 9: the rule matches a header using "!=" and the condition is true
+=== TEST 5: the rule matches a header using "!="
 --- configuration
 {
   "services": [
@@ -457,59 +258,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 10: the rule matches a header using "!=" and the condition is false
---- configuration
-{
-  "services": [
-    {
-      "id": 42,
-      "proxy": {
-        "policy_chain": [
-          {
-            "name": "apicast.policy.routing",
-            "configuration": {
-              "rules": [
-                {
-                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": {
-                    "operations": [
-                      {
-                        "match": "header",
-                        "header_name": "Test-Header",
-                        "op": "!=",
-                        "value": "some_value"
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "apicast.policy.echo"
-          }
-        ]
-      }
-    }
-  ]
-}
---- upstream
-  location / {
-     content_by_lua_block {
-       ngx.say('yay, api backend');
-     }
-  }
---- request
-GET /
---- more_headers
-Test-Header: some_value
---- response_body
-GET / HTTP/1.1
---- error_code: 200
---- no_error_log
-[error]
-
-=== TEST 11: the rule matches a header using "matches" and the condition is true
+=== TEST 6: the rule matches a header using "matches"
 --- configuration
 {
   "services": [
@@ -561,59 +310,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 12: the rule matches a header using "matches" and the condition is false
---- configuration
-{
-  "services": [
-    {
-      "id": 42,
-      "proxy": {
-        "policy_chain": [
-          {
-            "name": "apicast.policy.routing",
-            "configuration": {
-              "rules": [
-                {
-                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": {
-                    "operations": [
-                      {
-                        "match": "header",
-                        "header_name": "Test-Header",
-                        "op": "matches",
-                        "value": ".*123.*"
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "apicast.policy.echo"
-          }
-        ]
-      }
-    }
-  ]
-}
---- upstream
-  location / {
-     content_by_lua_block {
-       ngx.say('yay, api backend');
-     }
-  }
---- request
-GET /
---- more_headers
-Test-Header: i_dont_match
---- response_body
-GET / HTTP/1.1
---- error_code: 200
---- no_error_log
-[error]
-
-=== TEST 13: the rule matches a query arg using "==" and the condition is true
+=== TEST 7: the rule matches a query arg using "=="
 --- configuration
 {
   "services": [
@@ -663,57 +360,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 14: the rule matches a query arg using "==" and the condition is false
---- configuration
-{
-  "services": [
-    {
-      "id": 42,
-      "proxy": {
-        "policy_chain": [
-          {
-            "name": "apicast.policy.routing",
-            "configuration": {
-              "rules": [
-                {
-                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": {
-                    "operations": [
-                      {
-                        "match": "query_arg",
-                        "query_arg_name": "test_arg",
-                        "op": "==",
-                        "value": "some_value"
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "apicast.policy.echo"
-          }
-        ]
-      }
-    }
-  ]
-}
---- upstream
-  location /a_path {
-     content_by_lua_block {
-       ngx.say('yay, api backend');
-     }
-  }
---- request
-GET /a_path?test_arg=i_dont_match
---- response_body
-GET /a_path?test_arg=i_dont_match HTTP/1.1
---- error_code: 200
---- no_error_log
-[error]
-
-=== TEST 15: the rule matches a query arg using "!=" and the condition is true
+=== TEST 8: the rule matches a query arg using "!="
 --- configuration
 {
   "services": [
@@ -763,57 +410,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 16: the rule matches a query arg using "!=" and the condition is false
---- configuration
-{
-  "services": [
-    {
-      "id": 42,
-      "proxy": {
-        "policy_chain": [
-          {
-            "name": "apicast.policy.routing",
-            "configuration": {
-              "rules": [
-                {
-                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": {
-                    "operations": [
-                      {
-                        "match": "query_arg",
-                        "query_arg_name": "test_arg",
-                        "op": "!=",
-                        "value": "some_value"
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "apicast.policy.echo"
-          }
-        ]
-      }
-    }
-  ]
-}
---- upstream
-  location /a_path {
-     content_by_lua_block {
-       ngx.say('yay, api backend');
-     }
-  }
---- request
-GET /a_path?test_arg=some_value
---- response_body
-GET /a_path?test_arg=some_value HTTP/1.1
---- error_code: 200
---- no_error_log
-[error]
-
-=== TEST 17: the rule matches a query arg using "matches" and the condition is true
+=== TEST 9: the rule matches a query arg using "matches"
 --- configuration
 {
   "services": [
@@ -863,57 +460,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 18: the rule matches a query arg using "matches" and the condition is false
---- configuration
-{
-  "services": [
-    {
-      "id": 42,
-      "proxy": {
-        "policy_chain": [
-          {
-            "name": "apicast.policy.routing",
-            "configuration": {
-              "rules": [
-                {
-                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": {
-                    "operations": [
-                      {
-                        "match": "query_arg",
-                        "query_arg_name": "test_arg",
-                        "op": "matches",
-                        "value": ".*123.*"
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "apicast.policy.echo"
-          }
-        ]
-      }
-    }
-  ]
-}
---- upstream
-  location /a_path {
-     content_by_lua_block {
-       ngx.say('yay, api backend');
-     }
-  }
---- request
-GET /a_path?test_arg=i_dont_match
---- response_body
-GET /a_path?test_arg=i_dont_match HTTP/1.1
---- error_code: 200
---- no_error_log
-[error]
-
-=== TEST 19: the rule matches a jwt claim using "==" and the condition is true
+=== TEST 10: the rule matches a jwt claim using "=="
 --- backend
    location /transactions/oauth_authrep.xml {
      content_by_lua_block {
@@ -1010,104 +557,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 20: the rule matches a jwt claim using "==" and the condition is false
---- backend
-   location /transactions/oauth_authrep.xml {
-     content_by_lua_block {
-       ngx.exit(200)
-     }
-   }
---- configuration
-{
-  "oidc": [
-    {
-      "issuer": "https://example.com/auth/realms/apicast",
-      "config": {
-        "id_token_signing_alg_values_supported": [
-          "RS256"
-        ]
-      },
-      "keys": {
-        "somekid": {
-          "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----"
-        }
-      }
-    }
-  ],
-  "services": [
-    {
-      "id": 42,
-      "backend_version": "oauth",
-      "backend_authentication_type": "service_token",
-      "backend_authentication_value": "token-value",
-      "proxy": {
-        "authentication_method": "oidc",
-        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
-        "api_backend": "http://example.com:80/",
-        "proxy_rules": [
-          {
-            "pattern": "/",
-            "http_method": "GET",
-            "metric_system_name": "hits",
-            "delta": 2
-          }
-        ],
-        "policy_chain": [
-          {
-            "name": "apicast.policy.routing",
-            "configuration": {
-              "rules": [
-                {
-                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": {
-                    "operations": [
-                      {
-                        "match": "jwt_claim",
-                        "jwt_claim_name": "test_jwt_claim",
-                        "op": "==",
-                        "value": "some_value"
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "apicast.policy.echo"
-          },
-          {
-            "name": "apicast.policy.apicast"
-          }
-        ]
-      }
-    }
-  ]
-}
---- upstream
-  location / {
-     content_by_lua_block {
-       ngx.say('yay, api backend');
-     }
-  }
---- request
-GET /
---- more_headers eval
-use Crypt::JWT qw(encode_jwt);
-my $jwt = encode_jwt(payload => {
-test_jwt_claim => 'i_dont_match',
-aud => 'the_token_audience',
-sub => 'someone',
-iss => 'https://example.com/auth/realms/apicast',
-exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers=>{ kid => 'somekid' });
-"Authorization: Bearer $jwt"
---- error_code: 200
---- response_body
-GET / HTTP/1.1
---- no_error_log
-[error]
-
-=== TEST 21: the rule matches a jwt claim using "!=" and the condition is true
+=== TEST 11: the rule matches a jwt claim using "!="
 --- backend
    location /transactions/oauth_authrep.xml {
      content_by_lua_block {
@@ -1204,104 +654,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 22: the rule matches a jwt claim using "!=" and the condition is false
---- backend
-   location /transactions/oauth_authrep.xml {
-     content_by_lua_block {
-       ngx.exit(200)
-     }
-   }
---- configuration
-{
-  "oidc": [
-    {
-      "issuer": "https://example.com/auth/realms/apicast",
-      "config": {
-        "id_token_signing_alg_values_supported": [
-          "RS256"
-        ]
-      },
-      "keys": {
-        "somekid": {
-          "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----"
-        }
-      }
-    }
-  ],
-  "services": [
-    {
-      "id": 42,
-      "backend_version": "oauth",
-      "backend_authentication_type": "service_token",
-      "backend_authentication_value": "token-value",
-      "proxy": {
-        "authentication_method": "oidc",
-        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
-        "api_backend": "http://example.com:80/",
-        "proxy_rules": [
-          {
-            "pattern": "/",
-            "http_method": "GET",
-            "metric_system_name": "hits",
-            "delta": 2
-          }
-        ],
-        "policy_chain": [
-          {
-            "name": "apicast.policy.routing",
-            "configuration": {
-              "rules": [
-                {
-                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": {
-                    "operations": [
-                      {
-                        "match": "jwt_claim",
-                        "jwt_claim_name": "test_jwt_claim",
-                        "op": "!=",
-                        "value": "some_value"
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "apicast.policy.echo"
-          },
-          {
-            "name": "apicast.policy.apicast"
-          }
-        ]
-      }
-    }
-  ]
-}
---- upstream
-  location / {
-     content_by_lua_block {
-       ngx.say('yay, api backend');
-     }
-  }
---- request
-GET /
---- more_headers eval
-use Crypt::JWT qw(encode_jwt);
-my $jwt = encode_jwt(payload => {
-test_jwt_claim => 'some_value',
-aud => 'the_token_audience',
-sub => 'someone',
-iss => 'https://example.com/auth/realms/apicast',
-exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers=>{ kid => 'somekid' });
-"Authorization: Bearer $jwt"
---- error_code: 200
---- response_body
-GET / HTTP/1.1
---- no_error_log
-[error]
-
-=== TEST 23: the rule matches a jwt claim using "matches" and the condition is true
+=== TEST 12: the rule matches a jwt claim using "matches"
 --- backend
    location /transactions/oauth_authrep.xml {
      content_by_lua_block {
@@ -1398,104 +751,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 24: the rule matches a jwt claim using "matches" and the condition is false
---- backend
-   location /transactions/oauth_authrep.xml {
-     content_by_lua_block {
-       ngx.exit(200)
-     }
-   }
---- configuration
-{
-  "oidc": [
-    {
-      "issuer": "https://example.com/auth/realms/apicast",
-      "config": {
-        "id_token_signing_alg_values_supported": [
-          "RS256"
-        ]
-      },
-      "keys": {
-        "somekid": {
-          "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----"
-        }
-      }
-    }
-  ],
-  "services": [
-    {
-      "id": 42,
-      "backend_version": "oauth",
-      "backend_authentication_type": "service_token",
-      "backend_authentication_value": "token-value",
-      "proxy": {
-        "authentication_method": "oidc",
-        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
-        "api_backend": "http://example.com:80/",
-        "proxy_rules": [
-          {
-            "pattern": "/",
-            "http_method": "GET",
-            "metric_system_name": "hits",
-            "delta": 2
-          }
-        ],
-        "policy_chain": [
-          {
-            "name": "apicast.policy.routing",
-            "configuration": {
-              "rules": [
-                {
-                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": {
-                    "operations": [
-                      {
-                        "match": "jwt_claim",
-                        "jwt_claim_name": "test_jwt_claim",
-                        "op": "matches",
-                        "value": ".*123.*"
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "name": "apicast.policy.echo"
-          },
-          {
-            "name": "apicast.policy.apicast"
-          }
-        ]
-      }
-    }
-  ]
-}
---- upstream
-  location / {
-     content_by_lua_block {
-       ngx.say('yay, api backend');
-     }
-  }
---- request
-GET /
---- more_headers eval
-use Crypt::JWT qw(encode_jwt);
-my $jwt = encode_jwt(payload => {
-test_jwt_claim => 'i_dont_match',
-aud => 'the_token_audience',
-sub => 'someone',
-iss => 'https://example.com/auth/realms/apicast',
-exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers=>{ kid => 'somekid' });
-"Authorization: Bearer $jwt"
---- error_code: 200
---- response_body
-GET / HTTP/1.1
---- no_error_log
-[error]
-
-=== TEST 25: several matching rules
+=== TEST 13: several matching rules
 When there are several rules that match, the upstream selected is the one of
 the first rule that matches.
 --- configuration
@@ -1560,7 +816,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 26: upstream with path
+=== TEST 14: upstream with path
 The path of the upstream is appended to the path of the request.
 --- configuration
 {
@@ -1610,7 +866,7 @@ GET /the_path_in_the_rule/the_request_path HTTP/1.1
 --- no_error_log
 [error]
 
-=== TEST 27: entities in the rules are not set
+=== TEST 15: entities in the rules are not set
 This test checks that when the entities in the rules are not set, the program
 does not raise any errors and rules do not match.
 --- backend
@@ -1735,7 +991,7 @@ GET / HTTP/1.1
 --- no_error_log
 [error]
 
-=== TEST 28: upstream with several operations and all of them are true
+=== TEST 16: upstream with several operations and all of them are true
 When the "combine_op" (and, or) is not set, APIcast defaults to 'and'.
 So the condition evaluates to true only when all the operations evaluate to
 true as well.
@@ -1795,7 +1051,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 29: upstream with several conditions and some of them are false
+=== TEST 17: upstream with several conditions and some of them are false
 When one or more conditions are false, the request is not routed
 --- configuration
 {
@@ -1853,7 +1109,7 @@ GET /a_path HTTP/1.1
 --- no_error_log
 [error]
 
-=== TEST 30: conditions combined with 'or'
+=== TEST 18: conditions combined with 'or'
 In this test, we define a rule with two operations that evaluate to false
 combined with 'or', and a second rule with two operations combined with 'or'
 and only the second operation evaluates to true.
@@ -1941,7 +1197,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 31: conditions combined with 'and'
+=== TEST 19: conditions combined with 'and'
 In this test, we define a rule with two operations combined with 'and' where
 only one of them evaluates to true, and a second rule with two operations
 combined with 'and' where both of them evaluate to true.
@@ -2029,7 +1285,7 @@ yay, api backend
 --- no_error_log
 [error]
 
-=== TEST 32: conditions with liquid templating
+=== TEST 20: conditions with liquid templating
 --- configuration
 {
   "services": [

--- a/t/apicast-policy-routing.t
+++ b/t/apicast-policy-routing.t
@@ -21,13 +21,15 @@ __DATA__
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "path",
-                      "op": "==",
-                      "value": "/a_path"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "path",
+                        "op": "==",
+                        "value": "/a_path"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -68,13 +70,15 @@ yay, api backend
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "path",
-                      "op": "==",
-                      "value": "/"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "path",
+                        "op": "==",
+                        "value": "/"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -115,13 +119,15 @@ GET /i_dont_match HTTP/1.1
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "path",
-                      "op": "!=",
-                      "value": "/"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "path",
+                        "op": "!=",
+                        "value": "/"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -162,13 +168,15 @@ yay, api backend
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "path",
-                      "op": "!=",
-                      "value": "/a_path"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "path",
+                        "op": "!=",
+                        "value": "/a_path"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -209,13 +217,15 @@ GET /a_path HTTP/1.1
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "path",
-                      "op": "matches",
-                      "value": ".*123.*"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "path",
+                        "op": "matches",
+                        "value": ".*123.*"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -256,13 +266,15 @@ yay, api backend
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "path",
-                      "op": "matches",
-                      "value": "^123$"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "path",
+                        "op": "matches",
+                        "value": "^123$"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -303,14 +315,16 @@ GET /something_123_something HTTP/1.1
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "header",
-                      "header_name": "Test-Header",
-                      "op": "==",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "header",
+                        "header_name": "Test-Header",
+                        "op": "==",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -353,14 +367,16 @@ yay, api backend
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "header",
-                      "header_name": "Test-Header",
-                      "op": "==",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "header",
+                        "header_name": "Test-Header",
+                        "op": "==",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -403,14 +419,16 @@ GET / HTTP/1.1
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "header",
-                      "header_name": "Test-Header",
-                      "op": "!=",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "header",
+                        "header_name": "Test-Header",
+                        "op": "!=",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -453,14 +471,16 @@ yay, api backend
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "header",
-                      "header_name": "Test-Header",
-                      "op": "!=",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "header",
+                        "header_name": "Test-Header",
+                        "op": "!=",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -503,14 +523,16 @@ GET / HTTP/1.1
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "header",
-                      "header_name": "Test-Header",
-                      "op": "matches",
-                      "value": ".*123.*"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "header",
+                        "header_name": "Test-Header",
+                        "op": "matches",
+                        "value": ".*123.*"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -553,14 +575,16 @@ yay, api backend
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "header",
-                      "header_name": "Test-Header",
-                      "op": "matches",
-                      "value": ".*123.*"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "header",
+                        "header_name": "Test-Header",
+                        "op": "matches",
+                        "value": ".*123.*"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -603,14 +627,16 @@ GET / HTTP/1.1
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "query_arg",
-                      "query_arg_name": "test_arg",
-                      "op": "==",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "query_arg",
+                        "query_arg_name": "test_arg",
+                        "op": "==",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -651,14 +677,16 @@ yay, api backend
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "query_arg",
-                      "query_arg_name": "test_arg",
-                      "op": "==",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "query_arg",
+                        "query_arg_name": "test_arg",
+                        "op": "==",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -699,14 +727,16 @@ GET /a_path?test_arg=i_dont_match HTTP/1.1
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "query_arg",
-                      "query_arg_name": "test_arg",
-                      "op": "!=",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "query_arg",
+                        "query_arg_name": "test_arg",
+                        "op": "!=",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -747,14 +777,16 @@ yay, api backend
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "query_arg",
-                      "query_arg_name": "test_arg",
-                      "op": "!=",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "query_arg",
+                        "query_arg_name": "test_arg",
+                        "op": "!=",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -795,14 +827,16 @@ GET /a_path?test_arg=some_value HTTP/1.1
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "query_arg",
-                      "query_arg_name": "test_arg",
-                      "op": "matches",
-                      "value": ".*123.*"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "query_arg",
+                        "query_arg_name": "test_arg",
+                        "op": "matches",
+                        "value": ".*123.*"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -843,14 +877,16 @@ yay, api backend
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "query_arg",
-                      "query_arg_name": "test_arg",
-                      "op": "matches",
-                      "value": ".*123.*"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "query_arg",
+                        "query_arg_name": "test_arg",
+                        "op": "matches",
+                        "value": ".*123.*"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -926,14 +962,16 @@ GET /a_path?test_arg=i_dont_match HTTP/1.1
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "jwt_claim",
-                      "jwt_claim_name": "test_jwt_claim",
-                      "op": "==",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "jwt_claim",
+                        "jwt_claim_name": "test_jwt_claim",
+                        "op": "==",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -1021,14 +1059,16 @@ yay, api backend
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "jwt_claim",
-                      "jwt_claim_name": "test_jwt_claim",
-                      "op": "==",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "jwt_claim",
+                        "jwt_claim_name": "test_jwt_claim",
+                        "op": "==",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -1116,14 +1156,16 @@ GET / HTTP/1.1
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "jwt_claim",
-                      "jwt_claim_name": "test_jwt_claim",
-                      "op": "!=",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "jwt_claim",
+                        "jwt_claim_name": "test_jwt_claim",
+                        "op": "!=",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -1211,14 +1253,16 @@ yay, api backend
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "jwt_claim",
-                      "jwt_claim_name": "test_jwt_claim",
-                      "op": "!=",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "jwt_claim",
+                        "jwt_claim_name": "test_jwt_claim",
+                        "op": "!=",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -1306,14 +1350,16 @@ GET / HTTP/1.1
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "jwt_claim",
-                      "jwt_claim_name": "test_jwt_claim",
-                      "op": "matches",
-                      "value": ".*123.*"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "jwt_claim",
+                        "jwt_claim_name": "test_jwt_claim",
+                        "op": "matches",
+                        "value": ".*123.*"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -1401,14 +1447,16 @@ yay, api backend
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "jwt_claim",
-                      "jwt_claim_name": "test_jwt_claim",
-                      "op": "matches",
-                      "value": ".*123.*"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "jwt_claim",
+                        "jwt_claim_name": "test_jwt_claim",
+                        "op": "matches",
+                        "value": ".*123.*"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -1463,23 +1511,27 @@ the first rule that matches.
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "path",
-                      "op": "==",
-                      "value": "/a_path"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "path",
+                        "op": "==",
+                        "value": "/a_path"
+                      }
+                    ]
+                  }
                 },
                 {
                   "url": "http://example.com",
-                  "condition": [
-                    {
-                      "thing_to_match": "path",
-                      "op": "==",
-                      "value": "/a_path"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "path",
+                        "op": "==",
+                        "value": "/a_path"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -1523,13 +1575,15 @@ The path of the upstream is appended to the path of the request.
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT/the_path_in_the_rule",
-                  "condition": [
-                    {
-                      "thing_to_match": "path",
-                      "op": "==",
-                      "value": "/the_request_path"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "path",
+                        "op": "==",
+                        "value": "/the_request_path"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -1607,36 +1661,42 @@ does not raise any errors and rules do not match.
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "header",
-                      "header_name": "header_not_in_the_request",
-                      "op": "==",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "header",
+                        "header_name": "header_not_in_the_request",
+                        "op": "==",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 },
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "query_arg",
-                      "query_arg_name": "arg_not_in_the_request",
-                      "op": "==",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "query_arg",
+                        "query_arg_name": "arg_not_in_the_request",
+                        "op": "==",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 },
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "jwt_claim",
-                      "jwt_claim_name": "claim_not_in_the_request",
-                      "op": "==",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "jwt_claim",
+                        "jwt_claim_name": "claim_not_in_the_request",
+                        "op": "==",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -1675,7 +1735,10 @@ GET / HTTP/1.1
 --- no_error_log
 [error]
 
-=== TEST 28: upstream with several conditions and all of them are true
+=== TEST 28: upstream with several operations and all of them are true
+When the "combine_op" (and, or) is not set, APIcast defaults to 'and'.
+So the condition evaluates to true only when all the operations evaluate to
+true as well.
 --- configuration
 {
   "services": [
@@ -1689,19 +1752,21 @@ GET / HTTP/1.1
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "path",
-                      "op": "==",
-                      "value": "/a_path"
-                    },
-                    {
-                      "thing_to_match": "header",
-                      "header_name": "Test-Header",
-                      "op": "==",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "path",
+                        "op": "==",
+                        "value": "/a_path"
+                      },
+                      {
+                        "thing_to_match": "header",
+                        "header_name": "Test-Header",
+                        "op": "==",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -1745,19 +1810,21 @@ When one or more conditions are false, the request is not routed
               "rules": [
                 {
                   "url": "http://test:$TEST_NGINX_SERVER_PORT",
-                  "condition": [
-                    {
-                      "thing_to_match": "path",
-                      "op": "==",
-                      "value": "/a_path"
-                    },
-                    {
-                      "thing_to_match": "header",
-                      "header_name": "Test-Header",
-                      "op": "==",
-                      "value": "some_value"
-                    }
-                  ]
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "path",
+                        "op": "==",
+                        "value": "/a_path"
+                      },
+                      {
+                        "thing_to_match": "header",
+                        "header_name": "Test-Header",
+                        "op": "==",
+                        "value": "some_value"
+                      }
+                    ]
+                  }
                 }
               ]
             }
@@ -1782,6 +1849,182 @@ GET /a_path
 Test-Header: i_dont_match
 --- response_body
 GET /a_path HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 30: conditions combined with 'or'
+In this test, we define a rule with two operations that evaluate to false
+combined with 'or', and a second rule with two operations combined with 'or'
+and only the second operation evaluates to true.
+The test checks that the upstream selected is the one of the second rule.
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT/wrong",
+                  "condition": {
+                    "combine_op": "or",
+                    "operations": [
+                      {
+                        "thing_to_match": "path",
+                        "op": "==",
+                        "value": "/rule_path"
+                      },
+                      {
+                        "thing_to_match": "header",
+                        "header_name": "Test-Header",
+                        "op": "==",
+                        "value": "rule_header_value"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": {
+                    "combine_op": "or",
+                    "operations": [
+                      {
+                        "thing_to_match": "path",
+                        "op": "==",
+                        "value": "/rule_path"
+                      },
+                      {
+                        "thing_to_match": "query_arg",
+                        "query_arg_name": "test_arg",
+                        "op": "==",
+                        "value": "rule_arg_value"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /request_path {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+
+  location /wrong {
+     content_by_lua_block {
+       ngx.status = 403
+       ngx.say('Selected wrong upstream');
+     }
+  }
+--- request
+GET /request_path?test_arg=rule_arg_value
+--- more_headers
+Test-Header: i_dont_match
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 31: conditions combined with 'and'
+In this test, we define a rule with two operations combined with 'and' where
+only one of them evaluates to true, and a second rule with two operations
+combined with 'and' where both of them evaluate to true.
+The test checks that the upstream selected is the one of the second rule.
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT/wrong",
+                  "condition": {
+                    "combine_op": "and",
+                    "operations": [
+                      {
+                        "thing_to_match": "path",
+                        "op": "==",
+                        "value": "/rule_path"
+                      },
+                      {
+                        "thing_to_match": "header",
+                        "header_name": "Test-Header",
+                        "op": "==",
+                        "value": "rule_header_value"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": {
+                    "combine_op": "and",
+                    "operations": [
+                      {
+                        "thing_to_match": "path",
+                        "op": "==",
+                        "value": "/rule_path"
+                      },
+                      {
+                        "thing_to_match": "query_arg",
+                        "query_arg_name": "test_arg",
+                        "op": "==",
+                        "value": "rule_arg_value"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /rule_path {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+
+  location /wrong {
+     content_by_lua_block {
+       ngx.status = 403
+       ngx.say('Selected wrong upstream');
+     }
+  }
+--- request
+GET /rule_path?test_arg=rule_arg_value
+--- more_headers
+Test-Header: i_dont_match
+--- response_body
+yay, api backend
 --- error_code: 200
 --- no_error_log
 [error]

--- a/t/apicast-policy-routing.t
+++ b/t/apicast-policy-routing.t
@@ -2028,3 +2028,56 @@ yay, api backend
 --- error_code: 200
 --- no_error_log
 [error]
+
+=== TEST 32: conditions with liquid templating
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "condition": {
+                    "operations": [
+                      {
+                        "thing_to_match": "header",
+                        "header_name": "Service-Id",
+                        "op": "==",
+                        "value": "{{ service.id }}",
+                        "value_type": "liquid"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /
+--- more_headers
+Service-Id: 42
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]


### PR DESCRIPTION
Closes #972 

This PR adds a new policy, routing. It can select an upstream based on the request path, a request header, a request query argument, and a JWT claim.

I added a [README](https://github.com/3scale/apicast/pull/976/files#diff-4b14e371f001593fb9bdbc2891a5ef2c) that explains how the policy works.

Depends on #974 and #975 

Ref: https://issues.jboss.org/browse/THREESCALE-1709