### PR TITLE
[THREESCALE-1781] Fix bug with proxied POST requests to HTTPS API backend via forward proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix 3scale Batcher policy failing to cache and report requests containing app ID only [PR #956](https://github.com/3scale/apicast/pull/956), [THREESCALE-1515](https://issues.jboss.org/browse/THREESCALE-1515)
 - Auths against the 3scale backend are now retried when using the 3scale batching policy [PR #961](https://github.com/3scale/apicast/pull/961)
+- Fix timeouts when proxying POST requests to an HTTPS upstream using `HTTPS_PROXY` [PR #978](https://github.com/3scale/apicast/pull/978), [THREESCALE-1781](https://issues.jboss.org/browse/THREESCALE-1781)
 
 ### Added
 


### PR DESCRIPTION
This PR fixes a bug that happens when proxying POST requests to an HTTPS upstream when using HTTPS_PROXY.

We were using resty.http's `.get_client_body_reader()`, but it looks like the result of that function is `nil` in this case.

I just changed that call with `ngx.req.get_body_data()`. The 2 tests added in this PR were failing before the change.

Ref: https://issues.jboss.org/browse/THREESCALE-1781