### PR TITLE
Ensure that the apicast post_action phase runs only if access runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix 3scale Batcher policy failing to cache and report requests containing app ID only [PR #956](https://github.com/3scale/apicast/pull/956), [THREESCALE-1515](https://issues.jboss.org/browse/THREESCALE-1515)
 - Auths against the 3scale backend are now retried when using the 3scale batching policy [PR #961](https://github.com/3scale/apicast/pull/961)
 - Fix timeouts when proxying POST requests to an HTTPS upstream using `HTTPS_PROXY` [PR #978](https://github.com/3scale/apicast/pull/978), [THREESCALE-1781](https://issues.jboss.org/browse/THREESCALE-1781)
+- The APIcast policy now ensures that its post-action phase only runs when its access phase ran. Not ensuring this was causing a bug that was triggered when combining the APIcast policy with some policies that can deny the request, such as the IP check one. In certain cases, APIcast reported to the 3scale backend in its post-action phase even when other policies denied the request with a 4xx error. [PR #985](https://github.com/3scale/apicast/pull/985)
 
 ### Added
 

--- a/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
@@ -76,9 +76,8 @@ local function format_usage(usage)
   return res
 end
 
-local function set_flags_to_avoid_auths_in_apicast(context)
+local function set_flag_to_avoid_auths_in_apicast(context)
   context.skip_apicast_access = true
-  context.skip_apicast_post_action = true
 end
 
 local function report(service_id, backend, reports_batcher)
@@ -184,12 +183,12 @@ local function handle_cached_auth(self, cached_auth, service, transaction)
 end
 
 function _M.rewrite(_, context)
-  -- The APIcast policy reads these flags in the access() and post_action()
-  -- phases. That's why we need to set them before those phases. If we set
-  -- them in access() and placed the APIcast policy before the batcher in the
-  -- chain, APIcast would read the flags before the batcher set them, and both
-  -- policies would report to the 3scale backend.
-  set_flags_to_avoid_auths_in_apicast(context)
+  -- The APIcast policy reads this flag in the access phase.
+  -- That's why we need to set it before that phase. If we set it in access()
+  -- and placed the APIcast policy before the batcher in the chain, APIcast
+  -- would read the flags before the batcher set them, and both policies would
+  -- report to the 3scale backend.
+  set_flag_to_avoid_auths_in_apicast(context)
 end
 
 -- Note: when an entry in the cache expires, there might be several requests

--- a/gateway/src/apicast/policy/apicast/apicast.lua
+++ b/gateway/src/apicast/policy/apicast/apicast.lua
@@ -60,8 +60,6 @@ function _M:rewrite(context)
 end
 
 function _M:post_action(context)
-  if context.skip_apicast_post_action then return end
-
   if not (context[self] and context[self].run_post_action) then return end
 
   local p = context and context.proxy or ngx.ctx.proxy or self.proxy

--- a/gateway/src/apicast/policy/apicast/apicast.lua
+++ b/gateway/src/apicast/policy/apicast/apicast.lua
@@ -53,7 +53,8 @@ function _M:rewrite(context)
     p:rewrite(service, context)
   end
 
-  context[self] = p.get_upstream(service)
+  context[self] = context[self] or {}
+  context[self].upstream = p.get_upstream(service)
 
   ngx.ctx.proxy = p
 end
@@ -83,7 +84,7 @@ function _M:access(context)
 end
 
 function _M:content(context)
-  local upstream = assert(context[self], 'missing upstream')
+  local upstream = assert(context[self].upstream, 'missing upstream')
 
   if upstream then
     upstream:call(context)

--- a/spec/policy/3scale_batcher/3scale_batcher_spec.lua
+++ b/spec/policy/3scale_batcher/3scale_batcher_spec.lua
@@ -29,14 +29,13 @@ describe('3scale batcher policy', function()
   end)
 
   describe('.rewrite', function()
-    it('sets flags to avoid calling backend in the APIcast policy', function()
+    it('sets flag to avoid calling backend in the APIcast policy', function()
       local context = {}
       local batcher_policy = ThreescaleBatcher.new({})
 
       batcher_policy:rewrite(context)
 
       assert.is_true(context.skip_apicast_access)
-      assert.is_true(context.skip_apicast_post_action)
     end)
   end)
 

--- a/spec/policy/apicast/apicast_spec.lua
+++ b/spec/policy/apicast/apicast_spec.lua
@@ -9,4 +9,52 @@ describe('APIcast policy', function()
   it('has a version', function()
     assert.truthy(_M._VERSION)
   end)
+
+  describe('.access', function()
+    it('stores in the context a flag that indicates that post_action should be run', function()
+      local context = {}
+      local apicast = _M.new()
+
+      apicast:access(context)
+
+      assert.is_true(context[apicast].run_post_action)
+    end)
+  end)
+
+  describe('.post_action', function()
+    describe('when the "run_post_action" flag is set to true', function()
+      it('runs its logic', function()
+        -- A way to know whether the logic of the method run consists of
+        -- checking if post_action() was called on the proxy of the context.
+
+        local apicast = _M.new()
+        local context = {
+          proxy = { post_action = function() end },
+          [apicast] = { run_post_action = true }
+        }
+
+        stub(context.proxy, 'post_action')
+
+        apicast:post_action(context)
+
+        assert.spy(context.proxy.post_action).was_called()
+      end)
+    end)
+
+    describe('when the "run_post_action" flag is not set', function()
+      it('does not run its logic', function()
+        local apicast = _M.new()
+        local context = {
+          proxy = { post_action = function() end },
+          [apicast] = { run_post_action = nil }
+        }
+
+        stub(context.proxy, 'post_action')
+
+        apicast:post_action(context)
+
+        assert.spy(context.proxy.post_action).was_not_called()
+      end)
+    end)
+  end)
 end)

--- a/t/fixtures/policies/deny/1.0.0/apicast-policy.json
+++ b/t/fixtures/policies/deny/1.0.0/apicast-policy.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "Deny policy",
+  "summary": "A policy that denies requests. To be used in integration tests.",
+  "version": "1.0.0",
+  "configuration": {
+    "type": "object",
+    "properties": {
+      "phase": {
+        "type": "string",
+        "enum": [
+          "rewrite",
+          "access"
+        ]
+      }
+    },
+    "required": ["phase"]
+  }
+}

--- a/t/fixtures/policies/deny/1.0.0/deny.lua
+++ b/t/fixtures/policies/deny/1.0.0/deny.lua
@@ -1,0 +1,23 @@
+local _M = require('apicast.policy').new('deny', '1.0.0')
+
+local new = _M.new
+
+function _M.new(configuration)
+  local policy = new(configuration)
+  policy.phase = configuration.phase
+  return policy
+end
+
+function _M:rewrite()
+  if self.phase == 'rewrite' then
+    ngx.exit(403)
+  end
+end
+
+function _M:access()
+  if self.phase == 'access' then
+    ngx.exit(403)
+  end
+end
+
+return _M

--- a/t/fixtures/policies/deny/1.0.0/init.lua
+++ b/t/fixtures/policies/deny/1.0.0/init.lua
@@ -1,0 +1,1 @@
+return require('deny')


### PR DESCRIPTION
This PR fixes a bug that was triggered when combining the APIcast policy with some policies that can deny the request, such as the IP check one.

APIcast can call 3scale backend's authrep in the `access` and the `post_action` phases depending on whether the request is cached or not. The problem is that some policies were calling `ngx.exit(4xx)` to deny a request, and that prevents some phases from running, but it does not skip the post_action one.

In practice, this means that with a policy chain like `ip_check + apicast`, even when the IP check policy denied the request, post_action in apicast would run, and report to backend in certain cases.

The bug does not affect all the policies that deny a request. In particular, policies that use the `errors` module (https://github.com/3scale/apicast/blob/64c2b2655051d66a90096c500c33be1f40ec4a75/gateway/src/apicast/errors.lua) instead of calling `ngx.exit()` directly were not affected. The reason is that the errors module sets ` ngx.var.cached_key` to nil, and that prevents post_action from reporting to the 3scale backend.