### PR TITLE
Add "push_policy" command to the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New routing policy that selects an upstream based on the request path, a header, a query argument, or a jwt claim [PR #976](https://github.com/3scale/apicast/pull/976), [PR #983](https://github.com/3scale/apicast/pull/983), [PR #984](https://github.com/3scale/apicast/pull/984), [THREESCALE-1709](https://issues.jboss.org/browse/THREESCALE-1709)
 - Added "last" attribute in the mapping rules. When set to true indicates that, if the rule matches, APIcast should not try to match the rules placed after this one [PR #982](https://github.com/3scale/apicast/pull/982), [THREESCALE-1344](https://issues.jboss.org/browse/THREESCALE-1344)
 - Added TLS Validation policy to verify TLS Client Certificate against a whitelist. [PR #966](https://github.com/3scale/apicast/pull/966), [THREESCALE-1671](https://issues.jboss.org/browse/THREESCALE-1671)
+- New CLI command "push_policy" that pushes a policy schema to the 3scale admin portal [PR #986](https://github.com/3scale/apicast/pull/986), [THREESCALE-871](https://issues.jboss.org/browse/THREESCALE-871)
 
 ### Changed
 

--- a/gateway/src/apicast/cli.lua
+++ b/gateway/src/apicast/cli.lua
@@ -24,6 +24,7 @@ _M.commands = load_commands({
   'start',
   'generate',
   'console',
+  'push_policy'
 }, parser)
 
 function mt.__call(self, arg)

--- a/gateway/src/apicast/cli/command/push_policy.lua
+++ b/gateway/src/apicast/cli/command/push_policy.lua
@@ -1,0 +1,31 @@
+local setmetatable = setmetatable
+
+local policy_pusher = require('apicast.policy_pusher').new()
+
+local _M = { }
+
+local mt = { __index = _M }
+
+function mt.__call(_, opts)
+  policy_pusher:push(
+    opts.name, opts.version, opts.admin_portal_domain, opts.access_token
+  )
+end
+
+local function configure(cmd)
+  cmd:argument('name', 'the name of the policy')
+  cmd:argument('version', 'the version of the policy')
+  cmd:argument('admin_portal_domain', 'your admin portal domain. If you are using SaaS it is YOUR_ACCOUNT-admin.3scale.net')
+  cmd:argument('access_token', 'an access token that you can get from the 3scale admin portal')
+  return cmd
+end
+
+function _M.new(parser)
+  local cmd = configure(
+    parser:command('push_policy', 'Push a policy manifest to the 3scale admin portal')
+  )
+
+  return setmetatable({ parser = parser, cmd = cmd }, mt)
+end
+
+return setmetatable(_M, mt)

--- a/gateway/src/apicast/policy_pusher.lua
+++ b/gateway/src/apicast/policy_pusher.lua
@@ -1,0 +1,57 @@
+local policy_manifests_loader = require('apicast.policy_manifests_loader')
+local http_ng = require('resty.http_ng')
+
+local setmetatable = setmetatable
+local format = string.format
+
+local _M = {}
+
+local mt = { __index = _M }
+
+function _M.new(http_client, manifests_loader)
+  local self = setmetatable({}, mt)
+  self.http_client = http_client or http_ng.new()
+  self.policy_manifests_loader = manifests_loader or policy_manifests_loader
+  return self
+end
+
+local system_endpoint = '/admin/api/registry/policies'
+
+local function system_url(access_token, admin_portal_domain)
+  return format('https://%s:%s%s', access_token, admin_portal_domain, system_endpoint)
+end
+
+local function push_to_system(name, version, manifest, admin_portal_domain, access_token, http_client)
+  local url = system_url(access_token, admin_portal_domain)
+
+  return http_client.json.post(
+    url, { name = name, version = version, schema = manifest }
+  )
+end
+
+local function show_msg(http_resp, err)
+  if http_resp then
+    if http_resp.status >= 200 and http_resp.status < 300 then
+      ngx.log(ngx.INFO, 'Pushed the policy')
+    else
+      ngx.log(ngx.ERR, 'Error while pushing the policy: ', http_resp.body)
+    end
+  else
+    ngx.log(ngx.ERR, 'Could not push the policy to 3scale: ', err)
+  end
+end
+
+function _M:push(name, version, admin_portal_domain, access_token)
+  local policy_manifest = self.policy_manifests_loader.get(name, version)
+  if policy_manifest then
+    local res, err = push_to_system(
+      name, version, policy_manifest, admin_portal_domain, access_token, self.http_client
+    )
+
+    show_msg(res, err)
+  else
+    ngx.log(ngx.ERR, 'Cannot find policy with name: ', name, ' and version: ', version)
+  end
+end
+
+return _M

--- a/spec/fixtures/policies/test/1.0.0-0/apicast-policy.json
+++ b/spec/fixtures/policies/test/1.0.0-0/apicast-policy.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "Example policy",
+  "summary": "An example policy to be used in unit tests.",
+  "version": "1.0.0-0",
+  "configuration": {
+    "type": "object",
+    "properties": {
+    }
+  }
+}

--- a/spec/fixtures/policies/test/2.0.0-0/apicast-policy.json
+++ b/spec/fixtures/policies/test/2.0.0-0/apicast-policy.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "Example policy",
+  "summary": "An example policy to be used in unit tests.",
+  "version": "2.0.0-0",
+  "configuration": {
+    "type": "object",
+    "properties": {
+    }
+  }
+}

--- a/spec/policy_manifests_loader_spec.lua
+++ b/spec/policy_manifests_loader_spec.lua
@@ -1,0 +1,56 @@
+local policy_manifests_loader = require 'apicast.policy_manifests_loader'
+
+local resty_env = require('resty.env')
+local pl_file = require('pl.file')
+local cjson = require('cjson')
+
+describe('Policy Manifests Loader', function()
+  describe('.get_manifest', function()
+    describe('when it is a builtin policy and it exists', function()
+      it('returns its manifest', function()
+        -- Use the headers policy for testing. It could be any other.
+        local manifest_file = 'gateway/src/apicast/policy/headers/apicast-policy.json'
+        local headers_string_manifest = pl_file.read(manifest_file)
+        local headers_decoded_manifest = cjson.decode(headers_string_manifest)
+
+        local manifest = policy_manifests_loader.get('headers', 'builtin')
+
+        assert.same(headers_decoded_manifest, manifest)
+      end)
+    end)
+
+    describe('when it is a non-builtin policy and it exists', function()
+      before_each(function()
+        resty_env.set('APICAST_POLICY_LOAD_PATH', 'spec/fixtures/policies')
+      end)
+
+      it('returns its manifest', function()
+        local manifest_file = 'spec/fixtures/policies/test/2.0.0-0/apicast-policy.json'
+        local test_policy_string_manifest = pl_file.read(manifest_file)
+        local test_policy_decoded_manifest = cjson.decode(test_policy_string_manifest)
+
+        local manifest = policy_manifests_loader.get('test', '2.0.0-0')
+
+        assert.same(test_policy_decoded_manifest, manifest)
+      end)
+    end)
+
+    describe('when the built-in policy does no exist', function()
+      it('returns nil', function()
+        assert.is_nil(policy_manifests_loader.get('invalid', 'builtin'))
+      end)
+    end)
+
+    describe('when the non-built-in policy does no exist', function()
+      it('returns nil', function()
+        assert.is_nil(policy_manifests_loader.get('invalid', '1.0.0'))
+      end)
+    end)
+
+    describe('when the policy exists but with a different version', function()
+      it('returns nil', function()
+        assert.is_nil(policy_manifests_loader.get('headers', 'invalid'))
+      end)
+    end)
+  end)
+end)

--- a/spec/policy_pusher_spec.lua
+++ b/spec/policy_pusher_spec.lua
@@ -1,0 +1,90 @@
+local PolicyPusher = require('apicast.policy_pusher')
+
+local cjson = require 'cjson'
+local http_ng = require 'resty.http_ng'
+
+describe('Policy pusher', function()
+  local policy_name = 'test_policy'
+  local policy_version = '1.0.0'
+  local policy_manifest = { name = 'Test policy', version = '1.0.0' }
+
+  local manifests_loader = {
+    get = function(name, version)
+      local manifests = {
+        [policy_name] = { [policy_version] = policy_manifest }
+      }
+
+      return manifests[name][version]
+    end
+  }
+
+  local admin_portal_domain = 'some-account-admin.3scale.net'
+  local access_token = 'my_access_token'
+
+  local test_backend
+  local http_client
+
+  before_each(function()
+    test_backend = http_ng.backend()
+    http_client = http_ng.new({ backend = test_backend })
+  end)
+
+  describe('if the policy exists', function()
+    it('pushes the policy to the 3scale admin portal', function()
+      local request_body = {
+        name = policy_name,
+        version = policy_version,
+        schema = policy_manifest
+      }
+
+      test_backend.expect{
+        url = 'https://' .. access_token .. ':' .. admin_portal_domain ..
+            '/admin/api/registry/policies',
+        body = cjson.encode(request_body)
+      }.respond_with{ status = 200 }
+
+      local policy_pusher = PolicyPusher.new(http_client, manifests_loader)
+      policy_pusher:push(policy_name, policy_version, admin_portal_domain, access_token)
+    end)
+  end)
+
+  describe('if the policy does no exist', function()
+    it('does not push anything to the 3scale admin portal', function()
+      local version = 'invalid'
+
+      stub(test_backend, 'send')
+
+      local policy_pusher = PolicyPusher.new(http_client, manifests_loader)
+      policy_pusher:push(policy_name, version, admin_portal_domain, access_token)
+
+      assert.stub(test_backend.send).was_not_called()
+    end)
+  end)
+
+  describe('if the request to 3scale returns an error', function()
+    it('shows the error', function()
+      stub(ngx, 'log')
+
+      local request_body = {
+        name = policy_name,
+        version = policy_version,
+        schema = policy_manifest
+      }
+
+      local error_msg_returned = 'Some error'
+
+      test_backend.expect{
+        url = 'https://' .. access_token .. ':' .. admin_portal_domain ..
+            '/admin/api/registry/policies',
+        body = cjson.encode(request_body)
+      }.respond_with{ status = 400, body = error_msg_returned }
+
+      local policy_pusher = PolicyPusher.new(http_client, manifests_loader)
+      policy_pusher:push(policy_name, policy_version, admin_portal_domain, access_token)
+
+      assert.stub(ngx.log).was_called_with(
+        ngx.ERR, 'Error while pushing the policy: ', error_msg_returned
+      )
+    end)
+  end)
+end)


### PR DESCRIPTION
This PR adds a command to push policy schemas to the 3scale admin portal.

I tagged it as WIP because we'll need confirmation from @hallelujah to make sure that the endpoints used and their parameters are correct.