### PR TITLE
added service id and service name headers when X-3scale-debug is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Environment files now can use global `context` variable to share data [PR #964](https://github.com/3scale/apicast/pull/964)
+- Adde sevice id and service name headers in debug context [PR #987](https://github.com/3scale/apicast/pull/987)
 
 ### Changed
 

--- a/gateway/src/apicast/proxy.lua
+++ b/gateway/src/apicast/proxy.lua
@@ -85,6 +85,8 @@ local function output_debug_headers(service, usage, credentials)
     ngx.header["X-3scale-credentials"]   = credentials
     ngx.header["X-3scale-usage"]         = usage
     ngx.header["X-3scale-hostname"]      = ngx.var.hostname
+    ngx.header["X-3scale-svc-id"]        = service.id
+    ngx.header["X-3scale-svc-name"]      = service.serializable.system_name
   end
 end
 

--- a/gateway/src/apicast/proxy.lua
+++ b/gateway/src/apicast/proxy.lua
@@ -85,8 +85,8 @@ local function output_debug_headers(service, usage, credentials)
     ngx.header["X-3scale-credentials"]   = credentials
     ngx.header["X-3scale-usage"]         = usage
     ngx.header["X-3scale-hostname"]      = ngx.var.hostname
-    ngx.header["X-3scale-svc-id"]        = service.id
-    ngx.header["X-3scale-svc-name"]      = service.serializable.system_name
+    ngx.header["X-3scale-service-id"]    = service.id
+    ngx.header["X-3scale-service-name"]  = service.serializable.system_name
   end
 end
 


### PR DESCRIPTION
Added info on the services in the response headers when using X-3scale-debug headers as asked in https://issues.jboss.org/browse/THREESCALE-1849