### PR TITLE
[nginx] do not send openresty version [THREESCALE-1989]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Do not send OpenResty version in the `Server` response header [PR #997](https://github.com/3scale/APIcast/pull/997)
+
 ## [3.5.0-beta1] - 2019-03-12
 
 ### Changed

--- a/gateway/conf/nginx.conf.liquid
+++ b/gateway/conf/nginx.conf.liquid
@@ -36,6 +36,7 @@ http {
   sendfile           on;
   tcp_nopush         on;
   tcp_nodelay        on;
+  server_tokens off;
 
 
 


### PR DESCRIPTION
Closes [THREESCALE-1989](https://issues.jboss.org/browse/THREESCALE-1989)

Changes
```
< HTTP/1.1 200 OK
< Server: openresty/1.13.6.2
< Date: Mon, 18 Mar 2019 16:26:35 GMT
< Content-Type: text/plain
< Transfer-Encoding: chunked
< Connection: keep-alive
```

Into
```
< HTTP/1.1 200 OK
< Server: openresty
< Date: Mon, 18 Mar 2019 16:27:05 GMT
< Content-Type: text/plain
< Transfer-Encoding: chunked
< Connection: keep-alive
```
