### PR TITLE
Prevent a crash in 3scale batcher on reports with missing credentials

### DIFF
--- a/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
@@ -39,10 +39,10 @@ local function metrics_part_in_key(usage)
 end
 
 local regexes_report_key = {
-  "service_id:(?<service_id>[\\w-]+),user_key:(?<user_key>[\\w-]+),metric:(?<metric>[\\w-]+)",
-  "service_id:(?<service_id>[\\w-]+),access_token:(?<access_token>[\\w-]+),metric:(?<metric>[\\w-]+)",
-  "service_id:(?<service_id>[\\w-]+),app_id:(?<app_id>[\\w-]+),app_key:(?<app_key>[\\w-]+),metric:(?<metric>[\\w-]+)",
-  "service_id:(?<service_id>[\\w-]+),app_id:(?<app_id>[\\w-]+),metric:(?<metric>[\\w-]+)"
+  [[service_id:(?<service_id>[\w-]+),user_key:(?<user_key>[\w-]+),metric:(?<metric>[\w-]+)]],
+  [[service_id:(?<service_id>[\w-]+),access_token:(?<access_token>[\w-]+),metric:(?<metric>[\w-]+)]],
+  [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\w-]+),app_key:(?<app_key>[\w-]+),metric:(?<metric>[\w-]+)]],
+  [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\w-]+),metric:(?<metric>[\w-]+)]],
 }
 
 function _M.key_for_cached_auth(transaction)

--- a/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
@@ -77,6 +77,8 @@ function _M.report_from_key_batched_report(key, value)
       }
     end
   end
+
+  return nil, 'credentials not found'
 end
 
 return _M

--- a/gateway/src/apicast/policy/3scale_batcher/reports_batcher.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/reports_batcher.lua
@@ -88,12 +88,15 @@ function _M:get_all(service_id)
 
   for _, key in ipairs(cached_report_keys) do
     local value = self.storage:get(key)
+    local report, err = keys_helper.report_from_key_batched_report(key, value)
 
-    local report = keys_helper.report_from_key_batched_report(key, value)
-
-    if value and value > 0 and report.service_id == service_id then
-      insert(cached_reports, report)
-      self.storage:delete(key)
+    if not err then
+      if value > 0 and report and report.service_id == service_id then
+        insert(cached_reports, report)
+        self.storage:delete(key)
+      end
+    else
+      ngx.log(ngx.WARN, 'failed to get report for key ', key, ' err: ', err)
     end
   end
 

--- a/spec/policy/3scale_batcher/keys_helper_spec.lua
+++ b/spec/policy/3scale_batcher/keys_helper_spec.lua
@@ -56,5 +56,11 @@ describe('Keys Helper', function()
       local report = keys_helper.report_from_key_batched_report(key)
       assert.same({ service_id = 's1', app_id = 'ai', metric = 'm1'}, report)
     end)
+
+    it('returns an error when key has no credentials', function()
+      local key = 'service_id:s1,app_id:,metric:m1'
+
+      assert.returns_error('credentials not found', keys_helper.report_from_key_batched_report(key))
+    end)
   end)
 end)


### PR DESCRIPTION
Found when investigating https://github.com/3scale/APIcast/pull/1007

If a report has no credentials it should be ignored (for now).