### PR TITLE
[make] Add dependencies helper message.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ lua_modules: $(ROVER) $(S2I_CONTEXT)/Roverfile.lock
 lua_modules/bin/rover:
 	@LUAROCKS_CONFIG=$(S2I_CONTEXT)/config-5.1.lua luarocks install --server=http://luarocks.org/dev lua-rover --tree=lua_modules 1>&2
 
-dependencies: lua_modules carton
+dependencies: lua_modules carton  ## Install project dependencies
 
 clean-containers: apicast-source
 	$(DOCKER_COMPOSE) down --volumes


### PR DESCRIPTION
Dependencies target was not documented in the `make help`, this commit add
a help message for the target.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>