### PR TITLE
[THREESCALE-2205] Fix incorrect connection reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed incorrect description of the `client` attribute in the Keycloak role check policy [PR #1005](https://github.com/3scale/APIcast/pull/1005), [THREESCALE_1867](https://issues.jboss.org/browse/THREESCALE-1867)
 - Segfault when normalizing some client certificates [PR #1006](https://github.com/3scale/APIcast/pull/1006)
+- Fixed incorrect connection reuse for requests on different domains [PR #1021](https://github.com/3scale/APIcast/pull/1021), [THREESCALE-2205](https://issues.jboss.org/browse/THREESCALE-2205)
 
 ### Removed
 

--- a/gateway/src/resty/http/proxy.lua
+++ b/gateway/src/resty/http/proxy.lua
@@ -17,7 +17,9 @@ local function connect_direct(httpc, request)
     local uri = request.uri
     local host = uri.host
     local ip, port = httpc:resolve(host, nil, uri)
-    local ok, err = httpc:connect(ip, port or default_port(uri))
+
+    local options = { pool = format('%s:%s', host, port) }
+    local ok, err = httpc:connect(ip, port or default_port(uri), options)
 
     if not ok then return nil, err end
 

--- a/spec/resty/http/proxy_spec.lua
+++ b/spec/resty/http/proxy_spec.lua
@@ -58,5 +58,47 @@ describe('resty.http.proxy', function()
             assert.same(200, res.status)
             assert.match('GET http://127.0.0.1:1984/request HTTP/1.1', res:read_body())
         end)
+
+        -- Regression test. Ref: https://issues.jboss.org/browse/THREESCALE-2205
+        context('when different subdomains resolve to the same IP', function()
+            local request_domain_1 = { url = 'http://test.example.com/', method = 'GET' }
+            local request_domain_2 = { url = 'http://prod.example.com/', method = 'GET' }
+
+            before_each(function()
+                -- Make everything resolve to the same IP
+                local resty_resolver = require 'resty.resolver.http'
+                stub(resty_resolver, 'resolve', function() return "1.1.1.1", 80 end)
+            end)
+
+            context('and it uses a http proxy', function()
+                before_each(function()
+                    _M:reset({ http_proxy = 'http://127.0.0.1:1984' })
+                end)
+
+                it('does not reuse the connection', function()
+                    local proxy = _M.new(request_domain_1)
+                    proxy:request(request_domain_1):read_body()
+                    proxy:set_keepalive()
+
+                    proxy = _M.new(request_domain_2)
+                    assert.same(0, proxy:get_reused_times())
+                end)
+            end)
+
+            context('and it does not use an http proxy', function()
+                before_each(function()
+                    _M:reset({})
+                end)
+
+                it('does not reuse the connection', function()
+                    local proxy = _M.new(request_domain_1)
+                    proxy:request(request_domain_1):read_body()
+                    proxy:set_keepalive()
+
+                    proxy = _M.new(request_domain_2)
+                    assert.same(0, proxy:get_reused_times())
+                end)
+            end)
+        end)
     end)
 end)


### PR DESCRIPTION
Fixes https://issues.jboss.org/browse/THREESCALE-2205

By default, the 'connect' method of lua-resty-http, uses the ip and the host as the key to find a connection in the pool of idle connections. Ref: https://github.com/ledgetech/lua-resty-http#connect

That can cause problems in the case of HTTPS requests as mentioned in the issue linked above. For example, when 2 different domains resolve to the same IP, the connection is reused, and it should not be.

The 'connect_proxy' method of the modified module was using correct IDs for the pool, but the 'connect_direct' method was not.