### PR TITLE
[config] add support to filter services by endpoint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Ability to configure client certificate chain depth [PR #1006](https://github.com/3scale/APIcast/pull/1006)
+- You can filter services by endpoint name using Regexp [PR #1022](https://github.com/3scale/APIcast/pull/1022) [THREESCALE-1524](https://issues.jboss.org/browse/THREESCALE-1524)
 
 ### Fixed
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -186,6 +186,29 @@ before the client is throttled by adding latency.
 When set to _true_, APIcast will log the response code of the response returned by the API backend in 3scale. In some plans this information can later be consulted from the 3scale admin portal.
 Find more information about the Response Codes feature on the [3scale support site](https://access.redhat.com/documentation/en-us/red_hat_3scale/2.saas/html/analytics/response-codes-tracking).
 
+### `APICAST_SERVICES_FILTER_BY_URL`
+**Value:** a PCRE (Perl Compatible Regular Expression)
+**Example:** .*.example.com
+
+Used to filter the service configured in the 3scale API Manager, the filter
+matches with the public base URL. Services that do not match the filter will be
+discarded. If the regular expression cannot be compiled no services will be
+loaded. 
+
+Note: If a service does not match, but is included in the
+`APICAST_SERVICES_LIST`, service will not be discarded
+
+Example:
+
+Regexp Filter: http:\/\/.*.google.com
+Service 1: backend endpoint http://www.google.com
+Service 2: backend endpoint http://www.yahoo.com
+Service 3: backend endpoint http://mail.google.com
+Service 4: backend endpoint http://mail.yahoo.com
+
+The services that will be configured in Apicast will be 1 and 3. Services 2 and
+4 will be discarded.
+
 ### `APICAST_SERVICES_LIST`
 **Value:** a comma-separated list of service IDs
 

--- a/gateway/src/apicast/configuration/service.lua
+++ b/gateway/src/apicast/configuration/service.lua
@@ -8,7 +8,9 @@ local rawget = rawget
 local lower = string.lower
 local gsub = string.gsub
 local select = select
+
 local re = require 'ngx.re'
+local match = ngx.re.match
 
 local http_authorization = require 'resty.http_authorization'
 
@@ -262,6 +264,24 @@ function _M:get_usage(method, path)
   else
     return extract_usage_v2(self, method, path)
   end
+end
+
+--- Validate that the given regexp match with one of the service hosts.
+--- This function needs a valid regexp, if not will return false
+-- @tparam string regexp Regular expresion to match with the host
+-- @return bool true if match
+function _M:match_host(regexp)
+  if not regexp or not self.hosts then
+      return false
+  end
+
+  for j = 1, #self.hosts do
+    local val, _ = match(self.hosts[j], regexp, 'oj')
+    if val then
+      return true
+    end
+  end
+  return false
 end
 
 return _M

--- a/t/apicast-subset-of-services.t
+++ b/t/apicast-subset-of-services.t
@@ -1,55 +1,56 @@
-use lib 't';
-use Test::APIcast 'no_plan';
+use Test::APIcast::Blackbox 'no_plan';
 
 run_tests();
 
 __DATA__
 
 === TEST 1: multi service configuration limited to specific service
---- main_config
-env APICAST_SERVICES_LIST=42,21;
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-  init_by_lua_block {
-    require('apicast.configuration_loader').mock({
-      services = {
-        {
-          id = 42,
-          backend_version = 1,
-          proxy = {
-            api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/one/",
-            hosts = { 'one' },
-            proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'one', delta = 1 }
-            }
+--- env eval
+("APICAST_SERVICES_LIST", "42,21")
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": 1,
+      "proxy": {
+        "hosts": [
+          "one"
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          {
+            "http_method": "GET",
+            "delta": 1,
+            "metric_system_name": "one",
+            "pattern": "/"
           }
-        },
-        {
-          id = 11,
-          proxy = {
-            hosts = { 'two' }
-          }
-        }
-      }
-    })
-  }
-  lua_shared_dict api_keys 10m;
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
+        ]
+      },
+      "id": 42
+    },
+    {
+      "proxy": {
+        "hosts": [
+          "two"
+        ]
+      },
+      "id": 11
+    }
+  ]
+}
+--- backend
   location /transactions/authrep.xml {
     content_by_lua_block { ngx.exit(200) }
   }
-
-  location ~ /api-backend(/.+) {
-     echo 'yay, api backend: $1';
+--- upstream
+  location ~ / {
+     echo 'yay, api backend';
   }
 --- pipelined_requests eval
 ["GET /?user_key=1","GET /?user_key=2"]
 --- more_headers eval
 ["Host: one", "Host: two"]
 --- response_body eval
-["yay, api backend: /one/\n", ""]
+["yay, api backend\n", ""]
 --- error_code eval
 [200, 404]

--- a/t/apicast-subset-of-services.t
+++ b/t/apicast-subset-of-services.t
@@ -54,3 +54,133 @@ __DATA__
 ["yay, api backend\n", ""]
 --- error_code eval
 [200, 404]
+
+
+
+=== TEST 2: multi service configuration limited with Regexp Filter
+--- env eval
+("APICAST_SERVICES_FILTER_BY_URL", "^on*")
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": 1,
+      "proxy": {
+        "hosts": [
+          "one"
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          {
+            "http_method": "GET",
+            "delta": 1,
+            "metric_system_name": "one",
+            "pattern": "/"
+          }
+        ]
+      },
+      "id": 42
+    },
+    {
+      "proxy": {
+        "hosts": [
+          "two"
+        ]
+      },
+      "id": 11
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block { ngx.exit(200) }
+  }
+--- upstream
+  location ~ / {
+     echo 'yay, api backend';
+  }
+--- pipelined_requests eval
+["GET /?user_key=1","GET /?user_key=2"]
+--- more_headers eval
+["Host: one", "Host: two"]
+--- response_body eval
+["yay, api backend\n", ""]
+--- error_code eval
+[200, 404]
+
+=== TEST 3: multi service configuration limited with Regexp Filter and service list
+--- env eval
+(
+"APICAST_SERVICES_FILTER_BY_URL", "^on*",
+"APICAST_SERVICES_LIST", "21"
+)
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": 1,
+      "proxy": {
+        "hosts": [
+          "one"
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          {
+            "http_method": "GET",
+            "delta": 1,
+            "metric_system_name": "one",
+            "pattern": "/"
+          }
+        ]
+      },
+      "id": 42
+    },
+    {
+      "backend_version": 1,
+      "proxy": {
+        "hosts": [
+          "two"
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/two",
+        "proxy_rules": [
+          {
+            "http_method": "GET",
+            "delta": 1,
+            "metric_system_name": "one",
+            "pattern": "/"
+          }
+        ]
+      },
+      "id": 21
+    },
+    {
+      "proxy": {
+        "hosts": [
+          "three"
+        ]
+      },
+      "id": 11
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block { ngx.exit(200) }
+  }
+--- upstream
+  location / {
+     echo 'yay, api backend';
+  }
+
+  location /two {
+     echo 'yay, api backend two';
+  }
+
+--- pipelined_requests eval
+["GET /?user_key=1","GET /?user_key=2", "GET /?user_key=3"]
+--- more_headers eval
+["Host: one", "Host: two", "Host: three"]
+--- response_body eval
+["yay, api backend\n", "yay, api backend two\n", ""]
+--- error_code eval
+[200, 200, 404]


### PR DESCRIPTION
This commit adds the option to filter services based on the endpoint.
This commit expose a new config flag using the env variable
`APICAST_SERVICES_FILTER`, services filter happens on
`configuration.filter_services`.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>