### PR TITLE
Local chain: forward correct context in all the request phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed incorrect description of the `client` attribute in the Keycloak role check policy [PR #1005](https://github.com/3scale/APIcast/pull/1005), [THREESCALE_1867](https://issues.jboss.org/browse/THREESCALE-1867)
 - Segfault when normalizing some client certificates [PR #1006](https://github.com/3scale/APIcast/pull/1006)
 - Fixed incorrect connection reuse for requests on different domains [PR #1021](https://github.com/3scale/APIcast/pull/1021), [THREESCALE-2205](https://issues.jboss.org/browse/THREESCALE-2205)
+- `export()` now works correctly in policies of the local chain. It was only working in the `rewrite` phase [PR #1023](https://github.com/3scale/APIcast/pull/1023)
+- The caching policy now works correctly when combined with the 3scale batcher one [PR #1023](https://github.com/3scale/APIcast/pull/1023)
 
 ### Removed
 

--- a/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
@@ -140,7 +140,7 @@ end
 
 local function update_downtime_cache(cache, transaction, backend_status, cache_handler)
   local key = keys_helper.key_for_cached_auth(transaction)
-  cache_handler(cache, key, backend_status)
+  cache_handler(cache, key, { status = backend_status })
 end
 
 local function handle_backend_ok(self, transaction, cache_handler)
@@ -163,7 +163,8 @@ local function handle_backend_denied(self, service, transaction, status, headers
 end
 
 local function handle_backend_error(self, service, transaction, cache_handler)
-  local cached = cache_handler and self.backend_downtime_cache:get(transaction)
+  local key = keys_helper.key_for_cached_auth(transaction)
+  local cached = cache_handler and self.backend_downtime_cache:get(key)
 
   if cached == 200 then
     self.reports_batcher:add(transaction)

--- a/gateway/src/apicast/policy/local_chain/local_chain.lua
+++ b/gateway/src/apicast/policy/local_chain/local_chain.lua
@@ -41,19 +41,22 @@ for _, phase in policy.phases() do
     local policy_chain = find_policy_chain(context)
 
     if policy_chain then
-      return policy_chain[phase](policy_chain, context, ...)
+      local merged_context = LinkedList.readwrite(context, policy_chain:export())
+      return policy_chain[phase](policy_chain, merged_context, ...)
     end
   end
 end
 
 local rewrite = _M.rewrite
 
+-- Similar to the methods defined just above. The only difference is that this
+-- one builds the policy chain.
 function _M:rewrite(context, ...)
   local policy_chain = build_chain(context)
 
-  context = LinkedList.readwrite(context, policy_chain:export())
+  local merged_context = LinkedList.readwrite(context, policy_chain:export())
 
-  rewrite(self, context, ...)
+  rewrite(self, merged_context, ...)
 end
 
 return _M


### PR DESCRIPTION
It was done correctly only for `rewrite()`. In the rest of the phases, the context received was not merged with the one coming from `policy_chain:export()`.

This is the same bug that we fixed in https://github.com/3scale/APIcast/pull/673 . However, we only fixed it for the rewrite phase.

I discovered this while working on [this branch](https://github.com/3scale/APIcast/tree/upstream-config-policy). I needed to export some data to the shared context and access it in the balancer phase and I realized that it was not there.
