### PR TITLE
Add service label on metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - You can filter services by endpoint name using Regexp [PR #1022](https://github.com/3scale/APIcast/pull/1022) [THREESCALE-1524](https://issues.jboss.org/browse/THREESCALE-1524)
 - "Upstream Connection" policy. It allows to configure several options for the connections to the upstream [PR #1025](https://github.com/3scale/APIcast/pull/1025), [THREESCALE-2166](https://issues.jboss.org/browse/THREESCALE-2166)
 - Enable APICAST_EXTENDED_METRICS env variable to provide more in-depth details [PR #1024](https://github.com/3scale/APIcast/pull/1024) [THREESCALE-2150](https://issues.jboss.org/browse/THREESCALE-2150)
+- Enable APICAST_EXTENDED_METRICS environment variable to provide additional details [PR #1024](https://github.com/3scale/APIcast/pull/1024) [THREESCALE-2150](https://issues.jboss.org/browse/THREESCALE-2150)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - You can filter services by endpoint name using Regexp [PR #1022](https://github.com/3scale/APIcast/pull/1022) [THREESCALE-1524](https://issues.jboss.org/browse/THREESCALE-1524)
 - "Upstream Connection" policy. It allows to configure several options for the connections to the upstream [PR #1025](https://github.com/3scale/APIcast/pull/1025), [THREESCALE-2166](https://issues.jboss.org/browse/THREESCALE-2166)
+- Enable APICAST_EXTENDED_METRICS env variable to provide more in-depth details [PR #1024](https://github.com/3scale/APIcast/pull/1024) [THREESCALE-2150](https://issues.jboss.org/browse/THREESCALE-2150)
 
 ### Fixed
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -386,6 +386,6 @@ with specific information that will provide more in-depth details about APIcast.
 
 The metrics that will have extended information are:
 
-- total_response_time_seconds: label service
-- upstream_response_time_seconds: label service
-- upstream_status: label service
+- total_response_time_seconds: labels service_id and service_system_name
+- upstream_response_time_seconds: labels service_id and service_system_name
+- upstream_status: labels service_id and service_system_name

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -374,3 +374,18 @@ Defines a HTTP proxy to be used for connecting to HTTPS services. Authentication
 **Example:** `foo,bar.com,.extra.dot.com`
 
 Defines a comma-separated list of hostnames and domain names for which the requests should not be proxied. Setting to a single `*` character, which matches all hosts, effectively disables the proxy.
+
+### `APICAST_EXTENDED_METRICS`
+
+**Default:** false
+**Value:** boolean
+**Example:** "true"
+
+Enables additional information on Prometheus metrics; some labels will be used
+with specific information that will provide more in-depth details about APIcast.
+
+The metrics that will have extended information are:
+
+- total_response_time_seconds: label service
+- upstream_response_time_seconds: label service
+- upstream_status: label service

--- a/doc/prometheus-metrics.md
+++ b/doc/prometheus-metrics.md
@@ -7,9 +7,9 @@
 | openresty_shdict_capacity          | Capacity of the dictionaries shared between workers              | gauge     | dict(one for every dictionary)                               | Default        |
 | openresty_shdict_free_space        | Free space of the dictionaries shared between workers            | gauge     | dict(one for every dictionary)                               | Default        |
 | nginx_metric_errors_total          | Number of errors of the Lua library that manages the metrics     | counter   | -                                                            | Default        |
-| total_response_time_seconds        | Time needed to sent a response to the client (in seconds)        | histogram | -                                                            | Default        |
-| upstream_response_time_seconds     | Response times from upstream servers (in seconds)                | histogram | -                                                            | Default        |
-| upstream_status                    | HTTP status from upstream servers                                | counter   | status                                                       | Default        |
+| total_response_time_seconds        | Time needed to sent a response to the client (in seconds)        | histogram | service                                                      | Default        |
+| upstream_response_time_seconds     | Response times from upstream servers (in seconds)                | histogram | service                                                      | Default        |
+| upstream_status                    | HTTP status from upstream servers                                | counter   | status, service                                              | Default        |
 | threescale_backend_calls           | Authorize and report requests to the 3scale backend (Apisonator) | counter   | endpoint(authrep, auth, report), status(2xx, 4xx, 5xx)       | APIcast        |
 | batching_policy_auths_cache_hits   | Hits in the auths cache of the 3scale batching policy            | counter   | -                                                            | 3scale Batcher |
 | batching_policy_auths_cache_misses | Misses in the auths cache of the 3scale batching policy          | counter   | -                                                            | 3scale Batcher |

--- a/doc/prometheus-metrics.md
+++ b/doc/prometheus-metrics.md
@@ -7,9 +7,9 @@
 | openresty_shdict_capacity          | Capacity of the dictionaries shared between workers              | gauge     | dict(one for every dictionary)                               | Default        |
 | openresty_shdict_free_space        | Free space of the dictionaries shared between workers            | gauge     | dict(one for every dictionary)                               | Default        |
 | nginx_metric_errors_total          | Number of errors of the Lua library that manages the metrics     | counter   | -                                                            | Default        |
-| total_response_time_seconds        | Time needed to sent a response to the client (in seconds)        | histogram | service                                                      | Default        |
-| upstream_response_time_seconds     | Response times from upstream servers (in seconds)                | histogram | service                                                      | Default        |
-| upstream_status                    | HTTP status from upstream servers                                | counter   | status, service                                              | Default        |
+| total_response_time_seconds        | Time needed to sent a response to the client (in seconds)        | histogram | service_id, service_system_name                              | Default        |
+| upstream_response_time_seconds     | Response times from upstream servers (in seconds)                | histogram | service_id, service_system_name                              | Default        |
+| upstream_status                    | HTTP status from upstream servers                                | counter   | status, service_id, service_system_name                      | Default        |
 | threescale_backend_calls           | Authorize and report requests to the 3scale backend (Apisonator) | counter   | endpoint(authrep, auth, report), status(2xx, 4xx, 5xx)       | APIcast        |
 | batching_policy_auths_cache_hits   | Hits in the auths cache of the 3scale batching policy            | counter   | -                                                            | 3scale Batcher |
 | batching_policy_auths_cache_misses | Misses in the auths cache of the 3scale batching policy          | counter   | -                                                            | 3scale Batcher |

--- a/gateway/src/apicast/configuration.lua
+++ b/gateway/src/apicast/configuration.lua
@@ -87,6 +87,7 @@ function _M.parse_service(service)
 
   return Service.new({
       id = tostring(service.id or 'default'),
+      system_name = tostring(service.system_name or ''),
       backend_version = backend_version,
       authentication_method = proxy.authentication_method or backend_version,
       hosts = proxy.hosts or { 'localhost' }, -- TODO: verify localhost is good default

--- a/gateway/src/apicast/metrics/upstream.lua
+++ b/gateway/src/apicast/metrics/upstream.lua
@@ -4,36 +4,40 @@ local prometheus = require('apicast.prometheus')
 
 local _M = {}
 
+local service_label = 'service'
+local status_label = 'status'
+
 local upstream_status_codes = prometheus(
   'counter',
   'upstream_status',
   'HTTP status from upstream servers',
-  { 'status' }
+  { status_label, service_label }
 )
 
 local upstream_resp_times = prometheus(
   'histogram',
   'upstream_response_time_seconds',
-  'Response times from upstream servers'
+  'Response times from upstream servers',
+  { service_label }
 )
 
-local function inc_status_codes_counter(status)
+local function inc_status_codes_counter(status, service)
   if tonumber(status) and upstream_status_codes then
-    upstream_status_codes:inc(1, { status })
+    upstream_status_codes:inc(1, { status, service })
   end
 end
 
-local function add_resp_time(response_time)
+local function add_resp_time(response_time, service)
   local time = tonumber(response_time)
 
   if time and upstream_resp_times then
-    upstream_resp_times:observe(time)
+    upstream_resp_times:observe(time, { service })
   end
 end
 
-function _M.report(status, response_time)
-  inc_status_codes_counter(status)
-  add_resp_time(response_time)
+function _M.report(status, response_time, service)
+  inc_status_codes_counter(status, service)
+  add_resp_time(response_time, service)
 end
 
 return _M

--- a/gateway/src/apicast/metrics/upstream.lua
+++ b/gateway/src/apicast/metrics/upstream.lua
@@ -4,26 +4,31 @@ local prometheus = require('apicast.prometheus')
 
 local _M = {}
 
-local service_label = 'service'
+local service_label = 'service_id'
+local service_system_name_label = 'service_system_name'
 local status_label = 'status'
 
 local upstream_status_codes = prometheus(
   'counter',
   'upstream_status',
   'HTTP status from upstream servers',
-  { status_label, service_label }
+  { status_label, service_label, service_system_name_label }
 )
 
 local upstream_resp_times = prometheus(
   'histogram',
   'upstream_response_time_seconds',
   'Response times from upstream servers',
-  { service_label }
+  { service_label, service_system_name_label }
 )
 
 local function inc_status_codes_counter(status, service)
   if tonumber(status) and upstream_status_codes then
-    upstream_status_codes:inc(1, { status, service })
+    upstream_status_codes:inc(1, {
+      status,
+      service.id or "",
+      service.system_name or ""
+    })
   end
 end
 
@@ -31,11 +36,17 @@ local function add_resp_time(response_time, service)
   local time = tonumber(response_time)
 
   if time and upstream_resp_times then
-    upstream_resp_times:observe(time, { service })
+    upstream_resp_times:observe(time, {
+      service.id or "",
+      service.system_name or ""
+    })
   end
 end
 
 function _M.report(status, response_time, service)
+  if not service then
+    service = {}
+  end
   inc_status_codes_counter(status, service)
   add_resp_time(response_time, service)
 end

--- a/gateway/src/apicast/policy/nginx_metrics/nginx_metrics.lua
+++ b/gateway/src/apicast/policy/nginx_metrics/nginx_metrics.lua
@@ -84,7 +84,7 @@ local shdict_free_space_metric = prometheus('gauge', 'openresty_shdict_free_spac
 local response_times = prometheus(
   'histogram',
   'total_response_time_seconds',
-  'Time needed to sent a response to the client (in seconds).',
+  'Time needed to send a response to the client (in seconds).',
   { 'service' }
 )
 

--- a/spec/metrics/upstream_spec.lua
+++ b/spec/metrics/upstream_spec.lua
@@ -32,12 +32,12 @@ describe('upstream metrics', function()
 
     it('increases the counter of status codes', function()
       upstream_metrics.report(200, 0.1)
-      assert.stub(test_counter.inc).was_called_with(test_counter, 1, { 200 })
+      assert.stub(test_counter.inc).was_called_with(test_counter, 1, { 200, "", "" })
     end)
 
     it('adds the latency to the histogram', function()
       upstream_metrics.report(200, 0.1)
-      assert.stub(test_histogram.observe).was_called_with(test_histogram, 0.1, {})
+      assert.stub(test_histogram.observe).was_called_with(test_histogram, 0.1, {"", ""})
     end)
 
     describe('when the status is nil or empty', function()
@@ -58,17 +58,17 @@ describe('upstream metrics', function()
 
 
     describe('With service id', function()
-      local service_metric_id = "42"
+      local service = {id = "123", system_name="foo"}
       it("increases empty service on nil", function()
         upstream_metrics.report(200, 0.1, nil)
-        assert.stub(test_histogram.observe).was_called_with(test_histogram, 0.1, {})
-        assert.stub(test_counter.inc).was_called_with(test_counter, 1, { 200 })
+        assert.stub(test_histogram.observe).was_called_with(test_histogram, 0.1, {"", ""})
+        assert.stub(test_counter.inc).was_called_with(test_counter, 1, { 200, "", "" })
       end)
 
       it("increase a valid service", function()
-        upstream_metrics.report(200, 0.1, service_metric_id)
-        assert.stub(test_histogram.observe).was_called_with(test_histogram, 0.1, { service_metric_id })
-        assert.stub(test_counter.inc).was_called_with(test_counter, 1, { 200, service_metric_id })
+        upstream_metrics.report(200, 0.1, service)
+        assert.stub(test_histogram.observe).was_called_with(test_histogram, 0.1, { service.id, service.system_name })
+        assert.stub(test_counter.inc).was_called_with(test_counter, 1, { 200, service.id, service.system_name })
       end)
     end)
   end)

--- a/spec/metrics/upstream_spec.lua
+++ b/spec/metrics/upstream_spec.lua
@@ -37,7 +37,7 @@ describe('upstream metrics', function()
 
     it('adds the latency to the histogram', function()
       upstream_metrics.report(200, 0.1)
-      assert.stub(test_histogram.observe).was_called_with(test_histogram, 0.1)
+      assert.stub(test_histogram.observe).was_called_with(test_histogram, 0.1, {})
     end)
 
     describe('when the status is nil or empty', function()
@@ -53,6 +53,22 @@ describe('upstream metrics', function()
         upstream_metrics.report(200, nil)
         upstream_metrics.report(200, '')
         assert.stub(test_histogram.observe).was_not_called()
+      end)
+    end)
+
+
+    describe('With service id', function()
+      local service_metric_id = "42"
+      it("increases empty service on nil", function()
+        upstream_metrics.report(200, 0.1, nil)
+        assert.stub(test_histogram.observe).was_called_with(test_histogram, 0.1, {})
+        assert.stub(test_counter.inc).was_called_with(test_counter, 1, { 200 })
+      end)
+
+      it("increase a valid service", function()
+        upstream_metrics.report(200, 0.1, service_metric_id)
+        assert.stub(test_histogram.observe).was_called_with(test_histogram, 0.1, { service_metric_id })
+        assert.stub(test_counter.inc).was_called_with(test_counter, 1, { 200, service_metric_id })
       end)
     end)
   end)

--- a/t/prometheus-metrics.t
+++ b/t/prometheus-metrics.t
@@ -273,8 +273,8 @@ In particular, it shows the status codes and the response times
 "",
 [
     qr/upstream_response_time_seconds(.|\n)/,
-    qr/upstream_response_time_seconds_bucket\{service="",le=".*"\} 1/,
-    qr/upstream_status\{status="200",service=""\} 1/
+    qr/upstream_response_time_seconds_bucket\{service_id="",service_system_name="",le=".*"\} 1/,
+    qr/upstream_status\{status="200",service_id="",service_system_name=""\} 1/
 ]]
 --- no_error_log
 [error]
@@ -318,7 +318,7 @@ In particular, it shows the status codes and the response times
 --- response_body_like eval
 [
 "",
-qr/total_response_time_seconds(.|\n)*total_response_time_seconds_bucket\{service="",le=".*"\} 1/
+qr/total_response_time_seconds(.|\n)*total_response_time_seconds_bucket\{service_id="",service_system_name="",le=".*"\} 1/
 ]
 --- no_error_log
 [error]
@@ -333,6 +333,7 @@ qr/total_response_time_seconds(.|\n)*total_response_time_seconds_bucket\{service
   "services": [
     {
       "id": 42,
+      "system_name": "foo",
       "proxy": {
         "policy_chain": [
           {
@@ -369,10 +370,10 @@ qr/total_response_time_seconds(.|\n)*total_response_time_seconds_bucket\{service
 "",
 [
     qr/total_response_time_seconds(.|\n)*/,
-    qr/total_response_time_seconds_bucket\{service="42",le=".*"\} 1/,
+    qr/total_response_time_seconds_bucket\{service_id="42",service_system_name="foo",le=".*"\} 1/,
     qr/upstream_response_time_seconds(.|\n)*/,
-    qr/upstream_response_time_seconds_bucket\{service="42",le=".*"\} 1/,
-    qr/upstream_status\{status="200",service="42"\} 1/
+    qr/upstream_response_time_seconds_bucket\{service_id="42",service_system_name="foo",le=".*"\} 1/,
+    qr/upstream_status\{status="200",service_id="42",service_system_name="foo"\} 1/
 ]
 ]
 --- no_error_log
@@ -386,6 +387,7 @@ qr/total_response_time_seconds(.|\n)*total_response_time_seconds_bucket\{service
   "services": [
     {
       "id": 42,
+      "system_name": "foo",
       "proxy": {
         "hosts": [
           "one"
@@ -407,6 +409,7 @@ qr/total_response_time_seconds(.|\n)*total_response_time_seconds_bucket\{service
     },
     {
       "id": 21,
+      "system_name": "bar",
       "proxy": {
         "hosts": [
           "two"
@@ -451,13 +454,12 @@ qr/total_response_time_seconds(.|\n)*total_response_time_seconds_bucket\{service
 "",
 "",
 [
-qr/total_response_time_seconds_bucket\{service="42",le=".*"\} 1/,
-qr/upstream_response_time_seconds_bucket\{service="42",le=".*"\} 1/,
-qr/upstream_status\{status="200",service="42"\} 1/,
-qr/total_response_time_seconds_bucket\{service="21",le=".*"\} 1/,
-qr/upstream_response_time_seconds_bucket\{service="21",le=".*"\} 1/,
-qr/upstream_status\{status="200",service="21"\} 1/
+qr/total_response_time_seconds_bucket\{service_id="42",service_system_name="foo",le=".*"\} 1/,
+qr/upstream_response_time_seconds_bucket\{service_id="42",service_system_name="foo",le=".*"\} 1/,
+qr/upstream_status\{status="200",service_id="42",service_system_name="foo"\} 1/,
+qr/total_response_time_seconds_bucket\{service_id="21",service_system_name="bar",le=".*"\} 1/,
+qr/upstream_response_time_seconds_bucket\{service_id="21",service_system_name="bar",le=".*"\} 1/,
+qr/upstream_status\{status="200",service_id="21",service_system_name="bar"\} 1/
 ]]
 --- no_error_log
 [error]
-

--- a/t/prometheus-metrics.t
+++ b/t/prometheus-metrics.t
@@ -1,6 +1,46 @@
 use lib 't';
 use Test::APIcast::Blackbox 'no_plan';
 
+# This response body helper function check is like a response_body_like but it
+# can be used with multiple values for a single request. 
+
+# The reason to make this helper function is to make sure that multiple regexp
+# can be used with the same body to validate that everything is working as
+# expected.
+#
+# An usage example can be like this:
+# --- expected_response_body_like_multiple eval
+# [
+# qr/.*/,
+# qr/[0-9]*/,
+# [
+#     qr/^a.*/,
+#     qr/Z$/
+# ]]
+#
+# Where the third request will validate that starts with a and finish with Z. 
+add_response_body_check(sub {
+    my ($block, $body, $req_idx, $repeated_req_idx, $dry_run) = @_;
+
+    if (!$block->expected_response_body_like_multiple) {
+        return "";
+    }
+
+    my @asserts = @{$block->{expected_response_body_like_multiple}};
+    my $assertValues = ${asserts}[0][$req_idx];
+    if (ref(${assertValues}) eq 'ARRAY') {
+        foreach my $regexp(@{$assertValues}){
+            if (!($body =~ m/$regexp/)) {
+                fail(sprintf("Regular expression: '%s' does not match with the body: \n %s",$regexp, $body));
+            }
+        }
+    }else{
+        if (!($body =~ m/$assertValues/)) {
+            fail(sprintf("Regular expression: '%s' does not match with the body: \n %s",$assertValues, $body));
+        }
+    }
+});
+
 # The output varies between requests, so run only once
 repeat_each(1);
 
@@ -228,11 +268,14 @@ In particular, it shows the status codes and the response times
 ["", "Host: metrics"]
 --- error_code eval
 [ 200, 200 ]
---- response_body_like eval
+--- expected_response_body_like_multiple eval
 [
 "",
-qr/upstream_response_time_seconds(.|\n)*upstream_response_time_seconds_bucket\{le=".*"\} 1(.|\n)*upstream_status\{status="200"\} 1/
-]
+[
+    qr/upstream_response_time_seconds(.|\n)/,
+    qr/upstream_response_time_seconds_bucket\{service="",le=".*"\} 1/,
+    qr/upstream_status\{status="200",service=""\} 1/
+]]
 --- no_error_log
 [error]
 
@@ -275,7 +318,146 @@ qr/upstream_response_time_seconds(.|\n)*upstream_response_time_seconds_bucket\{l
 --- response_body_like eval
 [
 "",
-qr/total_response_time_seconds(.|\n)*total_response_time_seconds_bucket\{le=".*"\} 1/
+qr/total_response_time_seconds(.|\n)*total_response_time_seconds_bucket\{service="",le=".*"\} 1/
 ]
 --- no_error_log
 [error]
+
+
+
+=== TEST 6: extended metrics show services id
+--- env eval
+("APICAST_EXTENDED_METRICS", "true")
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.upstream",
+            "configuration": {
+              "rules": [
+                {
+                  "regex": "/",
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.exit(200);
+     }
+  }
+
+--- request eval
+["GET /", "GET /metrics"]
+--- more_headers eval
+["", "Host: metrics"]
+--- error_code eval
+[ 200, 200 ]
+--- expected_response_body_like_multiple eval
+[
+"",
+[
+    qr/total_response_time_seconds(.|\n)*/,
+    qr/total_response_time_seconds_bucket\{service="42",le=".*"\} 1/,
+    qr/upstream_response_time_seconds(.|\n)*/,
+    qr/upstream_response_time_seconds_bucket\{service="42",le=".*"\} 1/,
+    qr/upstream_status\{status="200",service="42"\} 1/
+]
+]
+--- no_error_log
+[error]
+
+=== TEST 7: extended metrics with multiple services
+--- env eval
+("APICAST_EXTENDED_METRICS", "true")
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "hosts": [
+          "one"
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.upstream",
+            "configuration": {
+              "rules": [
+                {
+                  "regex": "/",
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": 21,
+      "proxy": {
+        "hosts": [
+          "two"
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.upstream",
+            "configuration": {
+              "rules": [
+                {
+                  "regex": "/",
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT/two"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.exit(200);
+     }
+  }
+
+  location /two {
+     content_by_lua_block {
+       ngx.exit(200);
+     }
+  }
+--- request eval
+["GET /", "GET /two", "GET /metrics"]
+--- more_headers eval
+["Host: one", "Host: two", "Host: metrics"]
+--- error_code eval
+[ 200, 200, 200 ]
+--- expected_response_body_like_multiple eval
+[
+"",
+"",
+[
+qr/total_response_time_seconds_bucket\{service="42",le=".*"\} 1/,
+qr/upstream_response_time_seconds_bucket\{service="42",le=".*"\} 1/,
+qr/upstream_status\{status="200",service="42"\} 1/,
+qr/total_response_time_seconds_bucket\{service="21",le=".*"\} 1/,
+qr/upstream_response_time_seconds_bucket\{service="21",le=".*"\} 1/,
+qr/upstream_status\{status="200",service="21"\} 1/
+]]
+--- no_error_log
+[error]
+


### PR DESCRIPTION
This commits adds support to have additional information on some metrics[0],
this commit enables users to know the service affected by the metric. 

Due to this can be a problematic for Prometheus[1], to enable this a new ENV
variable(`APICAST_EXTENDED_METRICS`) is defined, so if users that have a few services
they can run the extended metrics without affecting Prometheus stability, if
they thousands of services the recommendation is to have this option disabled. 

In case of the extended_metrics is disabled, all the service labels will use
"all" value and Prometheus performance will not be affected.

The new metrics list looks like this:

```
bash-4.2$ curl http://localhost:9421/metrics -s | grep service
total_response_time_seconds_bucket{service="all",le="00.100"} 91
total_response_time_seconds_bucket{service="all",le="00.200"} 189
total_response_time_seconds_bucket{service="all",le="00.300"} 220
total_response_time_seconds_bucket{service="all",le="00.400"} 220
total_response_time_seconds_bucket{service="all",le="00.500"} 222
total_response_time_seconds_bucket{service="all",le="00.750"} 223
total_response_time_seconds_bucket{service="all",le="01.000"} 223
total_response_time_seconds_bucket{service="all",le="01.500"} 224
total_response_time_seconds_bucket{service="all",le="02.000"} 224
total_response_time_seconds_bucket{service="all",le="03.000"} 224
total_response_time_seconds_bucket{service="all",le="04.000"} 224
total_response_time_seconds_bucket{service="all",le="05.000"} 224
total_response_time_seconds_bucket{service="all",le="10.000"} 224
total_response_time_seconds_bucket{service="all",le="+Inf"} 224
total_response_time_seconds_count{service="all"} 224
total_response_time_seconds_sum{service="all"} 33.616
upstream_response_time_seconds_bucket{service="all",le="00.100"} 93
upstream_response_time_seconds_bucket{service="all",le="00.200"} 190
upstream_response_time_seconds_bucket{service="all",le="00.300"} 220
upstream_response_time_seconds_bucket{service="all",le="00.400"} 220
upstream_response_time_seconds_bucket{service="all",le="00.500"} 223
upstream_response_time_seconds_bucket{service="all",le="00.750"} 224
upstream_response_time_seconds_bucket{service="all",le="01.000"} 224
upstream_response_time_seconds_bucket{service="all",le="01.500"} 224
upstream_response_time_seconds_bucket{service="all",le="02.000"} 224
upstream_response_time_seconds_bucket{service="all",le="03.000"} 224
upstream_response_time_seconds_bucket{service="all",le="04.000"} 224
upstream_response_time_seconds_bucket{service="all",le="05.000"} 224
upstream_response_time_seconds_bucket{service="all",le="10.000"} 224
upstream_response_time_seconds_bucket{service="all",le="+Inf"} 224
upstream_response_time_seconds_count{service="all"} 224
upstream_response_time_seconds_sum{service="all"} 32.226
upstream_status{status="200",service="all"} 224
```

[0] List of affected metrics:
    total_response_time_seconds
    upstream_response_time_seconds
    upstream_status

[1] https://prometheus.io/docs/practices/naming/#labels
