### PR TITLE
[standalone] support for defining upstreams

### DIFF
--- a/gateway/config/standalone.lua
+++ b/gateway/config/standalone.lua
@@ -19,7 +19,12 @@ local standalone = assert(PolicyChain.load_policy(
         { url = to_url(context.configuration) }))
 
 if arg then -- running CLI to generate nginx config
-    local config = standalone:load_configuration() or {}
+    local config, err = standalone:load_configuration() or {}
+
+    if err then
+        print(err)
+        os.exit(1)
+    end
 
     return linked_list.readonly({
         template = 'http.d/standalone.conf.liquid',

--- a/gateway/config/standalone.lua
+++ b/gateway/config/standalone.lua
@@ -1,5 +1,6 @@
 local PolicyChain = require('apicast.policy_chain')
 local resty_url = require('resty.url')
+local linked_list = require('apicast.linked_list')
 local format = string.format
 
 local function to_url(uri)
@@ -18,11 +19,13 @@ local standalone = assert(PolicyChain.load_policy(
         { url = to_url(context.configuration) }))
 
 if arg then -- running CLI to generate nginx config
-    return {
+    local config = standalone:load_configuration() or {}
+
+    return linked_list.readonly({
         template = 'http.d/standalone.conf.liquid',
-        standalone = standalone:load_configuration(),
+        standalone = config,
         configuration = standalone.url,
-    }
+    }, config.global)
 
 else -- booting APIcast
     return {

--- a/gateway/config/standalone.lua
+++ b/gateway/config/standalone.lua
@@ -19,12 +19,7 @@ local standalone = assert(PolicyChain.load_policy(
         { url = to_url(context.configuration) }))
 
 if arg then -- running CLI to generate nginx config
-    local config, err = standalone:load_configuration() or {}
-
-    if err then
-        print(err)
-        os.exit(1)
-    end
+    local config = standalone:load_configuration() or {}
 
     return linked_list.readonly({
         template = 'http.d/standalone.conf.liquid',

--- a/gateway/cpanfile
+++ b/gateway/cpanfile
@@ -1,6 +1,9 @@
-requires 'Test::APIcast', '0.19';
+requires 'Test::APIcast', '0.22';
 requires 'Crypt::JWT';
 requires 'Test::Deep';
 requires 'TAP::Harness::JUnit';
 requires 'File::Slurp';
 requires 'JSON';
+requires 'URI::data';
+requires 'Data::Inspect';
+requires 'YAML';

--- a/gateway/cpanfile.snapshot
+++ b/gateway/cpanfile.snapshot
@@ -7,46 +7,6 @@ DISTRIBUTIONS
       Algorithm::Diff::_impl 1.1903
     requirements:
       ExtUtils::MakeMaker 0
-  CPAN-Meta-2.150010
-    pathname: D/DA/DAGOLDEN/CPAN-Meta-2.150010.tar.gz
-    provides:
-      CPAN::Meta 2.150010
-      CPAN::Meta::Converter 2.150010
-      CPAN::Meta::Feature 2.150010
-      CPAN::Meta::History 2.150010
-      CPAN::Meta::Merge 2.150010
-      CPAN::Meta::Prereqs 2.150010
-      CPAN::Meta::Spec 2.150010
-      CPAN::Meta::Validator 2.150010
-      Parse::CPAN::Meta 2.150010
-    requirements:
-      CPAN::Meta::Requirements 2.121
-      CPAN::Meta::YAML 0.011
-      Carp 0
-      Encode 0
-      Exporter 0
-      ExtUtils::MakeMaker 6.17
-      File::Spec 0.80
-      JSON::PP 2.27300
-      Scalar::Util 0
-      perl 5.008001
-      strict 0
-      version 0.88
-      warnings 0
-  CPAN-Meta-YAML-0.018
-    pathname: D/DA/DAGOLDEN/CPAN-Meta-YAML-0.018.tar.gz
-    provides:
-      CPAN::Meta::YAML 0.018
-    requirements:
-      B 0
-      Carp 0
-      Exporter 0
-      ExtUtils::MakeMaker 6.17
-      Fcntl 0
-      Scalar::Util 0
-      perl 5.008001
-      strict 0
-      warnings 0
   Cpanel-JSON-XS-4.02
     pathname: R/RU/RURBAN/Cpanel-JSON-XS-4.02.tar.gz
     provides:
@@ -363,16 +323,6 @@ DISTRIBUTIONS
       JSON::PP 2.27300
       Scalar::Util 0
       perl 5.006
-  JSON-PP-2.97001
-    pathname: I/IS/ISHIGAKI/JSON-PP-2.97001.tar.gz
-    provides:
-      JSON::PP 2.97001
-      JSON::PP::Boolean 2.97001
-      JSON::PP::IncrParser 2.97001
-    requirements:
-      ExtUtils::MakeMaker 0
-      Scalar::Util 1.08
-      Test::More 0
   LWP-MediaTypes-6.02
     pathname: G/GA/GAAS/LWP-MediaTypes-6.02.tar.gz
     provides:
@@ -495,10 +445,10 @@ DISTRIBUTIONS
       Test::More 0
       Time::HiRes 0
       XML::Simple 0
-  Test-APIcast-0.19
-    pathname: M/MC/MCICHRA/Test-APIcast-0.19.tar.gz
+  Test-APIcast-0.22
+    pathname: M/MC/MCICHRA/Test-APIcast-0.22.tar.gz
     provides:
-      Test::APIcast 0.19
+      Test::APIcast 0.22
       Test::APIcast::Blackbox undef
     requirements:
       File::Slurp 0
@@ -579,60 +529,6 @@ DISTRIBUTIONS
       List::Util 1.09
       Scalar::Util 1.09
       Test::Builder 0
-  Test-Harness-3.42
-    pathname: L/LE/LEONT/Test-Harness-3.42.tar.gz
-    provides:
-      App::Prove 3.42
-      App::Prove::State 3.42
-      App::Prove::State::Result 3.42
-      App::Prove::State::Result::Test 3.42
-      Harness::Hook undef
-      TAP::Base 3.42
-      TAP::Formatter::Base 3.42
-      TAP::Formatter::Color 3.42
-      TAP::Formatter::Console 3.42
-      TAP::Formatter::Console::ParallelSession 3.42
-      TAP::Formatter::Console::Session 3.42
-      TAP::Formatter::File 3.42
-      TAP::Formatter::File::Session 3.42
-      TAP::Formatter::Session 3.42
-      TAP::Harness 3.42
-      TAP::Harness::Env 3.42
-      TAP::Object 3.42
-      TAP::Parser 3.42
-      TAP::Parser::Aggregator 3.42
-      TAP::Parser::Grammar 3.42
-      TAP::Parser::Iterator 3.42
-      TAP::Parser::Iterator::Array 3.42
-      TAP::Parser::Iterator::Process 3.42
-      TAP::Parser::Iterator::Stream 3.42
-      TAP::Parser::IteratorFactory 3.42
-      TAP::Parser::Multiplexer 3.42
-      TAP::Parser::Result 3.42
-      TAP::Parser::Result::Bailout 3.42
-      TAP::Parser::Result::Comment 3.42
-      TAP::Parser::Result::Plan 3.42
-      TAP::Parser::Result::Pragma 3.42
-      TAP::Parser::Result::Test 3.42
-      TAP::Parser::Result::Unknown 3.42
-      TAP::Parser::Result::Version 3.42
-      TAP::Parser::Result::YAML 3.42
-      TAP::Parser::ResultFactory 3.42
-      TAP::Parser::Scheduler 3.42
-      TAP::Parser::Scheduler::Job 3.42
-      TAP::Parser::Scheduler::Spinner 3.42
-      TAP::Parser::Source 3.42
-      TAP::Parser::SourceHandler 3.42
-      TAP::Parser::SourceHandler::Executable 3.42
-      TAP::Parser::SourceHandler::File 3.42
-      TAP::Parser::SourceHandler::Handle 3.42
-      TAP::Parser::SourceHandler::Perl 3.42
-      TAP::Parser::SourceHandler::RawTAP 3.42
-      TAP::Parser::YAMLish::Reader 3.42
-      TAP::Parser::YAMLish::Writer 3.42
-      Test::Harness 3.42
-    requirements:
-      ExtUtils::MakeMaker 0
   Test-LongString-0.17
     pathname: R/RG/RGARCIA/Test-LongString-0.17.tar.gz
     provides:
@@ -847,13 +743,34 @@ DISTRIBUTIONS
       XML::SAX 0.15
       XML::SAX::Expat 0
       perl 5.008
-  XSLoader-0.24
-    pathname: S/SA/SAPER/XSLoader-0.24.tar.gz
+  YAML-1.29
+    pathname: T/TI/TINITA/YAML-1.29.tar.gz
     provides:
-      XSLoader 0.24
+      YAML 1.29
+      YAML::Any 1.29
+      YAML::Dumper undef
+      YAML::Dumper::Base undef
+      YAML::Error undef
+      YAML::Loader undef
+      YAML::Loader::Base undef
+      YAML::Marshall undef
+      YAML::Mo undef
+      YAML::Node undef
+      YAML::Tag undef
+      YAML::Type::blessed undef
+      YAML::Type::code undef
+      YAML::Type::glob undef
+      YAML::Type::ref undef
+      YAML::Type::regexp undef
+      YAML::Type::undef undef
+      YAML::Types undef
+      YAML::Warning undef
+      yaml_mapping undef
+      yaml_scalar undef
+      yaml_sequence undef
     requirements:
       ExtUtils::MakeMaker 0
-      Test::More 0.47
+      perl 5.008001
   libwww-perl-6.33
     pathname: O/OA/OALDERS/libwww-perl-6.33.tar.gz
     provides:

--- a/gateway/http.d/standalone.conf.liquid
+++ b/gateway/http.d/standalone.conf.liquid
@@ -27,6 +27,7 @@ server {
     server_name {{ server_name }};
 
     set $ctx_ref -1;
+    set $proxy_pass '';
 
     location / {
         rewrite_by_lua_block {
@@ -50,7 +51,27 @@ server {
       content_by_lua_block { require('apicast.executor'):post_action() }
       log_by_lua_block { require('apicast.executor'):log() }
     }
+
+    location @upstream {
+      internal;
+
+      rewrite_by_lua_block {
+        require('resty.ctx').apply()
+      }
+
+      proxy_pass $proxy_pass;
+
+      proxy_http_version 1.1;
+      proxy_set_header Host $http_host;
+      proxy_set_header Connection "";
+
+      # these are duplicated so when request is redirected here those phases are executed
+      post_action @post_action;
+      body_filter_by_lua_block { require('apicast.executor'):body_filter() }
+      header_filter_by_lua_block { require('apicast.executor'):header_filter() }
+    }
 }
+
 {% endfor %}
 
 {% for upstream in standalone.external %}

--- a/gateway/http.d/standalone.conf.liquid
+++ b/gateway/http.d/standalone.conf.liquid
@@ -1,5 +1,7 @@
 {% for server in standalone.server.listen %}
 server {
+    access_log {{ server.access_log | default: access_log | default: 'stdout' }};
+
     listen {{ server.port }} default_server
     {%- if server.tls %} ssl {% endif -%}
     {%- case server.protocol -%}

--- a/gateway/src/apicast/policy/standalone/configuration.lua
+++ b/gateway/src/apicast/policy/standalone/configuration.lua
@@ -92,7 +92,13 @@ do
         local load = loaders[url.scheme]
         if not load then return nil, 'cannot load scheme' end
 
-        return setmetatable(load(url), config_mt)
+        local t, err = load(url)
+
+        if t then
+            return setmetatable(t, config_mt)
+        else
+            return t, err
+        end
     end
 end
 

--- a/gateway/src/apicast/policy/standalone/configuration.lua
+++ b/gateway/src/apicast/policy/standalone/configuration.lua
@@ -31,7 +31,7 @@ do
     local path = require('pl.path')
     local file = require('pl.file')
 
-    local YAML = require('lyaml')
+    local YAML = require('resty.yaml')
     local cjson = require('cjson')
 
     local decoders = {

--- a/gateway/src/apicast/policy/standalone/configuration.lua
+++ b/gateway/src/apicast/policy/standalone/configuration.lua
@@ -9,7 +9,7 @@ local mt = { __index = _M }
 
 local allowed_schemes = {
     file = true,
-    -- TODO: support Data URI
+    data = true,
 }
 
 
@@ -28,11 +28,13 @@ end
 do
     local loaders = { }
     local pcall = pcall
+    local tostring = tostring
     local path = require('pl.path')
     local file = require('pl.file')
 
     local YAML = require('resty.yaml')
     local cjson = require('cjson')
+    local data_url = require('apicast.configuration_loader.data_url')
 
     local decoders = {
         ['.yml'] = YAML.load,
@@ -66,6 +68,10 @@ do
         else
             return nil, 'no such file'
         end
+    end
+
+    function loaders.data(uri)
+        return data_url.parse(tostring(uri))
     end
 
     function _M:load()

--- a/gateway/src/apicast/policy/standalone/standalone.lua
+++ b/gateway/src/apicast/policy/standalone/standalone.lua
@@ -274,7 +274,7 @@ function _M:load_configuration()
     self.services = setmetatable(build_services(configuration), { __index = default.services })
     self.upstreams = build_upstreams(configuration)
 
-    ngx.log(ngx.NOTICE, 'loaded standalone configuration from: ', url)
+    ngx.log(ngx.DEBUG, 'loaded standalone configuration from: ', url, ' ', configuration)
     return configuration
   else
     ngx.log(ngx.WARN, 'failed to load ', url, ' err: ', err)

--- a/gateway/src/apicast/policy/standalone/standalone.lua
+++ b/gateway/src/apicast/policy/standalone/standalone.lua
@@ -190,12 +190,21 @@ end
 
 do
   local Service_mt = { __index = Service }
+  local null = ngx.null
+
+  local function policy_configuration(policy)
+    local config = policy.configuration
+
+    if config and config ~= null then
+      return config
+    end
+  end
 
   local function build_policy_chain(policies)
     local chain = PolicyChain.new()
 
     for i=1, #policies do
-      chain:add_policy(policies[i].policy, policies[i].version, policies[i].configuration)
+      chain:add_policy(policies[i].policy, policies[i].version, policy_configuration(policies[i]))
     end
 
     return chain

--- a/gateway/src/resty/yaml.lua
+++ b/gateway/src/resty/yaml.lua
@@ -1,0 +1,13 @@
+local yaml = require('lyaml.functional')
+
+yaml.NULL = ngx.null
+yaml.isnull = function(value) return value == ngx.null end
+
+local YAML = require('lyaml')
+
+local _M = {
+  load = YAML.load,
+  null = YAML.null,
+}
+
+return _M

--- a/spec/policy/standalone/configuration_spec.lua
+++ b/spec/policy/standalone/configuration_spec.lua
@@ -25,7 +25,7 @@ describe('Standalone Configuration', function()
         end
 
         it('loads valid .yml file', function()
-            assert.same({ global = {} }, load('valid.yml'))
+            assert.same({ global = ngx.null }, load('valid.yml'))
         end)
 
         it('loads valid .json file', function()

--- a/spec/policy/standalone/configuration_spec.lua
+++ b/spec/policy/standalone/configuration_spec.lua
@@ -6,6 +6,10 @@ describe('Standalone Configuration', function()
             assert(_M.new('file://tmp/conf.toml'))
         end)
 
+        it('accepts data uri', function()
+            assert(_M.new('data:application/json,%7B%7D'))
+        end)
+
         it('does not accept http', function()
             assert.returns_error('scheme not supported', _M.new('http://example.com'))
         end)
@@ -20,28 +24,35 @@ describe('Standalone Configuration', function()
     end)
 
     describe('.load', function()
-        local function load(file)
-            return _M.new(('file://spec/fixtures/standalone/%s'):format(file)):load()
+        local function file(name)
+            return ('file://spec/fixtures/standalone/%s'):format(name)
+        end
+        local function load(uri)
+            return _M.new(uri):load()
         end
 
         it('loads valid .yml file', function()
-            assert.same({ global = ngx.null }, load('valid.yml'))
+            assert.same({ global = ngx.null }, load(file(('valid.yml'))))
         end)
 
         it('loads valid .json file', function()
-            assert.same({ global = {} }, load('valid.json'))
+            assert.same({ global = {} }, load(file('valid.json')))
+        end)
+
+        it('loads valid json data uri', function()
+            assert.same({ global = {}}, assert(load('data:application/json,%7B%22global%22%3A%7B%7D%7D')))
         end)
 
         it('not loads invalid .yml file', function()
-            assert.returns_error('2:5: did not find expected \'-\' indicator', load('invalid.yml'))
+            assert.returns_error('2:5: did not find expected \'-\' indicator', load(file('invalid.yml')))
         end)
 
         it('not loads invalid .json file', function()
-            assert.returns_error('Expected value but found invalid number at character 1', load('invalid.json'))
+            assert.returns_error('Expected value but found invalid number at character 1', load(file('invalid.json')))
         end)
 
         it('not loads invalid .txt file', function()
-            assert.returns_error('unsupported format', load('invalid.txt'))
+            assert.returns_error('unsupported format', load(file('invalid.txt')))
         end)
     end)
 end)

--- a/spec/resty/yaml_spec.lua
+++ b/spec/resty/yaml_spec.lua
@@ -1,0 +1,15 @@
+local _M = require 'resty.yaml'
+
+describe('Resty YAML', function()
+  describe('.load', function()
+    it('loads yaml', function()
+      assert.same({ global = _M.null }, _M.load('global: '))
+    end)
+  end)
+
+  describe('.null', function()
+    it('is ngx.null', function ()
+      assert.equal(ngx.null, _M.null)
+    end)
+  end)
+end)

--- a/t/apicast-policy-standalone.t
+++ b/t/apicast-policy-standalone.t
@@ -14,8 +14,7 @@ server:
   - port: $TEST_NGINX_SERVER_PORT
     name: test
 routes:
-  - name: test
-    match:
+  - match:
       uri_path: /t
       server_port: test
     destination:
@@ -28,6 +27,39 @@ internal:
 GET /t
 --- response_body
 GET /t HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]
+[warn]
+
+
+
+=== TEST 2: standalone can point to external destination
+--- environment_file: standalone
+--- configuration_format: yaml
+--- configuration
+server:
+  listen:
+  - port: $TEST_NGINX_SERVER_PORT
+    name: test
+routes:
+  - match:
+      uri_path: /t
+      server_port: test
+    destination:
+      upstream: test-mock
+external:
+  - name: test-mock
+    server: http://mock:$TEST_NGINX_SERVER_PORT
+--- upstream_name: mock
+--- upstream
+location = /t {
+  echo "test";
+}
+--- request
+GET /t
+--- response_body
+test
 --- error_code: 200
 --- no_error_log
 [error]

--- a/t/apicast-policy-standalone.t
+++ b/t/apicast-policy-standalone.t
@@ -1,6 +1,20 @@
 use lib 't';
 use Test::APIcast::Blackbox 'no_plan';
 
+sub Test::Base::Filter::eval_self {
+    my ($self, $input) = @_;
+    my $block = $self->current_block;
+
+    {
+        my @ARGV = ($block);
+        my @return = CORE::eval($input);
+
+        return $@ if $@;
+        return @return;
+    }
+}
+
+
 run_tests();
 
 __DATA__
@@ -60,6 +74,53 @@ location = /t {
 GET /t
 --- response_body
 test
+--- error_code: 200
+--- no_error_log
+[error]
+[warn]
+
+
+
+=== TEST 3: data-uri encoded yaml configuration
+--- environment_file: standalone
+--- env eval_self
+use URI;
+
+my ($self) = @_;
+my $block = $self->current_block;
+my $format = $block->configuration_format;
+my $configuration = Test::Nginx::Util::expand_env_in_config($block->configuration);
+
+my $u = URI->new("data:");
+$u->media_type("application/$format");
+$u->data(scalar($configuration));
+
+$block->set_value('configuration', '');
+
+(
+  'APICAST_CONFIGURATION' => $u->as_string,
+)
+--- configuration_file:
+--- configuration_format: yaml
+--- configuration env
+server:
+  listen:
+  - port: $TEST_NGINX_SERVER_PORT
+    name: test
+routes:
+  - match:
+      uri_path: /t
+      server_port: test
+    destination:
+      service: echo
+internal:
+  - name: echo
+    policy_chain:
+    - policy: apicast.policy.echo
+--- request
+GET /t
+--- response_body
+GET /t HTTP/1.1
 --- error_code: 200
 --- no_error_log
 [error]

--- a/t/apicast-policy-standalone.t
+++ b/t/apicast-policy-standalone.t
@@ -199,3 +199,20 @@ GET /t HTTP/1.1
 --- no_error_log
 [error]
 [warn]
+
+
+
+=== TEST 6: invalid configuration
+--- environment_file: standalone
+--- SKIP: works on OpenResty 1.15.x
+--- must_die
+--- configuration_format: yaml
+--- configuration
+server:
+    - wrong
+    invalid: true
+--- request
+GET
+--- error_log
+[error]
+did not find expected '-' indicator

--- a/t/apicast-policy-standalone.t
+++ b/t/apicast-policy-standalone.t
@@ -125,3 +125,47 @@ GET /t HTTP/1.1
 --- no_error_log
 [error]
 [warn]
+
+
+
+=== TEST 4: service with policy chain and upstream
+--- environment_file: standalone
+--- configuration_format: yaml
+--- configuration
+server:
+  listen:
+  - port: $TEST_NGINX_SERVER_PORT
+    name: test
+routes:
+  - match:
+      uri_path: /t
+      server_port: test
+    destination:
+      service: cors
+internal:
+  - name: cors
+    upstream: http://test_upstream:$TEST_NGINX_SERVER_PORT
+    policy_chain:
+    - policy: apicast.policy.cors
+--- upstream_name: test_upstream
+--- upstream
+location = /t {
+  echo "test";
+}
+--- request
+GET /t
+--- more_headers
+Origin: http://example.com
+Access-Control-Request-Method: GET
+Access-Control-Request-Headers: Content-Type
+--- response_body
+test
+--- response_headers
+Access-Control-Allow-Headers: Content-Type
+Access-Control-Allow-Methods: GET
+Access-Control-Allow-Origin: http://example.com
+Access-Control-Allow-Credentials: true
+--- error_code: 200
+--- no_error_log
+[error]
+[warn]

--- a/t/apicast-policy-standalone.t
+++ b/t/apicast-policy-standalone.t
@@ -169,3 +169,33 @@ Access-Control-Allow-Credentials: true
 --- no_error_log
 [error]
 [warn]
+
+
+
+=== TEST 5: service with policy chain and null configuration
+--- environment_file: standalone
+--- configuration_format: yaml
+--- configuration
+server:
+  listen:
+  - port: $TEST_NGINX_SERVER_PORT
+    name: test
+routes:
+  - match:
+      uri_path: /t
+      server_port: test
+    destination:
+      service: echo
+internal:
+  - name: echo
+    policy_chain:
+    - policy: apicast.policy.echo
+      configuration:
+--- request
+GET /t
+--- response_body
+GET /t HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]
+[warn]


### PR DESCRIPTION
route can refer to an upstream(external) and directly send a response
there without going through a policy chain

it snowballed a bit into a bunch of fixes for standalone mode

required for https://github.com/3scale/ostia/pull/57

### Example configuration

```json
{
  "global": { "log_level": "debug", "error_log": "stderr", "access_log": "stdout" },
  "server": { "listen": [{ "port": 8080, "name": "default", "protocol": "http" }] },
  "routes": [
    {
      "name": "hello",
      "match": { "server_port": "default", "uri_path": "/hello" },
      "destination": { "upstream": "https://echo-api.3scale.net" }
    }
  ],
  "internal": [ ],
  "external": [
    { "name": "https://echo-api.3scale.net", "server": "https://echo-api.3scale.net" }
  ]
}
```