### PR TITLE
3scale batching policy: fix name in the logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed incorrect connection reuse for requests on different domains [PR #1021](https://github.com/3scale/APIcast/pull/1021), [THREESCALE-2205](https://issues.jboss.org/browse/THREESCALE-2205)
 - `export()` now works correctly in policies of the local chain. It was only working in the `rewrite` phase [PR #1023](https://github.com/3scale/APIcast/pull/1023)
 - The caching policy now works correctly when combined with the 3scale batcher one [PR #1023](https://github.com/3scale/APIcast/pull/1023)
+- Fixed the name of the 3scale batching policy in the logs. Some logs showed "Caching policy" where it should have said "3scale Batcher" [PR #1029](https://github.com/3scale/APIcast/pull/1029)
 
 ### Removed
 

--- a/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
@@ -17,7 +17,7 @@ local ipairs = ipairs
 local default_auths_ttl = 10
 local default_batch_reports_seconds = 10
 
-local _M, mt = policy.new('Caching policy')
+local _M, mt = policy.new('3scale Batcher policy')
 
 local new = _M.new
 


### PR DESCRIPTION
The 3scale batching policy did not appear with the correct name in the logs.