### PR TITLE
[OIDC] Get issuer based on endpoint issuer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The caching policy now works correctly when combined with the 3scale batcher one [PR #1023](https://github.com/3scale/APIcast/pull/1023)
 - Fixed the name of the 3scale batching policy in the logs. Some logs showed "Caching policy" where it should have said "3scale Batcher" [PR #1029](https://github.com/3scale/APIcast/pull/1029)
 - Changed the schema of the IP check policy so it renders correctly in the UI [PR #1026](https://github.com/3scale/APIcast/pull/1026), [THREESCALE-1692](https://issues.jboss.org/browse/THREESCALE-1692)
+- Fixed the OIDC setup for services when it is used with `APICAST_SERVICES_LIST` parameter [PR #1032](https://github.com/3scale/APIcast/pull/1029)
 
 ### Removed
 

--- a/gateway/src/resty/oidc/discovery.lua
+++ b/gateway/src/resty/oidc/discovery.lua
@@ -120,7 +120,7 @@ function _M:call(issuer)
     local config, err = _M.openid_configuration(self, issuer)
     if not config then return nil, err end
 
-    return { config = config, issuer = config.issuer, keys = _M.jwks(self, config) }
+    return { config = config, issuer = config.issuer, endpoint_issuer = issuer, keys = _M.jwks(self, config) }
 end
 
 return _M

--- a/spec/configuration_loader/oidc_spec.lua
+++ b/spec/configuration_loader/oidc_spec.lua
@@ -52,7 +52,7 @@ describe('OIDC Configuration loader', function()
         }
       local oidc = loader.call(cjson.encode(config))
 
-      assert.same([[{"services":[{"id":21,"proxy":{"oidc_issuer_endpoint":"https:\/\/user:pass@example.com"}}],"oidc":[{"issuer":"https:\/\/example.com","config":{"jwks_uri":"http:\/\/example.com\/jwks","issuer":"https:\/\/example.com"},"keys":{}}]}]], oidc)
+      assert.same([[{"services":[{"id":21,"proxy":{"oidc_issuer_endpoint":"https:\/\/user:pass@example.com"}}],"oidc":[{"keys":{},"issuer":"https:\/\/example.com","config":{"jwks_uri":"http:\/\/example.com\/jwks","issuer":"https:\/\/example.com"},"endpoint_issuer":"https:\/\/user:pass@example.com"}]}]], oidc)
     end)
 
     -- This is a regression test. cjson crashed when parsing a config where

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -217,6 +217,7 @@ describe('Configuration Remote Loader V2', function()
           issuer = 'https://idp.example.com/auth/realms/foo',
           jwks_uri = 'https://idp.example.com/auth/realms/foo/jwks'
         },
+        endpoint_issuer = 'http://user:pass@idp.example.com/auth/realms/foo/',
         issuer = 'https://idp.example.com/auth/realms/foo',
         keys = { ['3g-I9PWt6NrznPLcbE4zZrakXar27FDKEpqRPlD2i2Y'] = {
           e = 'AQAB',

--- a/spec/configuration_store_spec.lua
+++ b/spec/configuration_store_spec.lua
@@ -50,6 +50,47 @@ describe('Configuration Store', function()
 
       assert(store:store({services = { service_one, service_two }, oidc = { ngx.null, ngx.null }}))
     end)
+
+    describe("with OIDC", function()
+      local service_one = {
+        id = '7', hosts = { 'example.com' },
+        oidc = {issuer_endpoint= "foo"}}
+      local service_two = {
+        id = '42', hosts = { 'example.com' },
+        oidc = {issuer_endpoint= "bar"}}
+
+      local oidcs = {
+        { issuer = "bar", value="bar"},
+        { issuer = "foo", value="foo"}}
+
+      it('stores config with unsorted services', function()
+        local store = configuration.new()
+        local newConfig = store:store({services = { service_one, service_two }, oidc=oidcs})
+        assert.are.equal(newConfig.services[1].oidc.value, "foo")
+        assert.are.equal(newConfig.services[2].oidc.value, "bar")
+      end)
+
+      it('service does not contain oidc if not issuer_endpoint', function()
+        local store = configuration.new()
+        local service = {id = '42', hosts = { 'example.com' }}
+
+        local newConfig = store:store({services = { service_one, service }, oidc=oidcs})
+        assert.are.equal(newConfig.services[1].oidc.value, "foo")
+        assert.are.equal(newConfig.services[2].oidc, nil)
+      end)
+
+      it('service with invalid issuer_endpoint', function()
+        local store = configuration.new()
+        local service = {
+          id = '42', hosts = { 'example.com' },
+          oidc = {issuer_endpoint= "invalid"}}
+
+        local newConfig = store:store({services = { service_one, service }, oidc=oidcs})
+        assert.are.equal(newConfig.services[1].oidc.value, "foo")
+        assert.are.equal(newConfig.services[2].oidc.value, nil)
+      end)
+
+    end)
   end)
 
   describe('.find_by_id', function()

--- a/t/apicast-oidc.t
+++ b/t/apicast-oidc.t
@@ -139,6 +139,7 @@ to_json({
     }
   }],
   oidc => [{
+    endpoint_issuer => 'https://example.com/auth/realms/apicast',
     keys => { somekid => { pem => $::public_key } },
   }]
 });

--- a/t/apicast-policy-rate-limit.t
+++ b/t/apicast-policy-rate-limit.t
@@ -1033,6 +1033,7 @@ so only the third call returns 429.
       },
       oidc = {
         {
+          endpoint_issuer = 'https://example.com/auth/realms/apicast',
           issuer = 'https://example.com/auth/realms/apicast',
           config = { id_token_signing_alg_values_supported = { 'RS256' } },
           keys = { somekid = { pem = require('fixtures.rsa').pub } },

--- a/t/apicast-policy-token-introspection.t
+++ b/t/apicast-policy-token-introspection.t
@@ -292,6 +292,7 @@ introspection endpoint from the oidc_issuer_endpoint of the service configuratio
 {
   "oidc": [
     {
+      "endpoint_issuer": "http://app:appsec@test_backend:$TEST_NGINX_SERVER_PORT/issuer/endpoint",
       "issuer": "https://example.com/auth/realms/apicast",
       "config": { "id_token_signing_alg_values_supported": [ "RS256" ] },
       "keys": { "somekid": { "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----" } }


### PR DESCRIPTION
At the moment, if you use OIDC setup with `APICAST_SERVICE_LIST` the matching of
the OIDC setup will be not correct, due to services will be filtered and the OIDC
will not be configured correctly due is not using the issuer to find the
oidc configuration.

To replicate this issue the following config can be used and filter the endpoint
42 out and the issuer will not be the correct for the service.

ENV: APICAST_SERVICE_LIST="1"
Config:
```
{
  "services": [
    {
      "backend_authentication_type": "provider_key",
      "backend_authentication_value": "fookey",
      "backend_version": "oauth",
      "id": 42,
      "proxy": {
        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
        "proxy_rules": [
          {
            "pattern": "/",
            "delta": 1,
            "metric_system_name": "hits",
            "http_method": "GET"
          }
        ],
        "api_backend": "http://test:30130/",
        "authentication_method": "oidc"
      }
    },
    {
      "backend_authentication_type": "provider_key",
      "backend_authentication_value": "fookey",
      "backend_version": "oauth",
      "id": 1,
      "proxy": {
        "oidc_issuer_endpoint": "https://example.com/auth/realms/second",
        "proxy_rules": [
          {
            "pattern": "/",
            "delta": 1,
            "metric_system_name": "hits",
            "http_method": "GET"
          }
        ],
        "api_backend": "http://test:30130/",
        "authentication_method": "oidc"
      }
    }
  ],
  "oidc": [
    {
      "keys": {
        "somekid": {
          "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----\n"
        }
      },
      "config": {
        "id_token_signing_alg_values_supported": [
          "RS256"
        ]
      },
      "issuer": "https://example.com/auth/realms/apicast"
    },
    {
      "keys": {
        "somekid": {
          "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----\n"
        }
      },
      "config": {
        "id_token_signing_alg_values_supported": [
          "RS256"
        ]
      },
      "issuer": "https://example.com/auth/realms/second"
    }
  ]
}
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>