### PR TITLE
[THREESCALE-2264] Obtain JWT client_id from different claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - "Upstream Connection" policy. It allows to configure several options for the connections to the upstream [PR #1025](https://github.com/3scale/APIcast/pull/1025), [THREESCALE-2166](https://issues.jboss.org/browse/THREESCALE-2166)
 - Enable APICAST_EXTENDED_METRICS env variable to provide more in-depth details [PR #1024](https://github.com/3scale/APIcast/pull/1024) [THREESCALE-2150](https://issues.jboss.org/browse/THREESCALE-2150)
 - Enable APICAST_EXTENDED_METRICS environment variable to provide additional details [PR #1024](https://github.com/3scale/APIcast/pull/1024) [THREESCALE-2150](https://issues.jboss.org/browse/THREESCALE-2150)
+- Add the option to obtain client_id from any JWT claim [THREESCALE-2264](https://issues.jboss.org/browse/THREESCALE-2264) [PR #1034](https://github.com/3scale/APIcast/pull/1034)
+
 
 ### Fixed
 

--- a/gateway/src/apicast/configuration.lua
+++ b/gateway/src/apicast/configuration.lua
@@ -115,6 +115,7 @@ function _M.parse_service(service)
       backend = backend,
       oidc = {
         issuer_endpoint = value(proxy.oidc_issuer_endpoint),
+        client_id = value(proxy.oidc_client_id),
       },
       credentials = {
         location = proxy.credentials_location or 'query',

--- a/gateway/src/apicast/configuration.lua
+++ b/gateway/src/apicast/configuration.lua
@@ -115,7 +115,8 @@ function _M.parse_service(service)
       backend = backend,
       oidc = {
         issuer_endpoint = value(proxy.oidc_issuer_endpoint),
-        client_id = value(proxy.oidc_client_id),
+        claim_with_client_id = value(proxy.jwt_claim_with_client_id),
+        claim_with_client_id_type = proxy.jwt_claim_with_client_id_type or "plain",
       },
       credentials = {
         location = proxy.credentials_location or 'query',

--- a/gateway/src/apicast/oauth/oidc.lua
+++ b/gateway/src/apicast/oauth/oidc.lua
@@ -16,6 +16,8 @@ local _M = {
   cache_size = 10000,
 }
 
+local default_claim_with_app_id =  "azp"
+
 function _M.reset()
   _M.cache = lrucache.new(_M.cache_size)
 end
@@ -31,19 +33,22 @@ local mt = {
 
 local empty = {}
 
-function _M.new(oidc_config, service)
+function _M.new(oidc_config)
   local oidc = oidc_config or empty
   local issuer = oidc.issuer
   local config = oidc.config or empty
   local alg_values = config.id_token_signing_alg_values_supported or empty
-  local tmpl, tmpl_err
+
+  local client_id_tmpl, client_id_tmpl_err, client_id_tmpl_type
   local err
 
-  if  oidc_config and oidc_config.client_id then
-     tmpl, tmpl_err = TemplateString.new(oidc_config.client_id, "liquid")
-    if tmpl_err then
+  if oidc.claim_with_client_id then
+    client_id_tmpl_type = oidc.claim_with_client_id_type
+    client_id_tmpl, client_id_tmpl_err = TemplateString.new(oidc.claim_with_client_id, client_id_tmpl_type)
+    if client_id_tmpl_err then
       err = 'Invalid client_id template string'
     end
+
   end
 
   if not issuer or #alg_values == 0 then
@@ -53,8 +58,8 @@ function _M.new(oidc_config, service)
   return setmetatable({
     config = config,
     issuer = issuer,
-    service = service,
-    tmpl = tmpl,
+    client_id_tmpl = client_id_tmpl,
+    client_id_tmpl_type = client_id_tmpl_type,
     keys = oidc.keys or empty,
     clock = ngx_now,
     alg_whitelist = util.to_hash(alg_values),
@@ -205,11 +210,7 @@ function _M:transform_credentials(credentials, cache_key)
   end
 
   local payload = jwt_obj.payload
-  local app_id = payload.azp
-
-  if self.tmpl then
-      app_id = self.tmpl:render(payload)
-  end
+  local app_id = self:get_client_id(payload)
 
   local ttl = timestamp_to_seconds_from_now(payload.exp)
 
@@ -224,6 +225,17 @@ function _M:transform_credentials(credentials, cache_key)
   return { app_id = app_id }, ttl, payload
 end
 
+function _M:get_client_id(jwt_payload)
+  if self.client_id_tmpl and self.client_id_tmpl_type == "liquid" then
+      return self.client_id_tmpl:render(jwt_payload)
+  end
+
+  if self.client_id_tmpl and self.client_id_tmpl_type == "plain" then
+    return jwt_payload[self.client_id_tmpl:render()]
+  end
+
+  return jwt_payload[default_claim_with_app_id]
+end
 
 
 return _M

--- a/spec/oauth/oidc_spec.lua
+++ b/spec/oauth/oidc_spec.lua
@@ -4,6 +4,7 @@ local jwt_validators = require('resty.jwt-validators')
 local jwt = require('resty.jwt')
 
 local rsa = require('fixtures.rsa')
+local ngx_variable = require('apicast.policy.ngx_variable')
 
 describe('OIDC', function()
 
@@ -153,7 +154,7 @@ describe('OIDC', function()
     end)
 
     it('verifies exp', function()
-      local oidc = _M.new(oidc_config)
+      local oidc = _M.new(oidc_config, {})
       local access_token = jwt:sign(rsa.private, {
         header = { typ = 'JWT', alg = 'RS256', kid = 'somekid' },
         payload = {
@@ -227,6 +228,71 @@ describe('OIDC', function()
       local credentials, _, _, err = oidc:transform_credentials({ access_token = access_token })
       assert(credentials, err)
     end)
+
+    describe('getting client_id from any JWT claim', function()
+
+      before_each(function()
+        stub(ngx_variable, 'available_context', function(context) return context end)
+      end)
+
+      it('use liquid template to modify app_id', function()
+
+        local oidc_config = {
+          issuer = 'https://example.com/auth/realms/apicast',
+          config = { id_token_signing_alg_values_supported = { 'RS256' } },
+          keys = { somekid = { pem = rsa.pub } },
+          client_id = "{{aud}}"}
+        local oidc = _M.new(oidc_config)
+
+        local access_token = jwt:sign(rsa.private, {
+          header = { typ = 'JWT', alg = 'RS256', kid = 'somekid' },
+          payload = {
+            iss = oidc_config.issuer,
+            aud = 'foo',
+            azp = 'ce3b2e5e',
+            sub = 'someone',
+            exp = ngx.now() + 10,
+          },
+        })
+
+        local credentials, ttl, _, err = oidc:transform_credentials({ access_token = access_token })
+
+        assert(credentials, err)
+
+        assert.same({ app_id  = "foo" }, credentials)
+        assert.equal(10, ttl)
+      end)
+
+      it('use liquid template functions to modify app_id', function()
+
+        local oidc_config = {
+          issuer = 'https://example.com/auth/realms/apicast',
+          config = { id_token_signing_alg_values_supported = { 'RS256' } },
+          keys = { somekid = { pem = rsa.pub } },
+          client_id = "{{ custom | first}}"}
+        local oidc = _M.new(oidc_config)
+        local access_token = jwt:sign(rsa.private, {
+          header = { typ = 'JWT', alg = 'RS256', kid = 'somekid' },
+          payload = {
+            iss = oidc_config.issuer,
+            aud = 'notused',
+            azp = 'ce3b2e5e',
+            sub = 'someone',
+            custom = {"foo", "bar"},
+            exp = ngx.now() + 10,
+          },
+        })
+
+        local credentials, ttl, _, err = oidc:transform_credentials({ access_token = access_token })
+
+        assert(credentials, err)
+
+        assert.same({ app_id  = "foo" }, credentials)
+        assert.equal(10, ttl)
+      end)
+
+    end)
+
   end)
 
 end)

--- a/t/apicast-oidc.t
+++ b/t/apicast-oidc.t
@@ -224,7 +224,8 @@ to_json({
     proxy => {
         authentication_method => 'oidc',
         oidc_issuer_endpoint => 'https://example.com/auth/realms/apicast',
-        oidc_client_id => '{{ foo }}',
+        jwt_claim_with_client_id => '{{ foo }}',
+        jwt_claim_with_client_id_type=> 'liquid',
         api_backend => "http://test:$TEST_NGINX_SERVER_PORT/",
         proxy_rules => [
           { pattern => '/', http_method => 'GET', metric_system_name => 'hits', delta => 1  }

--- a/t/apicast-oidc.t
+++ b/t/apicast-oidc.t
@@ -210,3 +210,55 @@ my $jwt = encode_jwt(payload => {
 "Authorization: Bearer $jwt"
 --- no_error_log
 [error]
+
+=== TEST 5: Use different claim for app_id
+--- configuration env eval
+use JSON qw(to_json);
+
+to_json({
+  services => [{
+    id => 42,
+    backend_version => 'oauth',
+    backend_authentication_type => 'provider_key',
+    backend_authentication_value => 'fookey',
+    proxy => {
+        authentication_method => 'oidc',
+        oidc_issuer_endpoint => 'https://example.com/auth/realms/apicast',
+        oidc_client_id => '{{ foo }}',
+        api_backend => "http://test:$TEST_NGINX_SERVER_PORT/",
+        proxy_rules => [
+          { pattern => '/', http_method => 'GET', metric_system_name => 'hits', delta => 1  }
+        ]
+    }
+  }],
+  oidc => [{
+    issuer => 'https://example.com/auth/realms/apicast',
+    config => { id_token_signing_alg_values_supported => [ 'RS256' ] },
+    keys => { somekid => { pem => $::public_key } },
+  }]
+});
+--- upstream
+  location /test {
+    echo "yes";
+  }
+--- backend
+  location = /transactions/oauth_authrep.xml {
+    content_by_lua_block {
+      local expected = "provider_key=fookey&service_id=42&usage%5Bhits%5D=1&app_id=fooid"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- request: GET /test
+--- error_code: 200
+--- more_headers eval
+use Crypt::JWT qw(encode_jwt);
+my $jwt = encode_jwt(payload => {
+  aud => 'something',
+  azp => 'appid',
+  sub => 'someone',
+  foo => 'fooid',
+  iss => 'https://example.com/auth/realms/apicast',
+  exp => time + 3600 }, key => \$::private_key, alg => 'RS256', extra_headers => { kid => 'somekid' });
+"Authorization: Bearer $jwt"
+--- no_error_log
+[error]


### PR DESCRIPTION
This commit adds the option to obtain the client_id from a different claim and
does not use the AZP claim if the identity provider does not need that. This
commit adds a new option `oidc_client_id` that can be used as a liquid template
to retrieve any claim from the JWT payload.

Fixes #1008
Fixes THREESCALE-2264

