### PR TITLE
[THREESCALE-1150] Add option to use only path-based routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Enable APICAST_EXTENDED_METRICS environment variable to provide additional details [PR #1024](https://github.com/3scale/APIcast/pull/1024) [THREESCALE-2150](https://issues.jboss.org/browse/THREESCALE-2150)
 - Add the option to obtain client_id from any JWT claim [THREESCALE-2264](https://issues.jboss.org/browse/THREESCALE-2264) [PR #1034](https://github.com/3scale/APIcast/pull/1034)
 
+- Added `APICAST_PATH_ROUTING_ONLY` variable that allows to perform path-based routing without falling back to the default host-based routing [PR #1035](https://github.com/3scale/APIcast/pull/1035), [THREESCALE-1150](https://issues.jboss.org/browse/THREESCALE-1150)
 
 ### Fixed
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -112,6 +112,16 @@ When configured to authenticate using OAuth, this param specifies the TTL (in se
 
 When this parameter is set to _true_, the gateway will use path-based routing in addition to the default host-based routing. The API request will be routed to the first service that has a matching mapping rule, from the list of services for which the value of the `Host` header of the request matches the _Public Base URL_.
 
+### `APICAST_PATH_ROUTING_ONLY`
+
+**Values:**
+- `true` or `1` for _true_
+- `false`, `0` or empty for _false_
+
+When this parameter is set to _true_, the gateway uses path-based routing and will not fallback to the default host-based routing. The API request will be routed to the first service that has a matching mapping rule, from the list of services for which the value of the `Host` header of the request matches the _Public Base URL_.
+
+This parameter has precedence over `APICAST_PATH_ROUTING`. If `APICAST_PATH_ROUTING_ONLY` is enabled, APIcast will only do path-based routing regardless of the value of `APICAST_PATH_ROUTING`.
+
 ### `APICAST_POLICY_LOAD_PATH`
 
 **Default**: `APICAST_DIR/policies`  

--- a/gateway/src/apicast/configuration_store.lua
+++ b/gateway/src/apicast/configuration_store.lua
@@ -10,7 +10,9 @@ local lrucache = require 'resty.lrucache'
 
 local _M = {
   _VERSION = '0.1',
-  path_routing = env.enabled('APICAST_PATH_ROUTING') or env.enabled('APICAST_PATH_ROUTING_ENABLED'),
+  path_routing = env.enabled('APICAST_PATH_ROUTING') or env.enabled('APICAST_PATH_ROUTING_ENABLED') or
+                 env.enabled('APICAST_PATH_ROUTING_ONLY'),
+  path_routing_only = env.enabled('APICAST_PATH_ROUTING_ONLY'),
   cache_size = 1000
 }
 
@@ -19,12 +21,18 @@ if env.enabled('APICAST_PATH_ROUTING_ENABLED') then ngx.log(ngx.WARN, 'DEPRECATI
 local mt = { __index = _M, __tostring = function() return 'Configuration Store' end }
 
 function _M.new(cache_size, options)
-  local path_routing
+  local path_routing, path_routing_only
 
   if options and options.path_routing ~= nil then
     path_routing = options.path_routing
   else
     path_routing = _M.path_routing
+  end
+
+  if options and options.path_routing_only ~= nil then
+    path_routing_only = options.path_routing_only
+  else
+    path_routing_only = _M.path_routing_only
   end
 
   return setmetatable({
@@ -41,6 +49,7 @@ function _M.new(cache_size, options)
     cache = lrucache.new(cache_size or _M.cache_size),
 
     path_routing = path_routing,
+    path_routing_only = path_routing_only,
 
     cache_size = cache_size
 

--- a/t/apicast-path-routing.t
+++ b/t/apicast-path-routing.t
@@ -142,3 +142,74 @@ If none of the services match it goes for the host.
 [411, 412]
 --- no_error_log
 [error]
+
+=== TEST 3: apicast path-based routing without fallback to host-based
+In this test, we define a couple of services. We make a request that does not
+match any of the mapping rules defined, but the host header matches one of the
+services. We define a custom "error_status_no_match" match in that service to
+verify that APIcast does not fallback to host-based routing. If it did, we
+would see that custom error status in the response, instead of a 404.
+--- env eval
+('APICAST_PATH_ROUTING_ONLY' => '1')
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version": 1,
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/foo/",
+        "hosts": [
+          "one"
+        ],
+        "backend_authentication_type": "service_token",
+        "backend_authentication_value": "service-one",
+        "error_status_no_match": 411,
+        "proxy_rules": [
+          {
+            "pattern": "/one",
+            "http_method": "GET",
+            "metric_system_name": "one",
+            "delta": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": 21,
+      "backend_version": 2,
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/bar/",
+        "hosts": [
+          "two"
+        ],
+        "backend_authentication_type": "service_token",
+        "backend_authentication_value": "service-two",
+        "error_status_no_match": 412,
+        "proxy_rules": [
+          {
+            "pattern": "/two",
+            "http_method": "GET",
+            "metric_system_name": "two",
+            "delta": 2
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block { ngx.exit(200) }
+  }
+--- upstream
+  location ~ /api-backend(/.+) {
+     echo 'yay, api backend: $1';
+  }
+--- request
+GET /do_not_match?user_key=uk
+--- more_headers
+Host: one
+--- error_code: 404
+--- no_error_log
+[error]


### PR DESCRIPTION
Reference: https://issues.jboss.org/browse/THREESCALE-1150

This PR adds a new env, `APICAST_PATH_ROUTING_ONLY`. When set to true, the gateway will use path-based routing and will not fallback to the default host-based routing, which is what happens when using `APICAST_PATH_ROUTING`.