### PR TITLE
Fix problem with context sharing between phases in batcher policy test

### DIFF
--- a/t/apicast-policy-3scale-batcher.t
+++ b/t/apicast-policy-3scale-batcher.t
@@ -451,6 +451,7 @@ init_by_lua_block {
 }
 
 rewrite_by_lua_block {
+  require('resty.ctx').apply()
   ngx.shared.cached_auths:flush_all()
 }
 --- config


### PR DESCRIPTION
In this particular test, the context was not being shared properly between phases. The problem did not show up in this test, but it can cause problems in other tests that rely on having always the correct
context in the log phases for example. Like it happened here: https://github.com/3scale/APIcast/pull/1024#issuecomment-488673351