### PR TITLE
[THREESCALE-2236] Add methods option on Keycloak policy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - "Upstream Connection" policy. It allows to configure several options for the connections to the upstream [PR #1025](https://github.com/3scale/APIcast/pull/1025), [THREESCALE-2166](https://issues.jboss.org/browse/THREESCALE-2166)
 - Enable APICAST_EXTENDED_METRICS environment variable to provide additional details [PR #1024](https://github.com/3scale/APIcast/pull/1024) [THREESCALE-2150](https://issues.jboss.org/browse/THREESCALE-2150)
 - Add the option to obtain client_id from any JWT claim [THREESCALE-2264](https://issues.jboss.org/browse/THREESCALE-2264) [PR #1034](https://github.com/3scale/APIcast/pull/1034)
-
 - Added `APICAST_PATH_ROUTING_ONLY` variable that allows to perform path-based routing without falling back to the default host-based routing [PR #1035](https://github.com/3scale/APIcast/pull/1035), [THREESCALE-1150](https://issues.jboss.org/browse/THREESCALE-1150)
+- Added the option to manage access based on method on Keycloak Policy. [THREESCALE-2236](https://issues.jboss.org/browse/THREESCALE-2236) [PR #1039](https://github.com/3scale/APIcast/pull/1039)
 
 ### Fixed
 

--- a/gateway/src/apicast/mapping_rule.lua
+++ b/gateway/src/apicast/mapping_rule.lua
@@ -13,7 +13,9 @@ local re_match = ngx.re.match
 local insert = table.insert
 local re_gsub = ngx.re.gsub
 
-local _M = {}
+local _M = {
+  any_method = "ANY"
+}
 
 local mt = { __index = _M }
 
@@ -132,7 +134,7 @@ end
 -- @tparam table args Table with the args and values of an HTTP request.
 -- @treturn boolean Whether the mapping rule matches the given request.
 function _M:matches(method, uri, args)
-  local match = self.method == method and
+  local match = (self.method == self.any_method or self.method == method) and
       matches_uri(self.regexpified_pattern, uri) and
       self.querystring_params(args)
 

--- a/gateway/src/apicast/policy/keycloak_role_check/README.md
+++ b/gateway/src/apicast/policy/keycloak_role_check/README.md
@@ -104,3 +104,17 @@
     ]
   }
   ```
+
+- When you want to allow those who have the realm role `role1` to access `/resource1` and only methods GET and POST.
+
+  ```json
+  {
+    "scopes": [
+      {
+        "realm_roles": [ { "name": "role1" } ],
+        "resource": "/resource1",
+        "methods": ["GET", "POST"]
+      }
+    ]
+  }
+  ```

--- a/gateway/src/apicast/policy/keycloak_role_check/apicast-policy.json
+++ b/gateway/src/apicast/policy/keycloak_role_check/apicast-policy.json
@@ -77,6 +77,26 @@
             "resource_type": {
               "description": "How to evaluate 'resource'",
               "$ref": "#/definitions/value_type"
+            },
+            "methods": {
+                "description": "Allowed methods",
+                "type": "array",
+                "default": ["ANY"],
+                "items": {
+                    "type": "string",
+                    "enum": [
+                        "ANY",
+                        "GET",
+                        "HEAD",
+                        "POST",
+                        "PUT",
+                        "DELETE",
+                        "PATCH",
+                        "OPTIONS",
+                        "TRACE",
+                        "CONNECT"
+                    ]
+                }
             }
           }
         }

--- a/gateway/src/apicast/policy/keycloak_role_check/keycloak_role_check.lua
+++ b/gateway/src/apicast/policy/keycloak_role_check/keycloak_role_check.lua
@@ -60,7 +60,7 @@ local default_type = 'plain'
 
 local new = _M.new
 
-local any_method = 'ANY'
+local any_method = MappingRule.any_method
 
 local function create_template(value, value_type)
   return TemplateString.new(value, value_type or default_type)
@@ -160,13 +160,6 @@ end
 
 local function validate_scope_access(scope, context, uri, request_method)
   for _, method  in ipairs(scope.methods) do
-    -- make a matched method just in case that `ANY` method is defined and
-    -- the mapping rules does not match, the matched_method need to be
-    -- cleared in the next interaction to trigger with the correct method.
-    local matched_method = request_method
-    if method == any_method then
-      matched_method = any_method
-    end
 
     local resource = scope.resource_template_string:render(context)
 
@@ -178,7 +171,7 @@ local function validate_scope_access(scope, context, uri, request_method)
       metric_system_name = 'hits'
     })
 
-    if mapping_rule:matches(matched_method, uri) then
+    if mapping_rule:matches(request_method, uri) then
       if match_realm_roles(scope, context) and match_client_roles(scope, context) then
         return true
       end

--- a/spec/mapping_rule_spec.lua
+++ b/spec/mapping_rule_spec.lua
@@ -120,6 +120,26 @@ describe('mapping_rule', function()
       assert.is_true(mapping_rule:matches('GET', '/foo/a:b/bar'))
       assert.is_true(mapping_rule:matches('GET', "/foo/a%b/bar"))
     end)
-
   end)
+
+  describe('.any_method', function()
+
+    it("Allow connections when any method is defined", function()
+
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/foo/',
+        querystring_parameters = { },
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', '/foo/'))
+      assert.is_true(mapping_rule:matches('POST', '/foo/'))
+      assert.is_true(mapping_rule:matches('PUT', "/foo/"))
+      assert.is_true(mapping_rule:matches('DELETE', "/foo/"))
+      assert.is_true(mapping_rule:matches('PATCH', "/foo/"))
+    end)
+  end)
+
 end)

--- a/t/apicast-policy-keycloak-role-check.t
+++ b/t/apicast-policy-keycloak-role-check.t
@@ -22,7 +22,7 @@ run_tests();
 
 __DATA__
 
-=== TEST1: Role check succeeds (whitelist)
+=== TEST 1: Role check succeeds (whitelist)
 The client which has the appropriate role accesses the resource.
 --- backend
   location /transactions/oauth_authrep.xml {
@@ -94,7 +94,7 @@ oauth failed with
 
 
 
-=== TEST2: Role check succeeds (blacklist)
+=== TEST 2: Role check succeeds (blacklist)
 The client which doesn't have the inappropriate role accesses the resource.
 --- backend
   location /transactions/oauth_authrep.xml {
@@ -169,7 +169,7 @@ oauth failed with
 
 
 
-=== TEST3: Role check fails (whitelist)
+=== TEST 3: Role check fails (whitelist)
 The client which doesn't have the appropriate role accesses the resource.
 --- backend
   location /transactions/oauth_authrep.xml {
@@ -240,7 +240,7 @@ auth failed
 
 
 
-=== TEST4: Role check fails (blacklist)
+=== TEST 4: Role check fails (blacklist)
 The client which has the inappropriate role accesses the resource.
 --- backend
   location /transactions/oauth_authrep.xml {
@@ -314,7 +314,7 @@ auth failed
 
 
 
-=== TEST5: Role check succeeds with Liquid template (whitelist)
+=== TEST 5: Role check succeeds with Liquid template (whitelist)
 The client which has the appropriate role accesses the resource.
 --- backend
   location /transactions/oauth_authrep.xml {
@@ -395,7 +395,7 @@ yay, api backend
 oauth failed with
 
 
-=== TEST6: Role check with allow methods
+=== TEST 6: Role check with allow methods
 The client which has the appropriate role accesses the resource with only one method allowed
 --- backend
   location /transactions/oauth_authrep.xml {
@@ -473,7 +473,7 @@ The client which has the appropriate role accesses the resource with only one me
 oauth failed with
 
 
-=== TEST7: Role check with allow methods and blacklist mode
+=== TEST 7: Role check with allow methods and blacklist mode
 Check an allowed role with the blacklisted mode with methods
 --- backend
   location /transactions/oauth_authrep.xml {


### PR DESCRIPTION
This commits add the `methods` option on the keycloack policy. That
allow users to define a new policy from any jwt claim, resource and
method.

To be backwards compatible 'ANY' method is in place, and if methods are
not defined this global method will be used and all will work as normal.

Example policy:

```
"policy_chain": [
  {
    "name": "apicast.policy.keycloak_role_check",
    "configuration": {
      "scopes": [
        {
          "realm_roles": [ { "name": "director" } ],
          "resource": "/confidential",
          "methods": ["POST"]
        }
      ],
      "type": "blacklist"
    }
  },
  { "name": "apicast.policy.apicast" }
]
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>