### PR TITLE
CI Fixes

### DIFF
--- a/script/install/circleci.sh
+++ b/script/install/circleci.sh
@@ -20,8 +20,10 @@ apt update
 
 echo manual > /etc/init/openresty.override
 
+export OPENRESTY_VERSION="1.13.6.2-1~trusty1"
+
 apt install -y cpanminus liblocal-lib-perl libev-dev luarocks python-pip systemtap libyaml-dev
-apt install -y openresty openresty-debug-dbgsym openresty-openssl-debug-dbgsym openresty-pcre-dbgsym openresty-zlib-dbgsym
+apt install -y openresty=$OPENRESTY_VERSION openresty-debug=$OPENRESTY_VERSION openresty-opm=$OPENRESTY_VERSION openresty-resty=$OPENRESTY_VERSION openresty-debug-dbgsym=$OPENRESTY_VERSION openresty-openssl-debug-dbgsym openresty-pcre-dbgsym openresty-zlib-dbgsym
 
 kernel=$(uname -r)
 apt install -y "linux-headers-${kernel}" "linux-image-${kernel}-dbgsym"

--- a/spec/policy/rate_limit/rate_limit_spec.lua
+++ b/spec/policy/rate_limit/rate_limit_spec.lua
@@ -217,7 +217,7 @@ describe('Rate limit policy', function()
 
         it('rejected (count), name_type is liquid and refers to var in the context', function()
           local test_host = 'some_host'
-
+          ngx_variable.available_context:revert()
           stub(ngx_variable, 'available_context', function()
             return { host = test_host }
           end)

--- a/spec/template_string_spec.lua
+++ b/spec/template_string_spec.lua
@@ -30,6 +30,7 @@ describe('template string', function()
   end)
 
   it('when rendering liquid, it can use the vars exposed in ngx_variable', function()
+    ngx_variable.available_context:revert()
     stub(ngx_variable, 'available_context', function(policies_context)
       local exposed = { a_key_exposed_in_ngx_var = 'a_value' }
       return LinkedList.readonly(exposed, policies_context)


### PR DESCRIPTION
Two commits:

1) Temporal fix for the double stub in the luaasert, that makes some builds to fail. 
2) Fix the profile script to install the supported Openresty version. The current one is not yet supported.  