### PR TITLE
[THREESCALE-2540] Fix issues with uppercase upstreams.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The caching policy now works correctly when combined with the 3scale batcher one [PR #1023](https://github.com/3scale/APIcast/pull/1023)
 - Fixed the name of the 3scale batching policy in the logs. Some logs showed "Caching policy" where it should have said "3scale Batcher" [PR #1029](https://github.com/3scale/APIcast/pull/1029)
 - Changed the schema of the IP check policy so it renders correctly in the UI [PR #1026](https://github.com/3scale/APIcast/pull/1026), [THREESCALE-1692](https://issues.jboss.org/browse/THREESCALE-1692)
+- Allow uppercase backend API in the service.[PR #1044](https://github.com/3scale/APIcast/pull/1044), [THREESCALE-2540](https://issues.jboss.org/browse/THREESCALE-2540)
 
 ### Removed
 

--- a/gateway/Roverfile.lock
+++ b/gateway/Roverfile.lock
@@ -12,7 +12,7 @@ lua-resty-iputils 0.3.0-1||production
 lua-resty-jit-uuid 0.0.7-1||production
 lua-resty-jwt 0.2.0-0||production
 lua-resty-repl 0.0.6-0||development
-lua-resty-url 0.3.4-1||production
+lua-resty-url 0.3.5-1||production
 lua-term 0.7-1||testing
 lua_cliargs 3.0-1||testing
 luacov 0.13.0-1||testing


### PR DESCRIPTION
If the proxy API backend is in uppercase it'll not work correctly and
Apicast exists with an execpetion [0]. This commit transform api_backend
always to lowercase string, so the system will not break even if
receives a uppercase string.

[0] Exception
```
2019/05/21 05:59:30 [error] 1037#1037: *3 lua entry thread aborted: runtime error: /home/centos/gateway/src/apicast/policy/apicast/apicast.lua:101: missing upstream
stack traceback:
coroutine 0:
        [C]: in function 'assert'
        /home/centos/gateway/src/apicast/policy/apicast/apicast.lua:101: in function </home/centos/gateway/src/apicast/policy/apicast/apicast.lua:100>
        /home/centos/gateway/src/apicast/policy_chain.lua:190: in function </home/centos/gateway/src/apicast/policy_chain.lua:187>
        /home/centos/gateway/src/apicast/policy_chain.lua:190: in function 'content'
        content_by_lua(lua_JOJems:485):1: in function <content_by_lua(lua_JOJems:485):1> while sending to client, client: 127.0.0.1, server: _, request: "GET /some-path?user_key=4e5944f11f575fd50bd6624c8d441f13 HTTP/1.1", host: "localhost:8080"
```

Fix THREESCALE-2540

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>