### PR TITLE
[Test] Luassert make sure to revert function if it is already mocked.

### DIFF
--- a/spec/policy/3scale_batcher/3scale_batcher_spec.lua
+++ b/spec/policy/3scale_batcher/3scale_batcher_spec.lua
@@ -131,6 +131,7 @@ describe('3scale batcher policy', function()
       describe('and backend is available', function()
         before_each(function()
           local backend_client = require('apicast.backend_client')
+          backend_client.authorize:revert()
           stub(backend_client, 'authorize').returns({ status = 200 })
         end)
 
@@ -144,12 +145,14 @@ describe('3scale batcher policy', function()
       describe('and backend is not available', function()
         before_each(function()
           local backend_client = require('apicast.backend_client')
+          backend_client.authorize:revert()
           stub(backend_client, 'authorize').returns({ status = 500 })
         end)
 
         describe('and the authorization is in the downtime cache', function()
           describe('and it is OK', function()
             before_each(function()
+              batcher_policy.backend_downtime_cache.get:revert()
               stub(batcher_policy.backend_downtime_cache, 'get').returns(200)
             end)
 
@@ -163,6 +166,7 @@ describe('3scale batcher policy', function()
 
           describe('and it is denied', function()
             before_each(function()
+              batcher_policy.backend_downtime_cache.get:revert()
               stub(batcher_policy.backend_downtime_cache, 'get').returns(409)
             end)
 
@@ -182,6 +186,7 @@ describe('3scale batcher policy', function()
 
         describe('and the authorization is not in the downtime cache', function()
           before_each(function()
+            batcher_policy.backend_downtime_cache.get:revert()
             stub(batcher_policy.backend_downtime_cache, 'get').returns(nil)
           end)
 


### PR DESCRIPTION
This commit overwrites luassert stub function to make sure that before
try to mock any function verifies that is not mocked, and if it is,
revert to the original one. This prevents scenarios where multiple stubs
are in one test and are leaked to other test and that scenario is hard
to debug/notice.

I tried to fix this on `luassert.state`, but looks like that the second stub is not always registered and it was a bit flaky, so this, for now, is the best solution that I found. 

Fix https://github.com/3scale/APIcast/issues/1043


Signed-off-by: Eloy Coto <eloy.coto@gmail.com>