### PR TITLE
[docs] fix APICAST_HTTPS_VERIFY_DEPTH documentation

### DIFF
--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -165,14 +165,6 @@ Path to a file with passphrases for the SSL cert keys specified with
 - `on`: reuses SSL sessions.
 - `off`: does not reuse SSL sessions.
 
-### `APICAST_PROXY_HTTPS_VERIFY_DEPTH`
-
-**Default:** 1
-**Values:** positive integers
-
-Defines the maximum length of the client certificate chain.
-If this parameter has 1 as its value, it implies that this length might include one additional certificate (eg. intermediate CA).
-
 ### `APICAST_REPORTING_THREADS`
 
 **Default**: 0  
@@ -352,6 +344,14 @@ Path to a file with X.509 certificate in the PEM format for HTTPS.
 **Default:** no value
 
 Path to a file with the X.509 certificate secret key in the PEM format.
+
+### `APICAST_HTTPS_VERIFY_DEPTH`
+
+**Default:** 1
+**Values:** positive integers
+
+Defines the maximum length of the client certificate chain.
+If this parameter has 1 as its value, it implies that this length might include one additional certificate (eg. intermediate CA).
 
 ### `all_proxy`, `ALL_PROXY`
 


### PR DESCRIPTION
Fix wrong documentation in #1006 

It is APICAST_HTTPS_VERIFY_DEPTH, not APICAST_PROXY_HTTPS_VERIFY_DEPTH

/cc @jsmolar 