### PR TITLE
 [THREESCALE-2194] Ensure locks are released on configuration_loader. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed the name of the 3scale batching policy in the logs. Some logs showed "Caching policy" where it should have said "3scale Batcher" [PR #1029](https://github.com/3scale/APIcast/pull/1029)
 - Changed the schema of the IP check policy so it renders correctly in the UI [PR #1026](https://github.com/3scale/APIcast/pull/1026), [THREESCALE-1692](https://issues.jboss.org/browse/THREESCALE-1692)
 - Allow uppercase backend API in the service.[PR #1044](https://github.com/3scale/APIcast/pull/1044), [THREESCALE-2540](https://issues.jboss.org/browse/THREESCALE-2540)
+- Fixed lock issues on configuration loader when Lazy mode is enabled.[PR #1050](https://github.com/3scale/APIcast/pull/1050), [THREESCALE-2194](https://issues.jboss.org/browse/THREESCALE-2194)
 
 ### Removed
 

--- a/gateway/src/apicast/configuration_loader/remote_v2.lua
+++ b/gateway/src/apicast/configuration_loader/remote_v2.lua
@@ -38,7 +38,6 @@ function _M.new(url, options)
   }
 
   local path = resty_url.split(endpoint or '')
-
   return setmetatable({
     endpoint = endpoint,
     path = path and path[6],

--- a/gateway/src/resty/oidc/discovery.lua
+++ b/gateway/src/resty/oidc/discovery.lua
@@ -61,6 +61,12 @@ function _M:openid_configuration(issuer)
         return nil, 'no OIDC endpoint'
     end
 
+    local _, err = resty_url.parse(uri)
+    if err then
+      ngx.log(ngx.WARN, 'OIDC url is not valid, uri: "' .. uri ..'", error: ' .. err)
+      return nil, 'OIDC url is not valid, uri: "' .. uri ..'", error: ' .. err
+    end
+
     local res = http_client.get(uri)
 
     if res.status ~= 200 then

--- a/spec/synchronization_spec.lua
+++ b/spec/synchronization_spec.lua
@@ -1,0 +1,78 @@
+describe("Synchronization", function()
+  local synchronization
+  local key = "foo"
+
+  before_each(function()
+    synchronization = require('resty.synchronization').new(1)
+  end)
+
+  it("Valid run execution", function()
+    local callback = spy.new(function() return 1 end)
+
+    local ret, result = synchronization:run(key, 10, callback)
+    assert.same(ret, true)
+    assert.same(result, {1})
+    assert.spy(callback).was.called()
+  end)
+
+  it("Validates that run send correctly the arguments", function()
+    local callback = spy.new(function(k, v) return k, v end)
+
+    local ret, result = synchronization:run(key, 4, callback, "bob", "alice")
+    assert.same(ret, true)
+    assert.same(result, {"bob", "alice"})
+    assert.spy(callback).was_called()
+  end)
+
+  it("Validates that run does not break if a exception on the callback", function()
+    local callback = spy.new(function()
+      local data = {};
+      return data[3]
+    end)
+
+    local ret, result = synchronization:run(key, 4, callback)
+    assert.same(ret, true)
+    assert.same(result, {})
+    assert.spy(callback).was_called()
+  end)
+
+  it("Validates that run fails if key is locked and timeout", function()
+    local callback = spy.new(function() return 1 end)
+
+    local sema = synchronization:acquire(key)
+    local ok, err = sema:wait(5)
+    assert.same(ok, true)
+    assert.same(err, nil)
+
+    local ret, result = synchronization:run(key, 2, callback)
+    assert.same(ret, false)
+    assert.same(result, nil)
+    assert.spy(callback).was_not_called()
+
+    synchronization:release(key)
+    sema:post()
+  end)
+
+  it("Validate that acquire fails if not initialize", function()
+    local sync = require('resty.synchronization')
+    local sema, err = sync:acquire(key)
+    assert.same(sema, nil)
+    assert.same(err, "not initialized")
+  end)
+
+  it("validate that acquire/release workflow", function()
+
+    local sema, _ = synchronization:acquire(key)
+    assert.is.not_nil(synchronization.semaphores[key])
+    assert.is.not_nil(sema)
+
+    local ok, err = sema:wait(15)
+    assert.same(ok, true)
+    assert.same(err, nil)
+
+    ok, err = synchronization.release(key)
+    assert.same(ok, nil)
+    assert.is.not_nil(err, nil)
+  end)
+
+end)


### PR DESCRIPTION
This commits add a new function `run` to the synchronization module,
that function ensures that a given function is going to be run in a safe
task and make sure that the release of the lock  always happens, so the
lock is not going to be blocked if something goes wrong.

Fix #1010
Fix THREESCALE-2194