### PR TITLE
Makefile: add lua_modules to PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ endif
 
 export COMPOSE_PROJECT_NAME
 
-.PHONY: benchmark
+.PHONY: benchmark lua_modules
 
 test: ## Run all tests
 	$(MAKE) --keep-going busted prove builder-image test-builder-image prove-docker runtime-image test-runtime-image


### PR DESCRIPTION
When starting from a clean repo clone, the `lua_modules` target fails sometimes. Adding it to `PHONY` fixes the problem.