### PR TITLE
[THREESCALE-2340] Make response codes compatible with reporting threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added the option to manage access based on method on Keycloak Policy. [THREESCALE-2236](https://issues.jboss.org/browse/THREESCALE-2236) [PR #1039](https://github.com/3scale/APIcast/pull/1039)
 - The Rate Limit policy now supports conditions defined with the "matches" operation. [PR #1051](https://github.com/3scale/APIcast/pull/1051), [THREESCALE-2590](https://issues.jboss.org/browse/THREESCALE-2590)
 - Upgrade OpenResty to 1.15.8.1 release.[PR #1049](https://github.com/3scale/APIcast/pull/1049), [THREESCALE-2200](https://issues.jboss.org/browse/THREESCALE-2200)
+- Now it is possible to report status codes when using reporting threads [PR #1058](https://github.com/3scale/APIcast/pull/1058), [THREESCALE-2340](https://issues.jboss.org/browse/THREESCALE-2340)
 
 ### Fixed
 

--- a/t/apicast-request-logs.t
+++ b/t/apicast-request-logs.t
@@ -27,6 +27,11 @@ __DATA__
       }
     })
 
+    -- Response codes cannot be sent when the request is not cached. In that
+    -- case, the authrep is called before calling the upstream, so the
+    -- response code is not available. Response codes are only sent in the
+    -- post-action phase. The cache is populated here to force a post-action
+    -- phase.
     ngx.shared.api_keys:set('42:somekey:usage%5Bbar%5D=0', 200)
   }
   lua_shared_dict api_keys 1m;

--- a/t/apicast-request-logs.t
+++ b/t/apicast-request-logs.t
@@ -113,3 +113,59 @@ api response
 <<"END";
 log[code]: 201
 END
+
+=== TEST 3: response codes with multiple reporting threads
+--- main_config
+env APICAST_RESPONSE_CODES=1;
+env APICAST_REPORTING_THREADS=4;
+--- http_config
+  include $TEST_NGINX_UPSTREAM_CONFIG;
+  lua_package_path "$TEST_NGINX_LUA_PATH";
+
+  init_by_lua_block {
+    require('apicast.configuration_loader').mock({
+      services = {
+        {
+          id = 42,
+          backend_version = 1,
+          proxy = {
+            api_backend = 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api/',
+            proxy_rules = {
+              { pattern = '/', http_method = 'GET', metric_system_name = 'bar' }
+            }
+          }
+        },
+      }
+    })
+
+    ngx.shared.api_keys:set('42:somekey:usage%5Bbar%5D=0', 200)
+  }
+  lua_shared_dict api_keys 1m;
+--- config
+  include $TEST_NGINX_APICAST_CONFIG;
+
+  location /api/ {
+    echo "api response";
+    echo_status 201;
+  }
+
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local args = ngx.req.get_uri_args()
+      for key, val in pairs(args) do
+        ngx.log(ngx.DEBUG, key, ": ", val)
+      end
+      ngx.exit(200)
+    }
+  }
+--- request eval
+["GET /test?user_key=somekey", "GET /foo?user_key=somekey", "GET /?user_key=somekey"]
+--- response_body eval
+["api response\x{0a}", "api response\x{0a}", "api response\x{0a}"]
+--- error_code eval
+[ 201, 201, 201 ]
+--- grep_error_log eval: qr/log\[\w+\]:.+/
+--- grep_error_log_out eval
+<<"END";
+log[code]: 201
+END


### PR DESCRIPTION
Fixes [THREESCALE-2340](https://issues.jboss.org/browse/THREESCALE-2340)

This PR makes response codes compatible with reporting threads.

The only problem was that the status code (`ngx.var.status`) was checked in a timer and timers do not have access to ngx.var.*.