### PR TITLE
Document and test management API only with policies exposed

### DIFF
--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -84,7 +84,8 @@ Allows to set the log level for the logs related to OpenID Connect integration
 **Values:**
 
 - `disabled`: completely disabled, just listens on the port
-- `status`: only the `/status/` endpoints enabled for health checks
+- `status`: enables the `/status/` endpoint for health checks, and the `/policies` endpoint that shows the list of available policies.
+- `policies`: enables only the `/policies` endpoint.
 - `debug`: full API is open
 
 The [Management API](./management-api.md) is powerful and can control the APIcast configuration.

--- a/t/management-policies-endpoint.t
+++ b/t/management-policies-endpoint.t
@@ -31,3 +31,18 @@ encode_json $::policies->();
 --- error_code: 200
 --- no_error_log
 [error]
+
+=== TEST 2: expose only policies
+APICAST_MANAGEMENT_API=policies enables the endpoint without enabling other
+status info
+--- env eval
+(APICAST_MANAGEMENT_API => "policies")
+--- request eval
+["GET /policies", "GET /status/info"]
+--- error_code eval
+[ 200, 404]
+--- expected_json eval
+use JSON;
+encode_json $::policies->();
+--- no_error_log
+[error]


### PR DESCRIPTION
This PR documents how to enable only the `/policies` endpoint in the management API. I also added a test for it. No code changes are required, this was already supported.