### PR TITLE
Backend enpoint override description update

### DIFF
--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -240,7 +240,8 @@ This is the value that will be used in the nginx `worker_processes` [directive](
 
 ### `BACKEND_ENDPOINT_OVERRIDE`
 
-URI that overrides the backend endpoint from the configuration, by default it is the external route. Is is useful when deploying APIcast into the same OpenShift cluster than 3scale as to use the internal hostname of the backend listener service instead of the public route. 
+URI that overrides the backend endpoint. By default, it is the external route. 
+This parameter is useful when deploying APIcast into the same OpenShift cluster than 3scale, as when using the internal hostname of the backend listener service instead of the public route. 
 
 **Example**: `http://backend-listener.<AMP_PROJECT>.svc.cluster.local:3000`.
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -243,7 +243,7 @@ This is the value that will be used in the nginx `worker_processes` [directive](
 URI that overrides the backend endpoint. By default, it is the external route. 
 This parameter is useful when deploying APIcast into the same OpenShift cluster than 3scale, as when using the internal hostname of the backend listener service instead of the public route. 
 
-**Example**: `http://backend-listener.<AMP_PROJECT>.svc.cluster.local:3000`.
+**Example**: `http://backend-listener.<3scale-namespace>.svc.cluster.local:3000`
 
 ### `OPENSSL_VERIFY`
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -242,6 +242,8 @@ This is the value that will be used in the nginx `worker_processes` [directive](
 
 URI that overrides the backend endpoint from the configuration, by default it is the external route. Is is useful when deploying APIcast into the same OpenShift cluster than 3scale as to use the internal hostname of the backend listener service instead of the public route. 
 
+**Example**: `http://backend-listener.<AMP_PROJECT>.svc.cluster.local:3000`.
+
 ### `OPENSSL_VERIFY`
 
 **Values:**

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -240,7 +240,7 @@ This is the value that will be used in the nginx `worker_processes` [directive](
 
 ### `BACKEND_ENDPOINT_OVERRIDE`
 
-URI that overrides the backend endpoint from the configuration, by default it is the external route. Is is useful when deploying APIcast into the same OpenShift cluster than 3scale API Manager as to use the internal hostname of the backend listener service instead of the public route. 
+URI that overrides the backend endpoint from the configuration, by default it is the external route. Is is useful when deploying APIcast into the same OpenShift cluster than 3scale as to use the internal hostname of the backend listener service instead of the public route. 
 
 ### `OPENSSL_VERIFY`
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -240,9 +240,7 @@ This is the value that will be used in the nginx `worker_processes` [directive](
 
 ### `BACKEND_ENDPOINT_OVERRIDE`
 
-URI that overrides backend endpoint from the configuration. Useful when deploying outside OpenShift deployed AMP.
-
-**Example**: `https://backend.example.com`.
+URI that overrides the backend endpoint from the configuration, by default it is the external route. Is is useful when deploying APIcast into the same OpenShift cluster than 3scale API Manager as to use the internal hostname of the backend listener service instead of the public route. 
 
 ### `OPENSSL_VERIFY`
 


### PR DESCRIPTION
This PR modifies the description of the BACKEND_ENDPOINT_OVERRIDE environment variable. 
Fixes the issue [#1059](https://github.com/3scale/APIcast/issues/1059).