### PR TITLE
[THREESCALE-2775] [Policy] IP Check uses multiple x-forwarder-for headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Changed the schema of the IP check policy so it renders correctly in the UI [PR #1026](https://github.com/3scale/APIcast/pull/1026), [THREESCALE-1692](https://issues.jboss.org/browse/THREESCALE-1692)
 - Allow uppercase backend API in the service.[PR #1044](https://github.com/3scale/APIcast/pull/1044), [THREESCALE-2540](https://issues.jboss.org/browse/THREESCALE-2540)
 - Fixed lock issues on configuration loader when Lazy mode is enabled.[PR #1050](https://github.com/3scale/APIcast/pull/1050), [THREESCALE-2194](https://issues.jboss.org/browse/THREESCALE-2194)
+- Fixed multiple x-forwarded-for headers issue on IP Check policy.[PR #1065](https://github.com/3scale/APIcast/pull/1065), [Issue #1061](https://github.com/3scale/APIcast/issues/1061)[THREESCALE-2775](https://issues.jboss.org/browse/THREESCALE-2775)
 
 ### Removed
 

--- a/gateway/src/apicast/policy/ip_check/client_ip.lua
+++ b/gateway/src/apicast/policy/ip_check/client_ip.lua
@@ -13,6 +13,11 @@ end
 
 local function ip_from_x_forwarded_for_header()
   local forwarded_for = ngx.req.get_headers()['X-Forwarded-For']
+  -- If the header is duplicated, get_heders() method  returns all the headers
+  -- in a table instead of the string, so we only use the first one.
+  if (type(forwarded_for) == "table") then
+    forwarded_for = forwarded_for[1]
+  end
 
   if not forwarded_for or forwarded_for == "" then
     return nil


### PR DESCRIPTION
This change allows to block traffic when multiple x-forwarder-for are defined
in the same request. Resty creates an array with all duplicated headers, so in
case of a array only the first heaeder will be used.

Also, adds the integration test to make sure that no regression in this case.

Example request to make it fail:

```
curl localhost:8080?user_key=123
    -H "X-Forwarded-For: 1.2.3.4" \
    -H "Host:one" \
    -H "X-Forwarded-For: 1.2.3.44"  \
    -v
```

config:
```
{
  "services": [
    {
      "id": 200,
      "endpoint": "http://localhost:8080",
      "backend_version": "1",
      "proxy": {
        "service_backend_version": "1",
        "hosts": [
                  "one"
              ],
        "api_backend": "https://echo-api.3scale.net:443",
        "proxy_rules": [
          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
        ],
        "policy_chain": [
          { "name": "apicast.policy.apicast" },
          {
            "name": "ip_check",
            "version": "builtin",
            "configuration": {
              "error_msg": "IP address not allowed",
              "client_ip_sources": [
                "X-Forwarded-For"
              ],
              "ips": [
                "1.2.3.4"
              ],
              "check_type": "blacklist"
            }
          }
        ]
      }
    }
  ]
}
```

Fixes #1061

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>