### PR TITLE
fix for make development failures - github issue #957

### DIFF
--- a/docker-compose-devel-volmount-default.yml
+++ b/docker-compose-devel-volmount-default.yml
@@ -1,0 +1,7 @@
+version: '2.2'
+services:
+  development:
+    volumes:
+      - .:/home/centos/
+      - .docker/cpanm:/home/centos/.cpanm
+

--- a/docker-compose-devel-volmount-mac.yml
+++ b/docker-compose-devel-volmount-mac.yml
@@ -1,0 +1,6 @@
+version: '2.2'
+services:
+  development:
+    volumes:
+      - .:/home/centos/:cached
+      - .docker/cpanm:/home/centos/.cpanm:delegated

--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -6,11 +6,9 @@ services:
       - redis
     working_dir: /home/centos/
     volumes:
-      - .:/home/centos/:cached
       - .docker/lua_modules:/home/centos/lua_modules
       - .docker/local:/home/centos/local
       - .docker/vendor/cache:/home/centos/vendor/cache
-      - .docker/cpanm:/home/centos/.cpanm:delegated
       # no need to access those from docker
       - /home/centos/.docker
       - /home/centos/.git


### PR DESCRIPTION
This PR fixes the development failures reported in  [https://github.com/3scale/apicast/issues/957](#957) using separate docker-compose files for volume configuration and -d option instead of --detach command line option for docker-compose. 