### PR TITLE
WIP:DOC: Update examples to be more user friendly.

### DIFF
--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -210,7 +210,7 @@ Service 3: backend endpoint http://prod.foo.dev
 Service 4: backend endpoint http://prod.bar.dev
 ```
 
-The services that will be configured in Apicast will be 1 and 3. Services 2 and
+The services that will be configured in embedded APIcast will be 1 and 3. Services 2 and
 4 will be discarded.
 
 ### `APICAST_SERVICES_LIST`

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -202,12 +202,13 @@ Note: If a service does not match, but is included in the
 `APICAST_SERVICES_LIST`, service will not be discarded
 
 Example:
-
-Regexp Filter: http:\/\/.*.google.com
-Service 1: backend endpoint http://www.google.com
-Service 2: backend endpoint http://www.yahoo.com
-Service 3: backend endpoint http://mail.google.com
-Service 4: backend endpoint http://mail.yahoo.com
+```
+Regexp Filter: http:\/\/.*.foo.dev
+Service 1: backend endpoint http://staging.foo.dev
+Service 2: backend endpoint http://staging.bar.dev
+Service 3: backend endpoint http://prod.foo.dev
+Service 4: backend endpoint http://prod.bar.dev
+```
 
 The services that will be configured in Apicast will be 1 and 3. Services 2 and
 4 will be discarded.


### PR DESCRIPTION
This fixes #1069 issue where Backend API was set as google.com and
yahoo.com due to in markdown files the urls need to be real.

Encoded the urls as code, and create some user-friendly api backend.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>