### PR TITLE
Operations: Add numerics options.

### DIFF
--- a/gateway/src/apicast/conditions/operation.lua
+++ b/gateway/src/apicast/conditions/operation.lua
@@ -23,7 +23,13 @@ local evaluate_func = {
   -- false otherwise.
   ['matches'] = function(left, right)
     return (match(tostring(left), tostring(right)) and true) or false
-  end
+  end,
+
+  -- Numerics entries
+  [">"] = function(left, right) return (tonumber(left) or 0) > (tonumber(right) or 0) end,
+  [">="] = function(left, right) return (tonumber(left) or 0) >= (tonumber(right) or 0) end,
+  ["<="] = function(left, right) return (tonumber(left) or 0) <= (tonumber(right) or 0) end,
+  ["<"] = function(left, right) return (tonumber(left) or 0) < (tonumber(right) or 0) end,
 }
 
 --- Initialize an operation

--- a/spec/conditions/operation_spec.lua
+++ b/spec/conditions/operation_spec.lua
@@ -85,5 +85,102 @@ describe('Operation', function()
 
       assert.is_false(not_eq_int_and_string)
     end)
+
+    describe("numerics operations", function()
+      local context = {
+          a="1",
+          b="2",
+          c="3",
+          invalid="invalid"
+      }
+
+      it("validate greater than operation", function()
+        local expected_results = {
+          {"1" , "2", false},
+          {"1" , "1", false},
+          {"2" , "1", true},
+          {"xx" , "2", false},
+          {"2" , "xx", true},
+          {"{{a}}" , "1", false},
+          {"{{b}}" , "2", false},
+          {"{{c}}" , "2", true},
+          {"{{invalid}}", 2, false},
+          {{123,123}, 2, false}
+        }
+
+
+        for _,x in ipairs(expected_results) do
+           local op = Operation.new(x[1], "liquid", ">", x[2], "liquid")
+           assert.are.same(op:evaluate(context), x[3], "issue comparing interaction ".. tostring(x[1]) .." > " ..tostring(x[2]))
+        end
+      end)
+
+      it("validate greater or equal than operation", function()
+        local expected_results = {
+          {"1" , "2", false},
+          {"1" , "1", true},
+          {"2" , "1", true},
+          {"xx" , "2", false},
+          {"2" , "xx", true},
+          {"0" , "xx", true},
+          {"{{a}}" , "0", true},
+          {"{{a}}" , "1", true},
+          {"{{c}}" , "2", true},
+          {"{{invalid}}", "2", false},
+          {"{{invalid}}", "0", true},
+          {{123,123}, 0, true},
+        }
+
+
+        for _,x in ipairs(expected_results) do
+           local op = Operation.new(x[1], "liquid", ">=", x[2], "liquid")
+           assert.are.same(op:evaluate(context), x[3], "issue comparing interaction ".. tostring(x[1]) .." >=" ..tostring(x[2]))
+        end
+      end)
+
+      it("validate less than operation", function()
+        local expected_results = {
+          {"1" , "2", true},
+          {"1" , "1", false},
+          {"2" , "1", false},
+          {"xx" , "2", true},
+          {"2" , "xx", false},
+          {"{{a}}" , "2", true},
+          {"{{a}}" , "1", false},
+          {"{{c}}" , "1", false},
+          {"{{invalid}}" , "2", true},
+          {"{{invalid}}" , "-2", false},
+          {{123,123}, "-2", false},
+        }
+
+
+        for _,x in ipairs(expected_results) do
+           local op = Operation.new(x[1], "liquid", "<", x[2], "liquid")
+           assert.are.same(op:evaluate(context), x[3], "issue comparing interaction ".. tostring(x[1]) .." < " .. tostring(x[2]))
+        end
+      end)
+
+      it("validate less or equal than operation", function()
+        local expected_results = {
+          {"1" , "2", true},
+          {"1" , "1", true},
+          {"2" , "1", false},
+          {"xx" , "2", true},
+          {"2" , "xx", false},
+          {"{{a}}" , "2", true},
+          {"{{a}}" , "1", true},
+          {"{{c}}" , "1", false},
+          {"{{invalid}}", 2, true},
+          {"{{invalid}}", -2, true},
+          {{123,123}, -2, true},
+        }
+
+        for _,x in ipairs(expected_results) do
+           local op = Operation.new(x[1], "liquid", "<=", x[2], "liquid")
+           assert.are.same(op:evaluate(context), x[3], "issue comparing interaction ".. tostring(x[1]) .." <=" .. tostring(x[2]))
+        end
+      end)
+    end)
+
   end)
 end)


### PR DESCRIPTION
Add a few numeric options on operations to be able to compare numbers.

**this is TBD PR** what happens when a non-numeric value is sent to a numeric operation, should be 0? Return false, return an error?



Signed-off-by: Eloy Coto <eloy.coto@gmail.com>