### PR TITLE
release: 3.6.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [3.6.0-beta1] - 2019-06-18
+
 ### Added
 
 - You can filter services by endpoint name using Regexp [PR #1022](https://github.com/3scale/APIcast/pull/1022) [THREESCALE-1524](https://issues.jboss.org/browse/THREESCALE-1524)
@@ -639,7 +641,7 @@ expressed might change in future releases.
 ### Changed
 - Major rewrite using JSON configuration instead of code generation.
 
-[Unreleased]: https://github.com/3scale/apicast/compare/v3.5.1...HEAD
+[Unreleased]: https://github.com/3scale/apicast/compare/v3.6.0-beta1...HEAD
 [2.0.0]: https://github.com/3scale/apicast/compare/v0.2...v2.0.0
 [3.0.0-alpha1]: https://github.com/3scale/apicast/compare/v2.0.0...v3.0.0-alpha1
 [3.0.0-alpha2]: https://github.com/3scale/apicast/compare/v3.0.0-alpha1...v3.0.0-alpha2
@@ -675,3 +677,4 @@ expressed might change in future releases.
 [3.5.0-rc1]: https://github.com/3scale/apicast/compare/v3.5.0-beta1...v3.5.0-rc1
 [3.5.0]: https://github.com/3scale/apicast/compare/v3.5.0-beta1...v3.5.0
 [3.5.1]: https://github.com/3scale/apicast/compare/v3.5.0...v3.5.1
+[3.6.0-beta1]: https://github.com/3scale/apicast/compare/v3.5.1...v3.6.0-beta1

--- a/gateway/src/apicast/version.lua
+++ b/gateway/src/apicast/version.lua
@@ -1,1 +1,1 @@
-return "3.5.1"
+return "3.6.0-beta1"


### PR DESCRIPTION
Note: travis build fails because of the v3.6.0-beta1 tag which will be created after merging.