### PR TITLE
Policy: HTTP proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Introduce possibility of specifying policy order restrictions in their schemas. APIcast now shows a warning when those restrictions are not respected [#1088](https://github.com/3scale/APIcast/pull/1088), [THREESCALE-2896](https://issues.jboss.org/browse/THREESCALE-2896)
 - Added new parameters to logging policy to allow custom access log [PR #1081](https://github.com/3scale/APIcast/pull/1089) [THREESCALE-1234](https://issues.jboss.org/browse/THREESCALE-1234)[THREESCALE-2876](https://issues.jboss.org/browse/THREESCALE-2876)
+- Added http_proxy policy to use an HTTP proxy in api_backed calls. [THREESCALE-2696](https://issues.jboss.org/browse/THREESCALE-2696) [PR #1080](https://github.com/3scale/APIcast/pull/1080)
 
 ## [3.6.0-rc1] - 2019-07-04
 

--- a/gateway/src/apicast/policy/http_proxy/Readme.md
+++ b/gateway/src/apicast/policy/http_proxy/Readme.md
@@ -1,0 +1,81 @@
+# HTTP proxy policy
+
+This policy allows users to define a HTTP proxy where the traffic will be send
+over the defined proxy, the example traffic flow is the following:
+
+```
+   ,-.
+   `-'
+   /|\
+    |            ,-------.          ,---------.          ,----------.
+   / \           |Apicast|          |HTTPPROXY|          |APIBackend|
+  User           `---+---'          `----+----'          `----------'
+   |  GET /resource  |                   |                    |
+   | --------------->|                   |                    |
+   |                 |                   |                    |
+   |                 |  Get /resource    |                    |
+   |                 |------------------>|                    |
+   |                 |                   |                    |
+   |                 |                   |  Get /resource/    |
+   |                 |                   | - - - - - - - - - >|
+   |                 |                   |                    |
+   |                 |                   |     response       |
+   |                 |                   |<- - - - - - - - - -|
+   |                 |                   |                    |
+   |                 |     response      |                    |
+   |                 |<------------------|                    |
+   |                 |                   |                    |
+   |                 |                   |                    |
+   | <---------------|                   |                    |
+  User           ,---+---.          ,----+----.          ,----------.
+   ,-.           |Apicast|          |HTTPPROXY|          |APIBackend|
+   `-'           `-------'          `---------'          `----------'
+   /|\
+    |
+   / \
+```
+
+All APIcast traffic to 3scale backend will not use the proxy, due to this only
+applies for the service and the communication between Apicast and API backend.
+
+If you want to use all traffic through a Proxy, an HTTP_PROXY env var need to be
+used.
+
+## Configuration
+
+```
+"policy_chain": [
+    {
+      "name": "apicast.policy.apicast"
+    },
+    {
+      "name": "apicast.policy.http_proxy",
+      "configuration": {
+          "all_proxy": "http://192.168.15.103:8888/",
+          "https_proxy": "https://192.168.15.103:8888/",
+          "http_proxy": "https://192.168.15.103:8888/"
+      }
+    }
+]
+```
+
+- If http_proxy or https_proxy is not defined the all_proxy will be taken. 
+
+## Caveats
+
+- This policy will disable all load-balancing policies and traffic will be
+  always send to the proxy. 
+- In case of HTTP_PROXY, HTTPS_PROXY or ALL_PROXY parameters are defined, this
+  policy will overwrite those values. 
+- Proxy connection does not support authentication.
+
+
+## Example Use case
+
+This policy was designed to be able to apply more fined grained policies and
+transformation using Apache Camel.
+
+An example project can be found
+[here](https://github.com/zregvart/camel-netty-proxy). This project is an HTTP
+Proxy that transforms to uppercase all the response body given by the API
+backend.

--- a/gateway/src/apicast/policy/http_proxy/apicast-policy.json
+++ b/gateway/src/apicast/policy/http_proxy/apicast-policy.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "Proxy service",
+  "summary": "Adds an HTTP proxy to the service.",
+  "description": [
+    "With this policy all the traffic for this service will be routed accross ",
+    "the defined proxy"
+  ],
+  "version": "builtin",
+  "configuration": {
+      "type": "object",
+      "properties": {
+        "all_proxy": {
+          "description": "Defines a HTTP proxy to be used for connecting to services if a protocol-specific proxy is not specified. Authentication is not supported.",
+          "type": "string"
+        },
+        "https_proxy": {
+          "description": "Defines a HTTPS proxy to be used for connecting to HTTPS services. Authentication is not supported",
+          "type": "string"
+        },
+        "http_proxy": {
+          "description": "Defines a HTTP proxy to be used for connecting to HTTP services. Authentication is not supported",
+          "type": "string"
+        }
+      }
+  }
+}

--- a/gateway/src/apicast/policy/http_proxy/init.lua
+++ b/gateway/src/apicast/policy/http_proxy/init.lua
@@ -1,0 +1,1 @@
+return require("proxy")

--- a/gateway/src/apicast/policy/http_proxy/proxy.lua
+++ b/gateway/src/apicast/policy/http_proxy/proxy.lua
@@ -1,0 +1,48 @@
+local policy = require('apicast.policy')
+local _M = policy.new('http_proxy', 'builtin')
+
+local resty_url = require 'resty.url'
+local ipairs = ipairs
+
+local new = _M.new
+
+local proxies = {"http", "https"}
+
+function _M.new(config)
+  local self = new(config)
+  self.proxies = {}
+
+  if config.all_proxy then
+    local err
+    self.all_proxy, err =  resty_url.parse(config.all_proxy)
+    if err then
+      ngx.log(ngx.WARN, "All proxy '", config.all_proxy, "' is not correctly defined, err:", err)
+    end
+  end
+
+  for _, proto in ipairs(proxies) do
+    local val, err =  resty_url.parse(config[string.format("%s_proxy", proto)])
+    if err then
+      ngx.log(ngx.WARN, proto, " proxy is not correctly defined, err: ", err)
+    end
+    self.proxies[proto] = val or self.all_proxy
+  end
+  return self
+end
+
+local function find_proxy(self, scheme)
+  return self.proxies[scheme]
+end
+
+function _M:export()
+  return  {
+    get_http_proxy = function(uri)
+      if not uri.scheme then
+        return nil
+      end
+      return find_proxy(self, uri.scheme)
+    end
+  }
+end
+
+return _M

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -179,11 +179,19 @@ end
 function _M:call(context)
     if ngx.headers_sent then return nil, 'response sent already' end
 
-    local proxy_uri = http_proxy.find(self)
+    local proxy_uri
+
+    -- get_http_proxy is a property set by the http_proxy policy
+    if context.get_http_proxy then
+      proxy_uri = context.get_http_proxy(self.uri)
+    else
+      proxy_uri = http_proxy.find(self)
+    end
 
     if proxy_uri then
         ngx.log(ngx.DEBUG, 'using proxy: ', proxy_uri)
-        -- https requests will be terminated, http will be rewritten and sent to a proxy
+        -- https requests will be terminated, http will be rewritten and sent
+        -- to a proxy
         http_proxy.request(self, proxy_uri)
     else
         self:rewrite_request()

--- a/gateway/src/resty/http/proxy.lua
+++ b/gateway/src/resty/http/proxy.lua
@@ -108,7 +108,9 @@ local function find_proxy_url(request)
     local uri = parse_request_uri(request)
     if not uri then return end
 
-    return _M.find(uri)
+    -- request can have a local proxy defined and env variables have lower
+    -- priority, if the proxy is defined in the request that will be used.
+    return request.proxy_uri or _M.find(uri)
 end
 
 local function connect(request)

--- a/spec/policy/http_proxy/http_proxy_spec.lua
+++ b/spec/policy/http_proxy/http_proxy_spec.lua
@@ -1,0 +1,61 @@
+local proxy_policy = require('apicast.policy.http_proxy')
+local resty_url = require 'resty.url'
+
+describe('HTTP proxy  policy', function()
+  local all_proxy_val = "http://all.com"
+  local http_proxy_val = "http://plain.com"
+  local https_proxy_val = "http://secure.com"
+
+  local http_uri = {scheme="http"}
+  local https_uri = {scheme="https"}
+
+  it("http[s] proxies are defined if all_proxy is in there", function()
+    local proxy = proxy_policy.new({
+      all_proxy = all_proxy_val
+    })
+    local callback = proxy:export()
+
+    assert.same(callback.get_http_proxy(http_uri), resty_url.parse(all_proxy_val))
+    assert.same(callback.get_http_proxy(https_uri), resty_url.parse(all_proxy_val))
+  end)
+
+  it("all_proxy does not overwrite http/https proxies", function()
+    local proxy = proxy_policy.new({
+      all_proxy = all_proxy_val,
+      http_proxy = http_proxy_val,
+      https_proxy = https_proxy_val
+    })
+    local callback = proxy:export()
+
+    assert.same(callback.get_http_proxy(http_uri), resty_url.parse(http_proxy_val))
+    assert.same(callback.get_http_proxy(https_uri), resty_url.parse(https_proxy_val))
+  end)
+
+  it("empty config return all nil", function()
+    local proxy = proxy_policy.new({})
+    local callback = proxy:export()
+
+    assert.is_nil(callback.get_http_proxy(https_uri))
+    assert.is_nil(callback.get_http_proxy(http_uri))
+  end)
+
+  describe("get_http_proxy callback", function()
+    local callback = proxy_policy.new({
+        all_proxy = all_proxy_val
+    }):export()
+
+    it("Valid protocol", function()
+
+      local result = callback.get_http_proxy(
+        resty_url.parse("http://google.com"))
+      assert.same(result, resty_url.parse(all_proxy_val))
+    end)
+
+    it("invalid protocol", function()
+      local result = callback:get_http_proxy(
+        {}, {scheme="invalid"})
+      assert.is_nil(result)
+    end)
+
+  end)
+end)

--- a/t/apicast-policy-http-proxy.t
+++ b/t/apicast-policy-http-proxy.t
@@ -1,0 +1,175 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+require("t/http_proxy.pl");
+
+repeat_each(3);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: API backend connection uses proxy
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.http_proxy",
+            "configuration": {
+                "http_proxy": "$TEST_NGINX_HTTP_PROXY"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     echo 'yay, api backend';
+  }
+--- request
+GET /?user_key=value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- error_log env
+using proxy: $TEST_NGINX_HTTP_PROXY
+
+=== TEST 2: API backend using all_proxy
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.http_proxy",
+            "configuration": {
+                "all_proxy": "$TEST_NGINX_HTTP_PROXY"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     echo 'yay, api backend';
+  }
+--- request
+GET /?user_key=value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- error_log env
+using proxy: $TEST_NGINX_HTTP_PROXY
+
+
+=== TEST 3: using HTTPS proxy for backend
+--- configuration random_port env
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://test:$TEST_NGINX_RANDOM_PORT",
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.http_proxy",
+            "configuration": {
+                "https_proxy": "$TEST_NGINX_HTTPS_PROXY"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream env
+listen $TEST_NGINX_RANDOM_PORT ssl;
+
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+location /test {
+    echo_foreach_split '\r\n' $echo_client_request_headers;
+    echo $echo_it;
+    echo_end;
+
+    access_by_lua_block {
+       assert = require('luassert')
+       assert.equal('https', ngx.var.scheme)
+       assert.equal('$TEST_NGINX_RANDOM_PORT', ngx.var.server_port)
+       assert.equal('test', ngx.var.ssl_server_name)
+    }
+}
+--- request
+GET /test?user_key=test3
+--- more_headers
+User-Agent: Test::APIcast::Blackbox
+ETag: foobar
+--- response_body env
+GET /test?user_key=test3 HTTP/1.1
+User-Agent: Test::APIcast::Blackbox
+ETag: foobar
+Connection: close
+Host: test:$TEST_NGINX_RANDOM_PORT
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT 127.0.0.1:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- user_files fixture=tls.pl eval
+--- error_log env
+using proxy: $TEST_NGINX_HTTPS_PROXY


### PR DESCRIPTION
This policy adds the option to set a service to use a http proxy (As is
in use for HTTP_PROXY parameter)

This service will allow Apicast users to send the traffic over a proxy
and do request modifications in 3-party proxies.

Traffic flow:

```
	   ,-.
	   `-'
	   /|\
		|            ,-------.          ,---------.          ,----------.
	   / \           |Apicast|          |HTTPPROXY|          |APIBackend|
	  User           `---+---'          `----+----'          `----------'
	   |  GET /resource  |                   |                    |
	   | --------------->|                   |                    |
	   |                 |                   |                    |
	   |                 |  Get /resource    |                    |
	   |                 |------------------>|                    |
	   |                 |                   |                    |
	   |                 |                   |  Get /resource/    |
	   |                 |                   | - - - - - - - - - >|
	   |                 |                   |                    |
	   |                 |                   |     response       |
	   |                 |                   |<- - - - - - - - - -|
	   |                 |                   |                    |
	   |                 |     response      |                    |
	   |                 |<------------------|                    |
	   |                 |                   |                    |
	   |                 |                   |                    |
	   | <---------------|                   |                    |
	  User           ,---+---.          ,----+----.          ,----------.
	   ,-.           |Apicast|          |HTTPPROXY|          |APIBackend|
	   `-'           `-------'          `---------'          `----------'
	   /|\
		|
	   / \

```

Configuration:
```
{
  "services": [
	{
	  "id": 200,
	  "backend_version":  1,
	  "backend_authentication_type": "service_token",
	  "backend_authentication_value": "token-value",
	  "proxy": {
		"hosts": [
		  "one"
		],
		"api_backend": "https://echo-api.3scale.net/",
		"proxy_rules": [
		  {
			"pattern": "/",
			"http_method": "GET",
			"metric_system_name": "hits",
			"delta": 1
		  }
		],
		"policy_chain": [
		  {
			"name": "apicast.policy.apicast"
		  },
		  {
			"name": "apicast.policy.http_proxy",
			"configuration": {
				"all_proxy": "http://192.168.15.103:8888/",
				"https_proxy": "https://192.168.15.103:8888/",
				"http_proxy": "https://192.168.15.103:8888/"
			}
		  }
		]
	  }
	}
  ]
}
```