### PR TITLE
Liquid: extended variables to liquid templating.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Extended variables in Liquid template operations [PR #1081](https://github.com/3scale/APIcast/pull/1081) 
+
 ## [3.6.0-beta1] - 2019-06-18
 
 ### Added

--- a/gateway/src/apicast/policy/ngx_variable.lua
+++ b/gateway/src/apicast/policy/ngx_variable.lua
@@ -7,6 +7,10 @@ local function context_values()
     uri = ngx.var.uri,
     host = ngx.var.host,
     remote_addr = ngx.var.remote_addr,
+    remote_port = ngx.var.remote_port,
+    scheme = ngx.var.scheme,
+    server_addr = ngx.var.server_addr,
+    server_port = ngx.var.server_port,
     headers = ngx.req.get_headers(),
     http_method = ngx.req.get_method(),
   }


### PR DESCRIPTION
Due to a user request, providing more variables to the Liquid templating
to allow headers policy (As axample) to get remote porrt, server address
and port and the scheme.

Fix #1079

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>