### PR TITLE
Bring changes in master to 3.6-stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Extended variables in Liquid template operations [PR #1081](https://github.com/3scale/APIcast/pull/1081) 
+
 ## [3.6.0-beta1] - 2019-06-18
 
 ### Added

--- a/docker-compose-devel-volmount-default.yml
+++ b/docker-compose-devel-volmount-default.yml
@@ -1,0 +1,7 @@
+version: '2.2'
+services:
+  development:
+    volumes:
+      - .:/home/centos/
+      - .docker/cpanm:/home/centos/.cpanm
+

--- a/docker-compose-devel-volmount-mac.yml
+++ b/docker-compose-devel-volmount-mac.yml
@@ -1,0 +1,6 @@
+version: '2.2'
+services:
+  development:
+    volumes:
+      - .:/home/centos/:cached
+      - .docker/cpanm:/home/centos/.cpanm:delegated

--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -6,11 +6,9 @@ services:
       - redis
     working_dir: /home/centos/
     volumes:
-      - .:/home/centos/:cached
       - .docker/lua_modules:/home/centos/lua_modules
       - .docker/local:/home/centos/local
       - .docker/vendor/cache:/home/centos/vendor/cache
-      - .docker/cpanm:/home/centos/.cpanm:delegated
       # no need to access those from docker
       - /home/centos/.docker
       - /home/centos/.git

--- a/gateway/src/apicast/policy/ngx_variable.lua
+++ b/gateway/src/apicast/policy/ngx_variable.lua
@@ -7,6 +7,10 @@ local function context_values()
     uri = ngx.var.uri,
     host = ngx.var.host,
     remote_addr = ngx.var.remote_addr,
+    remote_port = ngx.var.remote_port,
+    scheme = ngx.var.scheme,
+    server_addr = ngx.var.server_addr,
+    server_port = ngx.var.server_port,
     headers = ngx.req.get_headers(),
     http_method = ngx.req.get_method(),
   }


### PR DESCRIPTION
This PR merges `master` from `3.6-stable`. Notice that the base branch in this PR is `3.6-stable`.
`master` includes a couple of PRs that we'd like to include in the next 3.6.x release: #1067 and #1081 