### PR TITLE
release: 3.6.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [3.6.0-rc1] - 2019-07-04
+
 ### Added
 
 - Extended variables in Liquid template operations [PR #1081](https://github.com/3scale/APIcast/pull/1081) 
@@ -645,7 +647,7 @@ expressed might change in future releases.
 ### Changed
 - Major rewrite using JSON configuration instead of code generation.
 
-[Unreleased]: https://github.com/3scale/apicast/compare/v3.6.0-beta1...HEAD
+[Unreleased]: https://github.com/3scale/apicast/compare/v3.6.0-rc1...HEAD
 [2.0.0]: https://github.com/3scale/apicast/compare/v0.2...v2.0.0
 [3.0.0-alpha1]: https://github.com/3scale/apicast/compare/v2.0.0...v3.0.0-alpha1
 [3.0.0-alpha2]: https://github.com/3scale/apicast/compare/v3.0.0-alpha1...v3.0.0-alpha2
@@ -682,3 +684,4 @@ expressed might change in future releases.
 [3.5.0]: https://github.com/3scale/apicast/compare/v3.5.0-beta1...v3.5.0
 [3.5.1]: https://github.com/3scale/apicast/compare/v3.5.0...v3.5.1
 [3.6.0-beta1]: https://github.com/3scale/apicast/compare/v3.5.1...v3.6.0-beta1
+[3.6.0-rc1]: https://github.com/3scale/apicast/compare/v3.6.0-beta1...v3.6.0-rc1

--- a/gateway/src/apicast/version.lua
+++ b/gateway/src/apicast/version.lua
@@ -1,1 +1,1 @@
-return "3.6.0-beta1"
+return "3.6.0"


### PR DESCRIPTION
Notice that the base branch of this PR is `3.6-stable`.
The travis build fails because there's a link in the changelog to a tag that will be created after merging.