### PR TITLE
Policy: logging add custom access log options (JSON, Service vars, NGX vars)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Introduce possibility of specifying policy order restrictions in their schemas. APIcast now shows a warning when those restrictions are not respected [#1088](https://github.com/3scale/APIcast/pull/1088), [THREESCALE-2896](https://issues.jboss.org/browse/THREESCALE-2896)
+- Added new parameters to logging policy to allow custom access log [PR #1081](https://github.com/3scale/APIcast/pull/1089) [THREESCALE-1234](https://issues.jboss.org/browse/THREESCALE-1234)[THREESCALE-2876](https://issues.jboss.org/browse/THREESCALE-2876)
 
 ## [3.6.0-rc1] - 2019-07-04
 
 ### Added
 
-- Extended variables in Liquid template operations [PR #1081](https://github.com/3scale/APIcast/pull/1081) 
+- Extended variables in Liquid template operations [PR #1081](https://github.com/3scale/APIcast/pull/1081)[THREESCALE-2927](https://issues.jboss.org/browse/THREESCALE-2927)
 
 ## [3.6.0-beta1] - 2019-06-18
 

--- a/gateway/http.d/apicast.conf.liquid
+++ b/gateway/http.d/apicast.conf.liquid
@@ -1,5 +1,11 @@
 log_format time '[$time_local] $host:$server_port $remote_addr:$remote_port "$request" $status $body_bytes_sent ($request_time) $post_action_impact';
 
+map $status $extended_access_log {
+    default '';
+}
+
+log_format extended escape=none '$extended_access_log';
+
 server {
   listen {{ port.management | default: 8090 }};
   server_name {{ server_name.management | default: 'management _' }};
@@ -45,6 +51,8 @@ server {
 
   set $access_logs_enabled '1';
   access_log {{ access_log_file | default: "/dev/stdout" }} time if=$access_logs_enabled;
+  set $extended_access_logs_enabled '0';
+  access_log {{ access_log_file | default: "/dev/stdout" }} extended if=$extended_access_logs_enabled;
 
   {%- assign http_port = port.apicast | default: 8080 %}
   {%- assign https_port = env.APICAST_HTTPS_PORT %}

--- a/gateway/src/apicast/policy/logging/apicast-policy.json
+++ b/gateway/src/apicast/policy/logging/apicast-policy.json
@@ -4,15 +4,116 @@
   "summary": "Controls logging.",
   "description": [
     "Controls logging. It allows to enable and disable access logs per ",
-    "service."
+    "service. Also it allows to have a custom access logs format per service"
   ],
   "version": "builtin",
   "configuration": {
+    "definitions": {
+      "value_type": {
+        "type": "string",
+        "oneOf": [
+          {
+            "enum": [
+              "plain"
+            ],
+            "title": "Evaluate as plain text."
+          },
+          {
+            "enum": [
+              "liquid"
+            ],
+            "title": "Evaluate as liquid."
+          }
+        ]
+      }
+    },
     "type": "object",
     "properties": {
       "enable_access_logs": {
         "description": "Whether to enable access logs for the service",
         "type": "boolean"
+      },
+      "custom_logging": {
+        "title": "Custom logging format",
+        "description": "A string variable that uses liquid templating to render a custom access log entry. All Nginx variables can be used plus per service entries",
+        "type": "string"
+      },
+      "enable_json_logs": {
+        "description": "To enable logs in json format. Custom logging format will be disabled",
+        "type": "boolean"
+      },
+      "json_object_config": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "key": {
+              "description": "Key for the the json object",
+              "type": "string"
+            },
+            "value": {
+              "description": "String to get request information",
+              "type": "string"
+            },
+            "value_type": {
+              "description": "How to evaluate 'value' field",
+              "$ref": "#/definitions/value_type"
+            } 
+          }
+        }
+      },
+      "condition": {
+        "type": "object",
+        "properties": {
+          "operations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "op": {
+                  "description": "Match operation to compare match field with the provided value",
+                  "type": "string",
+                  "enum": [
+                    "==",
+                    "!=",
+                    "matches"
+                  ]
+                },
+                "match": {
+                  "description": "String to get request information to match",
+                  "type": "string"
+                },
+                "match_type": {
+                  "description": "How to evaluate 'match' value",
+                  "$ref": "#/definitions/value_type"
+                },
+                "value": {
+                  "description": "Value to compare the retrieved match",
+                  "type": "string"
+                },
+                "value_type": {
+                  "description": "How to evaluate 'value' field",
+                  "$ref": "#/definitions/value_type"
+                }
+              },
+              "required": [
+                "op",
+                "match",
+                "match_type",
+                "value",
+                "value_type"
+              ]
+            }
+          },
+          "combine_op": {
+            "type": "string",
+            "enum": [
+              "and",
+              "or"
+            ],
+            "default": "and"
+          }
+        }
       }
     }
   }

--- a/gateway/src/apicast/policy/logging/logging.lua
+++ b/gateway/src/apicast/policy/logging/logging.lua
@@ -1,13 +1,22 @@
 --- Logging policy
 
 local _M  = require('apicast.policy').new('Logging Policy', 'builtin')
-
 local new = _M.new
 
-local default_enable_access_logs = true
+local Condition = require('apicast.conditions.condition')
+local LinkedList = require('apicast.linked_list')
+local Operation = require('apicast.conditions.operation')
+local TemplateString = require('apicast.template_string')
+local cjson = require('cjson')
 
 -- Defined in ngx.conf.liquid and used in the 'access_logs' directive.
 local ngx_var_access_logs_enabled = 'access_logs_enabled'
+local ngx_var_extended_access_logs_enabled = 'extended_access_logs_enabled'
+local ngx_var_extended_access_log = 'extended_access_log'
+
+local default_enable_access_logs = true
+local default_template_type = 'plain'
+local default_combine_op = "and"
 
 -- Returns the value for the ngx var above from a boolean that indicates
 -- whether access logs are enabled or not.
@@ -29,12 +38,115 @@ function _M.new(config)
   end
 
   self.enable_access_logs_val = val_for_ngx_var[enable_access_logs]
+  self.custom_logging = config.custom_logging
+  self.enable_json_logs = config.enable_json_logs
+  self.json_object_config = config.json_object_config or {}
+
+  self:load_condition(config)
 
   return self
 end
 
-function _M:log()
+function _M:load_condition(config)
+  if not config.condition then
+    return
+  end
+
+  ngx.log(ngx.DEBUG, 'Enabling extended log with conditions')
+  local operations = {}
+  for _, operation in ipairs(config.condition.operations) do
+    table.insert( operations,
+      Operation.new(
+        operation.match, operation.match_type,
+        operation.op,
+        operation.value, operation.value_type or default_template_type))
+  end
+  self.condition = Condition.new( operations, config.condition.combine_op or default_combine_op)
+end
+
+local function get_request_context(context)
+  local ctx = { }
+  ctx.req = {
+    headers=ngx.req.get_headers(),
+  }
+
+  ctx.resp = {
+    headers=ngx.resp.get_headers(),
+  }
+
+  ctx.service = context.service or {}
+  return LinkedList.readonly(ctx, ngx.var)
+end
+
+local function enable_extended_access_log()
+  ngx.var[ngx_var_extended_access_logs_enabled] = 1
+end
+
+local function disable_extended_access_log()
+  ngx.var[ngx_var_extended_access_logs_enabled] = 0
+end
+
+local function disable_default_access_logs()
+  ngx.var[ngx_var_access_logs_enabled] = 0
+end
+
+--- log_dump_json: returns an string with the json output.
+local function log_dump_json(self, extended_context)
+  local result = {}
+  for _, value in ipairs(self.json_object_config) do
+    result[value.key] = TemplateString.new(value.value, value.value_type or default_template_type):render(extended_context)
+  end
+
+  local status, data = pcall(cjson.encode, result)
+  if not status then
+    ngx.log(ngx.WARN, "cannot serialize json on logging, err:", data)
+    -- Disable access log due to no valid information can be returned
+    disable_extended_access_log()
+    return ""
+  end
+
+  return data
+end
+
+-- log_dump_line: render the liquid custom_logging value and return it.
+local function log_dump_line(self, extended_context)
+  local tmpl = TemplateString.new(self.custom_logging, "liquid")
+  return tmpl:render(extended_context)
+end
+
+-- get_log_line return the log line based on the kind of log defined in the
+-- service, if Json is enabled will dump a json object, if not will render the
+-- simple log line.
+function _M:get_log_line(extended_context)
+  if self.enable_json_logs then
+    return log_dump_json(self, extended_context)
+  end
+  return log_dump_line(self, extended_context)
+end
+
+
+function _M:use_default_access_logs()
+  return not (self.custom_logging or self.enable_json_logs)
+end
+
+function _M:log(context)
   ngx.var[ngx_var_access_logs_enabled] = self.enable_access_logs_val
+  if self:use_default_access_logs() then
+    return
+  end
+  -- Extended log is now enaled, disable the default access_log
+  disable_default_access_logs()
+
+  local extended_context = get_request_context(context or {})
+  if self.condition and not self.condition:evaluate(extended_context) then
+    -- Access log is disabled here, request does not match, so log is disabled
+    -- for this request
+    disable_extended_access_log()
+    return
+  end
+
+  enable_extended_access_log()
+  ngx.var[ngx_var_extended_access_log] = self:get_log_line(extended_context)
 end
 
 return _M

--- a/gateway/src/apicast/policy/logging/logging.lua
+++ b/gateway/src/apicast/policy/logging/logging.lua
@@ -9,6 +9,8 @@ local Operation = require('apicast.conditions.operation')
 local TemplateString = require('apicast.template_string')
 local cjson = require('cjson')
 
+local ipairs = ipairs
+
 -- Defined in ngx.conf.liquid and used in the 'access_logs' directive.
 local ngx_var_access_logs_enabled = 'access_logs_enabled'
 local ngx_var_extended_access_logs_enabled = 'extended_access_logs_enabled'

--- a/gateway/src/apicast/policy/logging/readme.md
+++ b/gateway/src/apicast/policy/logging/readme.md
@@ -1,8 +1,8 @@
 # Logging policy
 
 This policy has two purposes: one is to enable and disable access log output,
-and and the other is to create a custom access log format for each service and
-be able to set conditions to write custom access log.
+and the other is to create a custom access log format for each service and be
+able to set conditions to write custom access log.
 
 
 ## Exported variables
@@ -20,7 +20,7 @@ response.
 
 ## Examples
 
-### Disabling access log:
+### Disabling access log
 
 ```json
 {
@@ -31,7 +31,7 @@ response.
 }
 ```
 
-### Enabling custom access log:
+### Enabling custom access log
 
 ```json
 {
@@ -43,7 +43,8 @@ response.
 }
 ```
 
-### Enabling custom access log with the service ID:
+### Enabling custom access log with the service identifier
+
 ```json
 {
   "name": "apicast.policy.logging",

--- a/gateway/src/apicast/policy/logging/readme.md
+++ b/gateway/src/apicast/policy/logging/readme.md
@@ -120,6 +120,7 @@ response.
 }
 ```
 
+
 ## Caveats
 
 - If `custom_logging` or `enable_json_logs` property is enabled, default access

--- a/gateway/src/apicast/policy/logging/readme.md
+++ b/gateway/src/apicast/policy/logging/readme.md
@@ -1,0 +1,172 @@
+# Logging policy
+
+This policy has two primary purposes: one is to enable and disable access log
+output, and the second one is to be able to create a custom access log format
+for each service and be able to set conditions to write custom access log. 
+
+
+## Exported variables
+
+Liquid templating can be used on custom logging, the exported variables are:
+
+- NGINX default log_format directive variables, as example: `{{remote_addr}}`.
+[Log format documentation](http://nginx.org/en/docs/http/ngx_http_log_module.html). 
+
+- Response and request headers using `{{req.headers.FOO}}` for getting FOO
+header in the request, or `{{res.headers.FOO}}` to retrieve FOO header on
+response.
+- Service information, as `{{service.id}}` and all service properties as the
+  `THREESCALE_CONFIG_FILE` or `THREESCALE_PORTAL_ENDPOINT` parameters provide.
+
+## Examples
+
+### Disable access log:
+
+```json
+{
+  "name": "apicast.policy.logging",
+  "configuration": {
+    "enable_access_logs": false
+  }
+}
+```
+
+### Enable custom access log:
+
+```json
+{
+  "name": "apicast.policy.logging",
+  "configuration": {
+    "enable_access_logs": false,
+    "custom_logging": "[{{time_local}}] {{host}}:{{server_port}} {{remote_addr}}:{{remote_port}} \"{{request}}\" {{status}} {{body_bytes_sent}} ({{request_time}}) {{post_action_impact}}",
+  }
+}
+```
+
+### Enable custom access log with the service ID:
+```json
+{
+  "name": "apicast.policy.logging",
+  "configuration": {
+    "enable_access_logs": false,
+    "custom_logging": "\"{{request}}\" to service {{service.id}} and {{service.name}}",
+  }
+}
+```
+
+### Write access log in JSON format:
+
+```json
+{
+  "name": "apicast.policy.logging",
+  "configuration": {
+    "enable_access_logs": false,
+    "enable_json_logs": true,
+    "json_object_config": [
+      {
+        "key": "host",
+        "value": "{{host}}",
+        "value_type": "liquid"
+      },
+      {
+        "key": "time",
+        "value": "{{time_local}}",
+        "value_type": "liquid"
+      },
+      {
+        "key": "custom",
+        "value": "custom_method",
+        "value_type": "plain"
+      }
+    ]
+  }
+}
+```
+
+### Write a custom access log only for a successful request.
+
+```json
+{
+  "name": "apicast.policy.logging",
+  "configuration": {
+    "enable_access_logs": false,
+    "custom_logging": "\"{{request}}\" to service {{service.id}} and {{service.name}}",
+    "condition": {
+      "operations": [
+        {"op": "==", "match": "{{status}}", "match_type": "liquid", "value": "200"}
+      ],
+      "combine_op": "and"
+    }
+  }
+}
+```
+
+### Write a custom access log where reponse status match 200 or 500.
+
+```json
+{
+  "name": "apicast.policy.logging",
+  "configuration": {
+    "enable_access_logs": false,
+    "custom_logging": "\"{{request}}\" to service {{service.id}} and {{service.name}}",
+    "condition": {
+      "operations": [
+        {"op": "==", "match": "{{status}}", "match_type": "liquid", "value": "200"},
+        {"op": "==", "match": "{{status}}", "match_type": "liquid", "value": "500"}
+      ],
+      "combine_op": "or"
+    }
+  }
+}
+```
+
+## Caveats
+
+- If `custom_logging` or `enable_json_logs` property is enabled, default access
+  log will be dissabled.
+- If `enable_json_logs` is enabled, `custom_logging` field will be omitted
+
+## Global configuration for all services. 
+
+Logging options can be useful in all services, to avoid having issues with logs
+that are not correctly formated in other services, a custom Apicast environment
+can be set and all services will implement a specifc policy, in this case
+logging.
+
+Here is an example of a policy that is loaded in all services: 
+
+custom_env.lua
+```
+local cjson = require('cjson')
+local PolicyChain = require('apicast.policy_chain')
+local policy_chain = context.policy_chain
+
+local logging_policy_config = cjson.decode([[
+{
+  "enable_access_logs": false,
+  "custom_logging": "\"{{request}}\" to service {{service.id}} and {{service.name}}"
+}
+]])
+
+policy_chain:insert( PolicyChain.load_policy('logging', 'builtin', logging_policy_config), 1) 
+
+return {
+  policy_chain = policy_chain,
+  port = { metrics = 9421 },
+}
+```
+
+To run Apicast with this specific environment: 
+
+```
+docker run --name apicast --rm -p 8080:8080 \
+    -v $(pwd):/config \
+    -e APICAST_ENVIRONMENT=/config/custom_env.lua \
+    -e THREESCALE_PORTAL_ENDPOINT=https://ACCESS_TOKEN@ADMIN_PORTAL_DOMAIN \
+    quay.io/3scale/apicast:master
+```
+
+Key concepts of the docker command: 
+  - Current lua file need to be shared to the container `-v $(pwd):/config`
+  - `APICAST_ENVIRONMENT` variable need to be set to the lua file that is
+    stored on `/config` directory.

--- a/gateway/src/apicast/policy/logging/readme.md
+++ b/gateway/src/apicast/policy/logging/readme.md
@@ -1,13 +1,13 @@
 # Logging policy
 
-This policy has two primary purposes: one is to enable and disable access log
-output, and the second one is to be able to create a custom access log format
-for each service and be able to set conditions to write custom access log. 
+This policy has two purposes: one is to enable and disable access log output,
+and and the other is to create a custom access log format for each service and
+be able to set conditions to write custom access log.
 
 
 ## Exported variables
 
-Liquid templating can be used on custom logging, the exported variables are:
+Liquid templating can be used on custom logging. The exported variables include:
 
 - NGINX default log_format directive variables, as example: `{{remote_addr}}`.
 [Log format documentation](http://nginx.org/en/docs/http/ngx_http_log_module.html). 
@@ -20,7 +20,7 @@ response.
 
 ## Examples
 
-### Disable access log:
+### Disabling access log:
 
 ```json
 {
@@ -31,7 +31,7 @@ response.
 }
 ```
 
-### Enable custom access log:
+### Enabling custom access log:
 
 ```json
 {
@@ -43,7 +43,7 @@ response.
 }
 ```
 
-### Enable custom access log with the service ID:
+### Enabling custom access log with the service ID:
 ```json
 {
   "name": "apicast.policy.logging",
@@ -54,7 +54,8 @@ response.
 }
 ```
 
-### Write access log in JSON format:
+
+### Configuring access logs in JSON format
 
 ```json
 {
@@ -83,7 +84,7 @@ response.
 }
 ```
 
-### Write a custom access log only for a successful request.
+### Configuring a custom access log only for a successful request
 
 ```json
 {
@@ -101,7 +102,9 @@ response.
 }
 ```
 
-### Write a custom access log where reponse status match 200 or 500.
+
+
+### Customizing access logs where reponse status match 200 or 500
 
 ```json
 {
@@ -124,13 +127,14 @@ response.
 ## Caveats
 
 - If `custom_logging` or `enable_json_logs` property is enabled, default access
-  log will be dissabled.
-- If `enable_json_logs` is enabled, `custom_logging` field will be omitted
+  log will be disabled.
+- If `enable_json_logs` is enabled, `custom_logging` field will be omitted.
 
-## Global configuration for all services. 
+## Global configuration for all services
 
-Logging options can be useful in all services, to avoid having issues with logs
-that are not correctly formated in other services, a custom Apicast environment
+
+In all services, logging options help to avoid having issues with logs that are
+not correctly formated in other services, a custom APIcast environment variable
 can be set and all services will implement a specifc policy, in this case
 logging.
 
@@ -157,7 +161,7 @@ return {
 }
 ```
 
-To run Apicast with this specific environment: 
+To run APIcast with this specific environment: 
 
 ```
 docker run --name apicast --rm -p 8080:8080 \
@@ -168,6 +172,6 @@ docker run --name apicast --rm -p 8080:8080 \
 ```
 
 Key concepts of the docker command: 
-  - Current lua file need to be shared to the container `-v $(pwd):/config`
-  - `APICAST_ENVIRONMENT` variable need to be set to the lua file that is
+  - Current Lua file must be shared to the container `-v $(pwd):/config`
+  - `APICAST_ENVIRONMENT` variable must be set to the lua file that is
     stored on `/config` directory.

--- a/spec/policy/logging/logging_spec.lua
+++ b/spec/policy/logging/logging_spec.lua
@@ -1,6 +1,13 @@
 local LoggingPolicy = require('apicast.policy.logging')
+local ngx_variable = require('apicast.policy.ngx_variable')
+local cjson = require('cjson')
 
 describe('Logging policy', function()
+
+  local function access_logs_are_enabled()
+    return ngx.var.access_logs_enabled == '1'
+  end
+
   describe('.log', function()
     before_each(function()
       ngx.var = {}
@@ -11,8 +18,7 @@ describe('Logging policy', function()
         local logging = LoggingPolicy.new({ enable_access_logs = true })
 
         logging:log()
-
-        assert.equals('1', ngx.var.access_logs_enabled)
+        assert.is_true(access_logs_are_enabled())
       end)
     end)
 
@@ -21,8 +27,7 @@ describe('Logging policy', function()
         local logging = LoggingPolicy.new({ enable_access_logs = false })
 
         logging:log()
-
-        assert.equals('0', ngx.var.access_logs_enabled)
+        assert.falsy(access_logs_are_enabled())
       end)
     end)
 
@@ -35,5 +40,173 @@ describe('Logging policy', function()
         assert.equals('1', ngx.var.access_logs_enabled)
       end)
     end)
+  end)
+
+  describe("Extended log", function()
+    local ctx = { service = { id = 123 } }
+
+    local function extended_logs_are_correctly_enabled()
+      assert.falsy(access_logs_are_enabled())
+      assert.equals(1, ngx.var.extended_access_logs_enabled)
+    end
+
+    before_each(function()
+      ngx.var = {foo = "fooValue"}
+      stub(ngx.req, 'get_headers', function() return { bar="barValue" } end)
+      stub(ngx.resp, 'get_headers', function() return { foo="fooValue" } end)
+      stub(ngx_variable, 'available_context', function(context) return context end)
+    end)
+
+    it("Default access log is disabled when is defined", function()
+      local logging = LoggingPolicy.new({custom_logging="foo"})
+      logging:log(ctx)
+
+      extended_logs_are_correctly_enabled()
+      assert.equals("foo", ngx.var.extended_access_log)
+    end)
+
+    it("log message render information from context and ngx.var", function()
+
+      local logging = LoggingPolicy.new({
+        custom_logging=">>{{foo}}::{{service.id}}"
+      })
+      logging:log(ctx)
+      extended_logs_are_correctly_enabled()
+      assert.equals(">>fooValue::123", ngx.var.extended_access_log)
+    end)
+
+    it("log message render response and request headers", function()
+      local logging = LoggingPolicy.new({
+        custom_logging=">>{{resp.headers.foo}}::{{req.headers.bar}}"
+      })
+      logging:log(ctx)
+      extended_logs_are_correctly_enabled()
+      assert.equals(">>fooValue::barValue", ngx.var.extended_access_log)
+    end)
+
+    describe("Conditions", function()
+
+      it("Conditions only log if matches", function()
+        local logging = LoggingPolicy.new({
+          custom_logging = "foo",
+          condition = {
+            operations={{op="==", match="{{ foo }}", match_type="liquid", value="fooValue", value_type="plain"}},
+            combine_op="and"
+          }})
+        logging:log(ctx)
+        extended_logs_are_correctly_enabled()
+        assert.equals("foo", ngx.var.extended_access_log)
+      end)
+
+      it("Validate default combine_op", function()
+        local logging = LoggingPolicy.new({
+          custom_logging = "foo",
+          condition = {
+            operations={{op="==", match="{{ foo }}", match_type="liquid", value="fooValue", value_type="plain"}}
+          }})
+        logging:log(ctx)
+        extended_logs_are_correctly_enabled()
+        assert.equals("foo", ngx.var.extended_access_log)
+      end)
+
+      it("Or combination match one", function()
+        local logging = LoggingPolicy.new({
+          custom_logging = "foo",
+          condition = {
+            operations={
+              {op="==", match="{{ invalid }}", match_type="liquid", value="fooValue", value_type="plain"},
+              {op="==", match="{{ foo }}", match_type="liquid", value="fooValue", value_type="plain"}
+            },
+            combine_op="or"
+          }})
+        logging:log(ctx)
+        extended_logs_are_correctly_enabled()
+        assert.equals("foo", ngx.var.extended_access_log)
+      end)
+
+      it("No Match combination", function()
+        local logging = LoggingPolicy.new({
+          custom_logging = "foo",
+          condition = {
+            operations={{op="==", match="{{ invalid }}", match_type="liquid", value="fooValue", value_type="plain"}},
+            combine_op="and"
+          }})
+        logging:log(ctx)
+        assert.falsy(access_logs_are_enabled())
+        assert.equals(0, ngx.var.extended_access_logs_enabled)
+        assert.is_nil(ngx.var.extended_access_log)
+      end)
+
+      describe("JSON Logs", function()
+
+        local expected_json = cjson.encode({foo="fooValue", bar="barValue"})
+
+        it("valid config", function()
+          local logging = LoggingPolicy.new({
+            enable_json_logs = true,
+            json_object_config = {
+              { key = "foo", value="{{foo}}", value_type="liquid"},
+              { key = "bar", value="{{req.headers.bar}}", value_type="liquid"},
+            }
+          })
+          logging:log(ctx)
+
+          extended_logs_are_correctly_enabled()
+          assert.equals(ngx.var.extended_access_log, expected_json)
+        end)
+
+        it("It is disabled by default", function()
+          local logging = LoggingPolicy.new({
+            custom_logging = "foo",
+          })
+          logging:log(ctx)
+
+          extended_logs_are_correctly_enabled()
+          assert.equals(ngx.var.extended_access_log, "foo")
+        end)
+
+
+        it("empty config logs empty json object", function()
+          local logging = LoggingPolicy.new({
+            enable_json_logs = true
+          })
+          logging:log(ctx)
+
+          extended_logs_are_correctly_enabled()
+          assert.equals(ngx.var.extended_access_log, '{}')
+        end)
+
+
+        it("render correctly liquid and plain entries", function()
+          local logging = LoggingPolicy.new({
+            enable_json_logs = true,
+            json_object_config = {
+              { key = "foo", value="{{foo}}", value_type="liquid"},
+              { key = "bar", value="barValue", value_type="plain"},
+            }
+          })
+          logging:log(ctx)
+
+          extended_logs_are_correctly_enabled()
+          assert.equals(ngx.var.extended_access_log, expected_json)
+        end)
+
+        it("Duplicated keys only render the last one", function()
+          local logging = LoggingPolicy.new({
+            enable_json_logs = true,
+            json_object_config = {
+              { key = "foo", value="{{foo}}", value_type="liquid"},
+              { key = "bar", value="barValue", value_type="liquid"},
+              { key = "bar", value="{{req.headers.bar}}", value_type="liquid"},
+            }
+          })
+          logging:log(ctx)
+
+          assert.falsy(access_logs_are_enabled())
+          assert.equals(ngx.var.extended_access_log, expected_json)
+        end)
+      end)
+    end)
+
   end)
 end)


### PR DESCRIPTION
Some users requested different ways to log the access log with more metadata,
different formats or conditional logging based on multiple request values. 

This policy address this, two new variables are now set, where to allow or disallow
to print a custom log message, and another one `extened_access_log` just store
all the information to print that. 

The policy has multiple options, here a few examples:

Custom log format
```
{
  "name": "apicast.policy.logging",
  "configuration": {
    "enable_access_logs": false
    "custom_logging": "\"{{request}}\" to service {{service.id}} and {{service.name}}",
  }
}
```

Only log the entry if the status is 200

```
{
  "name": "apicast.policy.logging",
  "configuration": {
    "enable_access_logs": false
    "custom_logging": "\"{{request}}\" to service {{service.id}} and {{service.name}}",
    "condition": {
      "operations": [
        {"op": "==", "match": "{{status}}", "match_type": "liquid", "value": "200"}
      ],
      "combine_op": "and"
    }
  }
}
```

This pr fixed #1082 and THREESCALE-1234 and THREESCALE-2876