### PR TITLE
Openshift: delete dnsmasq procces [THREESCALE-1555]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added http_proxy policy to use an HTTP proxy in api_backed calls. [THREESCALE-2696](https://issues.jboss.org/browse/THREESCALE-2696) [PR #1080](https://github.com/3scale/APIcast/pull/1080)
 - Option to load service configurations one by one lazily [PR #1099](https://github.com/3scale/APIcast/pull/1099)
 - New maintenance mode policy, useful for maintenance periods. [PR #1105](https://github.com/3scale/APIcast/pull/1105), [THREESCALE-3189](https://issues.jboss.org/browse/THREESCALE-3189)
+- Remove dnsmasq process for APIcast [PR #1090](https://github.com/3scale/APIcast/pull/1090), [THREESCALE-1555](https://issues.jboss.org/browse/THREESCALE-1555)
 
 ## [3.6.0-rc1] - 2019-07-04
 
 ### Added
 
 - Extended variables in Liquid template operations [PR #1081](https://github.com/3scale/APIcast/pull/1081)[THREESCALE-2927](https://issues.jboss.org/browse/THREESCALE-2927)
+
 
 ## [3.6.0-beta1] - 2019-06-18
 

--- a/gateway/.s2i/bin/run
+++ b/gateway/.s2i/bin/run
@@ -18,12 +18,4 @@ else
   apicast=apicast
 fi
 
-dnsmasq --listen-address=127.0.0.1 --port=5353 \
-  --all-servers --no-host --no-hosts \
-  --cache-size=1000 --no-negcache --domain-needed \
-  --server="${RESOLVER:-}" \
-  --log-facility=- ${DNSMASQ_OPTIONS:-} \
-
-export RESOLVER=127.0.0.1:5353
-
 exec "${apicast}" "$@"


### PR DESCRIPTION
DNSmasq process was not handled by Apicast at all, dnsmasq process can
die and
will never be up, so dns queries will start to fail.

The reasons to have APICast were:

    Openshift cluster provided multiple DNS servers in the resolv.conf:
    not anymore, currently is using a Kubernetes service with static IP, so
    all connections goes to the same service.
    DNS service was block during pod updates, no longer a case, it's
    working correctly, added more pods in to a service and do not have the
    case.
    Cache was not used, no longer needed due to resolver.search_dns is
    looking for the full query in the cache before make the dns request to
    the server. [0]

[0]
https://github.com/3scale/APIcast/blob/41ad2c2a04054cd05991a65fc807a8105cdb2fd6/gateway/src/resty/resolver.lua#L282-L302

Fix THREESCALE-1555

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>