### PR TITLE
CIRCLE: bump Openresty to 1.15.1 version.

### DIFF
--- a/script/install/circleci.sh
+++ b/script/install/circleci.sh
@@ -20,7 +20,7 @@ apt update
 
 echo manual > /etc/init/openresty.override
 
-export OPENRESTY_VERSION="1.13.6.2-1~trusty1"
+export OPENRESTY_VERSION="1.15.8.1-1~trusty1"
 
 apt install -y cpanminus liblocal-lib-perl libev-dev luarocks python-pip systemtap libyaml-dev
 apt install -y openresty=$OPENRESTY_VERSION openresty-debug=$OPENRESTY_VERSION openresty-opm=$OPENRESTY_VERSION openresty-resty=$OPENRESTY_VERSION openresty-debug-dbgsym=$OPENRESTY_VERSION openresty-openssl-debug-dbgsym openresty-pcre-dbgsym openresty-zlib-dbgsym


### PR DESCRIPTION
Missed from commit `7910917d5388ad0c445837bf0b6dec6879bb3dc1` and
Circleci is not testing the profile target with the last openresty
version.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>