### PR TITLE
Backport: spec/resty/http_ng/backend/async_resty: fix ssl test

### DIFF
--- a/spec/resty/http_ng/backend/async_resty_spec.lua
+++ b/spec/resty/http_ng/backend/async_resty_spec.lua
@@ -58,7 +58,7 @@ describe('resty backend', function()
       local response = backend:send(req)
 
       assert.truthy(response)
-      assert.match('unable to get local issuer certificate', response.error)
+      assert.match('self signed certificate in certificate chain', response.error)
       assert.equal(req, response.request)
       assert.falsy(response.ok)
     end)


### PR DESCRIPTION
The error message changed because of this commit:
https://github.com/chromium/badssl.com/commit/6806596afaca81090df1965e59f99eae33674d56