### PR TITLE
Load service configs one by one lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Introduce possibility of specifying policy order restrictions in their schemas. APIcast now shows a warning when those restrictions are not respected [#1088](https://github.com/3scale/APIcast/pull/1088), [THREESCALE-2896](https://issues.jboss.org/browse/THREESCALE-2896)
 - Added new parameters to logging policy to allow custom access log [PR #1081](https://github.com/3scale/APIcast/pull/1089) [THREESCALE-1234](https://issues.jboss.org/browse/THREESCALE-1234)[THREESCALE-2876](https://issues.jboss.org/browse/THREESCALE-2876)
 - Added http_proxy policy to use an HTTP proxy in api_backed calls. [THREESCALE-2696](https://issues.jboss.org/browse/THREESCALE-2696) [PR #1080](https://github.com/3scale/APIcast/pull/1080)
+- Option to load service configurations one by one lazily [PR #1099](https://github.com/3scale/APIcast/pull/1099)
 
 ## [3.6.0-rc1] - 2019-07-04
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -51,6 +51,25 @@ Double colon (`:`) separated list of environments (or paths) APIcast should load
 It can be used instead of `-e` or `---environment` parameter on the CLI and for example
 stored in the container image as default environment. Any value passed on the CLI overrides this variable.
 
+### `APICAST_LOAD_SERVICES_WHEN_NEEDED`
+**Values:**
+- `true` or `1` for _true_
+- `false`, `0` or empty for _false_
+
+**Default:** _false_
+
+This option might be useful for users with many services configured. By default,
+APIcast loads all the services each time it downloads its configuration from the
+admin portal. With a large number of services, this could become problematic.
+When this option is enabled, the configurations are loaded lazily. APIcast will
+only load the ones configured for the host specified in the host header of the
+request.
+
+Notes:
+- The caching defined by `APICAST_CONFIGURATION_CACHE` applies.
+- This option will be disabled when `APICAST_CONFIGURATION_LOADER` is `boot`.
+- Not compatible with `APICAST_PATH_ROUTING`.
+
 ### `APICAST_LOG_FILE`
 
 **Default:** _stderr_

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -58,12 +58,16 @@ stored in the container image as default environment. Any value passed on the CL
 
 **Default:** _false_
 
-This option might be useful for users with many services configured. By default,
-APIcast loads all the services each time it downloads its configuration from the
-admin portal. With a large number of services, this could become problematic.
-When this option is enabled, the configurations are loaded lazily. APIcast will
-only load the ones configured for the host specified in the host header of the
-request.
+This option can be used when there are many services configured. However, its
+performance depends on additional factors such as the number of services, the
+latency between APIcast and the 3scale Admin Portal, the Time To Live (TTL) of
+the configuration, etc.
+
+By default, APIcast loads all the services each time it downloads its
+configuration from the Admin Portal. With a large number of services, this could
+become problematic. When this option is enabled, the configurations are loaded
+lazily. APIcast will only load the ones configured for the host specified in the
+host header of the request.
 
 Notes:
 - The caching defined by `APICAST_CONFIGURATION_CACHE` applies.

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -358,12 +358,16 @@ UwIDAQAB
 
       assert.equals(1, #(cjson.decode(config).services))
     end)
-  end)
 
-  describe('.call', function()
-    it('gets environment from ENV', function()
-      local _, err = loader.call()
-      assert.equal('missing environment', err)
+    it('returns nil and an error if the config is not a valid', function()
+      env.set('THREESCALE_DEPLOYMENT_ENV', 'production')
+      test_backend.expect{ url = 'http://example.com/something/with/path/production.json?host=foobar.example.com' }.
+      respond_with{ status = 200, body = '{ invalid json }'}
+
+      local config, err = loader:index('foobar.example.com')
+
+      assert.is_nil(config)
+      assert.equals('Expected object key string but found invalid token at character 3', err)
     end)
   end)
 end)

--- a/t/configuration-loading-when-needed.t
+++ b/t/configuration-loading-when-needed.t
@@ -1,0 +1,53 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: loads only the services associated with the host of the request
+The important thing in this test is that it only defines the endpoint to get
+services by host. If the feature was not well implemented we would notice
+because it would try to fetch the services from the other endpoints which are
+not defined in this test.
+--- env eval
+(
+  'APICAST_CONFIGURATION' => "http://test:$ENV{TEST_NGINX_SERVER_PORT}",
+  'APICAST_CONFIGURATION_LOADER' => 'lazy',
+  'THREESCALE_DEPLOYMENT_ENV' => 'production',
+  'APICAST_LOAD_SERVICES_WHEN_NEEDED' => 'true',
+)
+--- upstream env
+location = /admin/api/services/proxy/configs/production.json {
+  content_by_lua_block {
+    expected = "host=localhost"
+    require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+
+    local response = {
+      proxy_configs = {
+        {
+          proxy_config = {
+            version = 1,
+            environment = 'production',
+            content = { id = 42, backend_version = 1 }
+          }
+        }
+      }
+    }
+
+    ngx.say(require('cjson').encode(response))
+  }
+}
+
+--- test
+content_by_lua_block {
+  require('resty.env').set('APICAST_CONFIGURATION_LOADER', 'lazy')
+  local configuration = require('apicast.configuration_loader').load('localhost')
+  ngx.say(require('cjson').encode(configuration))
+}
+
+--- error_code: 200
+--- response_body
+"{\"services\":[{\"id\":42,\"backend_version\":1}],\"oidc\":[false]}"
+--- no_error_log
+[error]


### PR DESCRIPTION
This PR adds the option to add service configurations lazily.

This might be useful for users with many services configured. By default, APIcast loads all the services each time it downloads its configuration from the 3scale admin portal. With a large number of services, this could become problematic.

When this option is enabled, the configurations are loaded lazily. APIcast will only load the ones configured for the host specified in the host header of the request.

The option is not enabled by default. It is enabled using the `APICAST_LOAD_SERVICES_WHEN_NEEDED` env.

The PR also includes a couple of commits that clean up a bit the `remote_v2` module used in this PR and also adds some comments.