### PR TITLE
Routing Policy  enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Option to load service configurations one by one lazily [PR #1099](https://github.com/3scale/APIcast/pull/1099), [THREESCALE-3168](https://issues.jboss.org/browse/THREESCALE-3168)
 - New maintenance mode policy, useful for maintenance periods. [PR #1105](https://github.com/3scale/APIcast/pull/1105), [THREESCALE-3189](https://issues.jboss.org/browse/THREESCALE-3189)
 - Remove dnsmasq process for APIcast [PR #1090](https://github.com/3scale/APIcast/pull/1090), [THREESCALE-1555](https://issues.jboss.org/browse/THREESCALE-1555)
+- Enable liquid operations and original request variable on routing policy [PR #1103](https://github.com/3scale/APIcast/pull/1103) [THREESCALE-3239](https://issues.jboss.org/browse/THREESCALE-3239)
 - Allow to use capture function in liquid templates. [PR #1107](https://github.com/3scale/APIcast/pull/1107), [THREESCALE-1911](https://issues.jboss.org/browse/THREESCALE-1911)
 - OAuth 2.0 MTLS policy [PR #1101](https://github.com/3scale/APIcast/pull/1101) [Issue #1003](https://github.com/3scale/APIcast/issues/1003)
 - Add an option to enable keepalive_timeout on gateway [THREESCALE-2886](https://issues.jboss.org/browse/THREESCALE-2886) [PR #1106](https://github.com/3scale/APIcast/pull/1106)
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix issues when OPENTRACING_FORWARD_HEADER was set [PR #1109](https://github.com/3scale/APIcast/pull/1109), [THREESCALE-1660](https://issues.jboss.org/browse/THREESCALE-1660)
 - New TLS termination policy [PR #1108](https://github.com/3scale/APIcast/pull/1108), [THREESCALE-2898](https://issues.jboss.org/browse/THREESCALE-2898)
+
 
 ## [3.6.0-rc1] - 2019-07-04
 

--- a/gateway/src/apicast/executor.lua
+++ b/gateway/src/apicast/executor.lua
@@ -37,6 +37,28 @@ local function build_context(executor)
     return linked_list.readwrite({}, config)
 end
 
+local function store_original_request(context)
+  -- There are a few phases[0] that req and var are not set and API is
+  -- disabled. The reason to call this using a pcall function is to avoid to
+  -- define the phases manually that are error prone. Also in openresty there
+  -- is not a good method to check this. [1]
+  -- [0] invalid phases: init_worker, init, timer and ssl_cer
+  -- [1] https://github.com/openresty/lua-resty-core/blob/9937f5d83367e388da4fcc1d7de2141c9e38d7e2/lib/resty/core/request.lua#L96
+  if context.original_request then
+    return
+  end
+
+  pcall(function()
+    context.original_request = linked_list.readonly({
+      headers = ngx.req.get_headers(),
+      host = ngx.var.host,
+      path = ngx.var.request_uri,
+      uri = ngx.var.uri,
+      server_addr = ngx.var.server_addr,
+    })
+  end)
+end
+
 local function shared_build_context(executor)
     local ok, ctx = pcall(function() return ngx.ctx end)
     if not ok then
@@ -47,8 +69,8 @@ local function shared_build_context(executor)
 
     if not context then
         context = build_context(executor)
-
         ctx.context = context
+        store_original_request(ctx)
     end
 
     return context

--- a/gateway/src/apicast/executor.lua
+++ b/gateway/src/apicast/executor.lua
@@ -44,7 +44,8 @@ local function store_original_request(context)
   -- is not a good method to check this. [1]
   -- [0] invalid phases: init_worker, init, timer and ssl_cer
   -- [1] https://github.com/openresty/lua-resty-core/blob/9937f5d83367e388da4fcc1d7de2141c9e38d7e2/lib/resty/core/request.lua#L96
-  if context.original_request then
+  --
+  if not context or context.original_request then
     return
   end
 
@@ -70,6 +71,9 @@ local function shared_build_context(executor)
     if not context then
         context = build_context(executor)
         ctx.context = context
+    end
+
+    if not ctx.original_request then
         store_original_request(ctx)
     end
 

--- a/gateway/src/apicast/policy/ngx_variable.lua
+++ b/gateway/src/apicast/policy/ngx_variable.lua
@@ -5,6 +5,7 @@ local _M = {}
 local function context_values()
   return {
     uri = ngx.var.uri,
+    path = ngx.var.path,
     host = ngx.var.host,
     remote_addr = ngx.var.remote_addr,
     remote_port = ngx.var.remote_port,

--- a/gateway/src/apicast/policy/routing/README.md
+++ b/gateway/src/apicast/policy/routing/README.md
@@ -340,6 +340,35 @@ the path is not `/accounts`:
     }
   }
 ```
+## Liquid templating on match
+
+It is possible to use liquid templating in the match section. This allows to
+define rules with dynamic information and provide a way to match with any
+request info.
+
+```json
+  {
+    "name": "routing",
+    "version": "builtin",
+    "configuration": {
+      "rules": [
+        {
+          "url": "http://example.com",
+          "condition": {
+            "operations": [
+              {
+                "match": "liquid",
+                "liquid_value": "{{original_request.path}}",
+                "op": "matches",
+                "value": "/bridge-1"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+```
 
 ## Liquid templating
 

--- a/gateway/src/apicast/policy/routing/apicast-policy.json
+++ b/gateway/src/apicast/policy/routing/apicast-policy.json
@@ -31,7 +31,8 @@
               "path",
               "header",
               "query_arg",
-              "jwt_claim"
+              "jwt_claim",
+              "liquid"
             ]
           },
           "op": {
@@ -112,6 +113,21 @@
                 },
                 "required": [
                   "jwt_claim_name"
+                ]
+              },
+              {
+                "properties": {
+                  "match": {
+                    "enum": [
+                      "liquid"
+                    ]
+                  },
+                  "liquid_value" : {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "liquid_value"
                 ]
               },
               {

--- a/gateway/src/apicast/policy/routing/routing_operation.lua
+++ b/gateway/src/apicast/policy/routing/routing_operation.lua
@@ -7,6 +7,7 @@
 
 local setmetatable = setmetatable
 local Operation = require('apicast.conditions.operation')
+local TemplateString = require('apicast.template_string')
 
 local _M = {}
 
@@ -48,6 +49,14 @@ function _M.new_op_with_jwt_claim(jwt_claim_name, op, value, value_type)
   local eval_left_func = function(request)
     local jwt = request:get_validated_jwt()
     return (jwt and jwt[jwt_claim_name]) or nil
+  end
+
+  return new(eval_left_func, op, value, value_type)
+end
+
+function _M.new_op_with_liquid_templating(liquid_expression, op, value, value_type)
+  local eval_left_func = function()
+    return TemplateString.new(liquid_expression or "" , "liquid"):render(ngx.ctx)
   end
 
   return new(eval_left_func, op, value, value_type)

--- a/gateway/src/apicast/policy/routing/rule.lua
+++ b/gateway/src/apicast/policy/routing/rule.lua
@@ -16,6 +16,7 @@ local function value_of_match(thing_to_be_matched, config_condition)
   return (thing_to_be_matched == 'header' and config_condition.header_name) or
     (thing_to_be_matched == 'query_arg' and config_condition.query_arg_name) or
     (thing_to_be_matched == 'jwt_claim' and config_condition.jwt_claim_name) or
+    (thing_to_be_matched == 'liquid' and config_condition.liquid_value) or
     nil
 end
 
@@ -34,6 +35,8 @@ local function init_operation(config_operation)
     return RoutingOperation.new_op_with_query_arg(match_val, op, value, value_type)
   elseif match == 'jwt_claim' then
     return RoutingOperation.new_op_with_jwt_claim(match_val, op, value, value_type)
+  elseif match == 'liquid' then
+    return RoutingOperation.new_op_with_liquid_templating(match_val, op, value, value_type)
   else
     error('Thing to be matched not supported: ' .. match)
   end

--- a/spec/policy/routing/routing_operation_spec.lua
+++ b/spec/policy/routing/routing_operation_spec.lua
@@ -215,6 +215,27 @@ describe('RoutingOperation', function()
       end)
     end)
 
+
+    describe('when the operation involves a liquid expression', function()
+
+      before_each(function()
+        stub(ngx_variable, 'available_context', function() return {foo="bar"} end)
+      end)
+
+      it('evaluates true conditions correctly', function()
+        local operation = RoutingOperation.new_op_with_liquid_templating(
+          "{{foo}}", "==", "bar")
+        assert.is_true(operation:evaluate({}))
+      end)
+
+      it('evaluates false conditions correctly', function()
+        local operation = RoutingOperation.new_op_with_liquid_templating(
+          "{{foo}}", "==", "false")
+        assert.is_false(operation:evaluate({}))
+      end)
+
+    end)
+
     it('can evaluate the right operand as liquid', function()
       -- Stub the available context to avoid depending on ngx.var.*
       stub(ngx_variable, 'available_context', function(context) return context end)


### PR DESCRIPTION
Hi, 

Multiple commits here: 

1) Added original request information in the executor in the ngx.ctx. 
2) Clean a little bit the ngx_variable, I think that nothing wrong around this one, but please have a look. 
Other commits are to allow liquid match in the routing policy to accomplish @ppatierno feedback. 

Regards