### PR TITLE
Liquid: Available context move to readwrite linked list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Option to load service configurations one by one lazily [PR #1099](https://github.com/3scale/APIcast/pull/1099)
 - New maintenance mode policy, useful for maintenance periods. [PR #1105](https://github.com/3scale/APIcast/pull/1105), [THREESCALE-3189](https://issues.jboss.org/browse/THREESCALE-3189)
 - Remove dnsmasq process for APIcast [PR #1090](https://github.com/3scale/APIcast/pull/1090), [THREESCALE-1555](https://issues.jboss.org/browse/THREESCALE-1555)
+- Allow to use capture function in liquid templates. [PR #1107](https://github.com/3scale/APIcast/pull/1107), [THREESCALE-1911](https://issues.jboss.org/browse/THREESCALE-1911)
 
 ## [3.6.0-rc1] - 2019-07-04
 

--- a/gateway/src/apicast/template_string.lua
+++ b/gateway/src/apicast/template_string.lua
@@ -10,6 +10,7 @@ local format = string.format
 local pcall = pcall
 
 local ngx_variable = require('apicast.policy.ngx_variable')
+local LinkedList = require('apicast.linked_list')
 
 local _M = {}
 
@@ -102,7 +103,8 @@ function LiquidTemplateString.new(string)
 end
 
 function LiquidTemplateString:render(context)
-  local available_context = ngx_variable.available_context(context)
+
+  local available_context = LinkedList.readwrite({}, ngx_variable.available_context(context))
 
   return Liquid.Interpreter:new(self.parser):interpret(
     LiquidInterpreterContext:new(available_context),


### PR DESCRIPTION
This commit allows users to use capture in their liquid expressions and
assign variables if they needed.

Due to the available_context return a readonly list, capture function
cannot assign the variable and things start to mess up[0]. Due to allow
users to define variables in liquid is quite bad, a new read-write
linked list is created with an empty table to allow write to a temporal
table.

[0] Exception:
```
2019/08/09 13:51:23 [error] 15620#15620: *9 lua entry thread aborted: runtime error: /home/centos/gateway/src/apicast/linked_list.lua:19: readonly list
stack traceback:
coroutine 0:
        [C]: in function 'error'
        /home/centos/gateway/src/apicast/linked_list.lua:19: in function '__newindex'
        ./lua_modules/share/lua/5.1/liquid.lua:2512: in function 'define_var'
        ./lua_modules/share/lua/5.1/liquid.lua:2459: in function 'visit'
        ./lua_modules/share/lua/5.1/liquid.lua:1975: in function 'render'
        /home/centos/gateway/src/apicast/policy/headers/headers.lua:91: in function 'run_commands'
        /home/centos/gateway/src/apicast/policy/headers/headers.lua:151: in function </home/centos/gateway/src/apicast/policy/headers/headers.lua:147>
        /home/centos/gateway/src/apicast/policy_chain.lua:200: in function 'rewrite'
        ...s/gateway/src/apicast/policy/local_chain/local_chain.lua:59: in function <...s/gateway/src/apicast/policy/local_chain/local_chain.lua:54>
        /home/centos/gateway/src/apicast/policy_chain.lua:200: in function 'rewrite'
        rewrite_by_lua(lua_Iy6Gdl:498):3: in main chunk, client: 172.18.0.1, server: _, request: "GET /bridge-1/?user_key=132 HTTP/1.1", host: "one"

```

Fix THREESCALE-1911

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>