### PR TITLE
Tracing: Fix exception with OPENTRACING_FORWARD_HEADER parameter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Remove dnsmasq process for APIcast [PR #1090](https://github.com/3scale/APIcast/pull/1090), [THREESCALE-1555](https://issues.jboss.org/browse/THREESCALE-1555)
 - Allow to use capture function in liquid templates. [PR #1107](https://github.com/3scale/APIcast/pull/1107), [THREESCALE-1911](https://issues.jboss.org/browse/THREESCALE-1911)
 
+### Fixed
+
+- Fix issues when OPENTRACING_FORWARD_HEADER was set [PR #1109](https://github.com/3scale/APIcast/pull/1109), [THREESCALE-1660](https://issues.jboss.org/browse/THREESCALE-1660)
+
 ## [3.6.0-rc1] - 2019-07-04
 
 ### Added

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -353,7 +353,7 @@ You can choose to mount a different configuration than the provided by default b
 
 **Example:** `/tmp/jaeger/jaeger.json`
 
-### `OPENTRACING_HEADER_FORWARD`
+### `OPENTRACING_FORWARD_HEADER`
 
 **Default:** `uber-trace-id`
 

--- a/gateway/conf.d/apicast.conf
+++ b/gateway/conf.d/apicast.conf
@@ -43,7 +43,7 @@ location = /___http_call {
   #{% endif %}
   #{% if opentracing_tracer != nil or opentracing_forward_header != nil %}
   #   {% capture proxy_set_header_opentracing %}
-  #{#} proxy_set_header {{opentracing_forward_header}} $http_{{ opentracing_forward_header | replace: "-","_" }};
+  #{#} proxy_set_header {{opentracing_forward_header}} $http_{{ opentracing_forward_header | tostring | replace: "-","_" }};
   #   {% endcapture %}
   #   {{ proxy_set_header_opentracing | replace: "#{#}", "" }}
   #{% endif %}

--- a/gateway/src/apicast/cli/template.lua
+++ b/gateway/src/apicast/cli/template.lua
@@ -130,6 +130,10 @@ function _M:interpret(str)
         end
     end)
 
+    filter_set:add_filter('tostring', function(string)
+      return tostring(string)
+    end)
+
     return interpreter:interpret(context, filter_set, resource_limit, filesystem)
 end
 

--- a/t/opentracing.t
+++ b/t/opentracing.t
@@ -39,3 +39,53 @@ qr/uber-trace-id: /
 --- udp_query eval
 qr/jaeger.version/
 --- wait: 10
+
+=== TEST 2: OpenTracing forward header
+Opentracing forward header is send to the upstream.
+--- env eval
+(
+    'OPENTRACING_FORWARD_HEADER' => "foobar"
+)
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "system_name": "foo",
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.upstream",
+            "configuration": {
+              "rules": [
+                {
+                  "regex": "/",
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+    content_by_lua_block {
+      local headers  = ngx.req.get_headers()
+      assert(headers["foobar"] == "value")
+    }
+  }
+--- request
+GET /a_path?
+--- more_headers eval
+"foobar: value"
+--- error_code: 200
+--- no_error_log
+[error]
+--- udp_listen: 6831
+--- udp_reply
+--- udp_query eval
+qr/jaeger.version/
+--- wait: 10


### PR DESCRIPTION
Due to the value of a ENV variable in the apicast.conf is a table,
replace can't be used directly on liquid variables.

This change add a new tostring method in the template to be able to use
string filters on nginx templates.

Added a new method because table need to be used to be able to use
empty conditions.

FIX THREESCALE-1660

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>