### PR TITLE
Devel: set EDITOR to vi

### DIFF
--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -16,6 +16,7 @@ services:
     tty: true
     init: true
     environment:
+      EDITOR: vi
       TEST_NGINX_REDIS_HOST: redis
       TEST_NGINX_BINARY: openresty
       PROJECT_PATH: /home/centos


### PR DESCRIPTION
At the moment, on the development container EDITOR is set to emacs, that
it's not installed at all.

I heavily use c^x + e to edit commands, and for me, having the EDITOR
variable set, it's a must.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>