### PR TITLE
Logging: Added target host on logging policy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Introduce possibility of specifying policy order restrictions in their schemas. APIcast now shows a warning when those restrictions are not respected [#1088](https://github.com/3scale/APIcast/pull/1088), [THREESCALE-2896](https://issues.jboss.org/browse/THREESCALE-2896)
-- Added new parameters to logging policy to allow custom access log [PR #1089](https://github.com/3scale/APIcast/pull/1089), [THREESCALE-1234](https://issues.jboss.org/browse/THREESCALE-1234)[THREESCALE-2876](https://issues.jboss.org/browse/THREESCALE-2876)
+- Added new parameters to logging policy to allow custom access log [PR #1089](https://github.com/3scale/APIcast/pull/1089), [THREESCALE-1234](https://issues.jboss.org/browse/THREESCALE-1234)[THREESCALE-2876](https://issues.jboss.org/browse/THREESCALE-2876), [PR #1116] (https://github.com/3scale/APIcast/pull/1116)
 - Added http_proxy policy to use an HTTP proxy in api_backed calls. [THREESCALE-2696](https://issues.jboss.org/browse/THREESCALE-2696), [PR #1080](https://github.com/3scale/APIcast/pull/1080)
 - Option to load service configurations one by one lazily [PR #1099](https://github.com/3scale/APIcast/pull/1099), [THREESCALE-3168](https://issues.jboss.org/browse/THREESCALE-3168)
 - New maintenance mode policy, useful for maintenance periods. [PR #1105](https://github.com/3scale/APIcast/pull/1105), [THREESCALE-3189](https://issues.jboss.org/browse/THREESCALE-3189)

--- a/gateway/src/apicast/executor.lua
+++ b/gateway/src/apicast/executor.lua
@@ -73,8 +73,8 @@ local function shared_build_context(executor)
         ctx.context = context
     end
 
-    if not ctx.original_request then
-        store_original_request(ctx)
+    if not context.original_request then
+        store_original_request(context)
     end
 
     return context

--- a/gateway/src/apicast/policy/logging/logging.lua
+++ b/gateway/src/apicast/policy/logging/logging.lua
@@ -77,6 +77,7 @@ local function get_request_context(context)
   }
 
   ctx.service = context.service or {}
+  ctx.original_request = context.original_request
   return LinkedList.readonly(ctx, ngx.var)
 end
 

--- a/gateway/src/apicast/policy/routing/routing_operation.lua
+++ b/gateway/src/apicast/policy/routing/routing_operation.lua
@@ -25,29 +25,29 @@ local function new(evaluate_left_side_func, op, value, value_type)
 end
 
 function _M.new_op_with_path(op, value, value_type)
-  local eval_left_func = function(request) return request:get_uri() end
+  local eval_left_func = function(context) return context.request:get_uri() end
   return new(eval_left_func, op, value, value_type)
 end
 
 function _M.new_op_with_header(header_name, op, value, value_type)
-  local eval_left_func = function(request)
-    return request:get_header(header_name)
+  local eval_left_func = function(context)
+    return context.request:get_header(header_name)
   end
 
   return new(eval_left_func, op, value, value_type)
 end
 
 function _M.new_op_with_query_arg(query_arg_name, op, value, value_type)
-  local eval_left_func = function(request)
-    return request:get_uri_arg(query_arg_name)
+  local eval_left_func = function(context)
+    return context.request:get_uri_arg(query_arg_name)
   end
 
   return new(eval_left_func, op, value, value_type)
 end
 
 function _M.new_op_with_jwt_claim(jwt_claim_name, op, value, value_type)
-  local eval_left_func = function(request)
-    local jwt = request:get_validated_jwt()
+  local eval_left_func = function(context)
+    local jwt = context.request:get_validated_jwt()
     return (jwt and jwt[jwt_claim_name]) or nil
   end
 
@@ -55,15 +55,15 @@ function _M.new_op_with_jwt_claim(jwt_claim_name, op, value, value_type)
 end
 
 function _M.new_op_with_liquid_templating(liquid_expression, op, value, value_type)
-  local eval_left_func = function()
-    return TemplateString.new(liquid_expression or "" , "liquid"):render(ngx.ctx)
+  local eval_left_func = function(context)
+    return TemplateString.new(liquid_expression or "" , "liquid"):render(context)
   end
 
   return new(eval_left_func, op, value, value_type)
 end
 
 function _M:evaluate(context)
-  local left_operand_val = self.evaluate_left_side_func(context.request)
+  local left_operand_val = self.evaluate_left_side_func(context)
 
   local op = Operation.new(
     left_operand_val, 'plain', self.op, self.value, self.value_type


### PR DESCRIPTION
This commit add the way to get the target host on logging policy without
getting request headers.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>

Related to #1082 