### PR TITLE
Routing policy: Add a way to replace the path on routing policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Allow to use capture function in liquid templates. [PR #1107](https://github.com/3scale/APIcast/pull/1107), [THREESCALE-1911](https://issues.jboss.org/browse/THREESCALE-1911)
 - OAuth 2.0 MTLS policy [PR #1101](https://github.com/3scale/APIcast/pull/1101) [Issue #1003](https://github.com/3scale/APIcast/issues/1003)
 - Add an option to enable keepalive_timeout on gateway [THREESCALE-2886](https://issues.jboss.org/browse/THREESCALE-2886) [PR #1106](https://github.com/3scale/APIcast/pull/1106)
-
+- Added a new replace path option in routing policy [THREESCALE-3512](https://issues.jboss.org/browse/THREESCALE-3512) [PR #1119](https://github.com/3scale/APIcast/pull/1119)
 
 ### Fixed
 

--- a/gateway/src/apicast/policy/routing/README.md
+++ b/gateway/src/apicast/policy/routing/README.md
@@ -430,3 +430,37 @@ config that specifies `some_host.com` as the host of the Host header:
     }
   }
 ```
+
+
+## Set the path used for upstream
+
+By default, when a request is routed, the policy keeps the request path.
+However, for a certain upstream maybe the path needs to be changed and cannot be
+global due to is specific for the given API.
+
+```json
+  {
+    "name": "routing",
+    "version": "builtin",
+    "configuration": {
+      "rules": [
+        {
+          "url": "http://example.com",
+          "replace_path": "{{ original_request.path | replace: 'v1beta1', 'v1' }}",
+          "condition": {
+            "operations": [
+              {
+                "match": "path",
+                "op": "==",
+                "value": "/v1beta1"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+```
+
+In this case, request original path is `v1beta1` and it'll call to
+`http://example.com/v1/`

--- a/gateway/src/apicast/policy/routing/apicast-policy.json
+++ b/gateway/src/apicast/policy/routing/apicast-policy.json
@@ -154,6 +154,10 @@
             "url": {
               "type": "string"
             },
+            "replace_path": {
+              "type": "string",
+              "description": "Liquid filter to modify the request path to the matched Upstream URL. When no specified, keep the original path"
+            },
             "host_header": {
               "description": "Host for the Host header. When not specified, defaults to the host of the URL.",
               "type": "string"

--- a/gateway/src/apicast/policy/routing/rule.lua
+++ b/gateway/src/apicast/policy/routing/rule.lua
@@ -4,8 +4,9 @@ local tab_insert = table.insert
 local tab_new = require('resty.core.base').new_tab
 local error = error
 
-local RoutingOperation = require('apicast.policy.routing.routing_operation')
 local Condition = require('apicast.conditions.condition')
+local RoutingOperation = require('apicast.policy.routing.routing_operation')
+local TemplateString = require 'apicast.template_string'
 local Upstream = require('apicast.upstream')
 
 local _M = {}
@@ -61,6 +62,10 @@ function _M.new_from_config_rule(config_rule)
 
   if upstream then
     self.url = config_rule.url
+    if config_rule.replace_path then
+        self.replace_path =  TemplateString.new(config_rule.replace_path, "liquid")
+    end
+
     self.host_header = config_rule.host_header
     self.condition = init_condition(config_rule.condition)
     return self

--- a/gateway/src/apicast/policy/routing/upstream_selector.lua
+++ b/gateway/src/apicast/policy/routing/upstream_selector.lua
@@ -32,6 +32,11 @@ function _M.select(_, rules, context)
       if rule.host_header and rule.host_header ~= '' then
         upstream:use_host_header(rule.host_header)
       end
+      if rule.replace_path then
+        upstream:set_path(rule.replace_path:render(context))
+        -- Set uri as nil if not will be appended to the upstream
+        ngx.req.set_uri("/")
+      end
 
       return upstream
     end

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -148,6 +148,10 @@ function _M:use_host_header(host)
     self.host = host
 end
 
+function _M:set_path(path)
+    self.uri.path = path
+end
+
 --- Rewrite request Host header to what is provided in the argument or in the URL.
 function _M:rewrite_request()
     local uri = self.uri

--- a/t/apicast-policy-routing.t
+++ b/t/apicast-policy-routing.t
@@ -1556,3 +1556,134 @@ yay, api backend
 --- error_code: 200
 --- no_error_log
 [error]
+
+
+=== TEST 24: replace path liquid expression
+This test validates that the replace path is working as desired and append
+something to the original path. Upstream location is using a regexp to make
+sure that the ngx.req.set_uri() is called and reset the uri in case of replace
+path
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "replace_path": "{{original_request.path }}-test",
+                  "condition": {
+                    "operations": [
+                      {
+                        "match": "liquid",
+                        "liquid_value": "{{ original_request.path }}",
+                        "op": "==",
+                        "value": "/bridge-1"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "url_rewriting",
+            "configuration": {
+              "commands": [
+                {
+                  "op": "sub",
+                  "regex": "^/bridge",
+                  "replace": "/"
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location ~* /bridge-1-test$ {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /bridge-1
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+=== TEST 25: replace path liquid expression using replace filter
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "replace_path": "{{original_request.path | replace: 'bridge', 'foo' }}-test",
+                  "condition": {
+                    "operations": [
+                      {
+                        "match": "liquid",
+                        "liquid_value": "{{ original_request.path }}",
+                        "op": "==",
+                        "value": "/bridge-1"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "url_rewriting",
+            "configuration": {
+              "commands": [
+                {
+                  "op": "sub",
+                  "regex": "^/bridge",
+                  "replace": "/"
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location ~* /foo-1-test$ {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /bridge-1
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]


### PR DESCRIPTION
Some users complained about that path on upstream can't be changed and a
global rewrite url will not work due each API backend is different, this
policy will update the request path to the liquid value.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>