### PR TITLE
Routing: Fix query args on replace_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Allow to use capture function in liquid templates. [PR #1107](https://github.com/3scale/APIcast/pull/1107), [THREESCALE-1911](https://issues.jboss.org/browse/THREESCALE-1911)
 - OAuth 2.0 MTLS policy [PR #1101](https://github.com/3scale/APIcast/pull/1101) [Issue #1003](https://github.com/3scale/APIcast/issues/1003)
 - Add an option to enable keepalive_timeout on gateway [THREESCALE-2886](https://issues.jboss.org/browse/THREESCALE-2886) [PR #1106](https://github.com/3scale/APIcast/pull/1106)
-- Added a new replace path option in routing policy [THREESCALE-3512](https://issues.jboss.org/browse/THREESCALE-3512) [PR #1119](https://github.com/3scale/APIcast/pull/1119)
+- Added a new replace path option in routing policy [THREESCALE-3512](https://issues.jboss.org/browse/THREESCALE-3512) [PR #1119](https://github.com/3scale/APIcast/pull/1119) [PR #1121](https://github.com/3scale/APIcast/pull/1121)
 
 ### Fixed
 

--- a/gateway/src/apicast/executor.lua
+++ b/gateway/src/apicast/executor.lua
@@ -11,6 +11,7 @@ local Policy = require('apicast.policy')
 local linked_list = require('apicast.linked_list')
 local prometheus = require('apicast.prometheus')
 local uuid = require('resty.jit-uuid')
+local url_helper = require('resty.url_helper')
 
 local setmetatable = setmetatable
 local ipairs = ipairs
@@ -50,10 +51,12 @@ local function store_original_request(context)
   end
 
   pcall(function()
+    local path, query = url_helper.split_path(ngx.var.request_uri)
     context.original_request = linked_list.readonly({
       headers = ngx.req.get_headers(),
       host = ngx.var.host,
-      path = ngx.var.request_uri,
+      path = path,
+      query = query,
       uri = ngx.var.uri,
       server_addr = ngx.var.server_addr,
     })

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -7,17 +7,14 @@
 --- upstream:call(context)
 
 local setmetatable = setmetatable
-local tonumber = tonumber
 local str_format = string.format
 
 local resty_resolver = require('resty.resolver')
 local resty_url = require('resty.url')
-local core_base = require('resty.core.base')
+local url_helper = require('resty.url_helper')
+
 local http_proxy = require('apicast.http_proxy')
-local str_find = string.find
-local str_sub = string.sub
 local format = string.format
-local new_tab = core_base.new_tab
 
 local _M = {
 
@@ -31,45 +28,13 @@ local mt = {
     __index = _M
 }
 
-local function split_path(path)
-    if not path then return end
-
-    local start = str_find(path, '?', 1, true)
-
-    if start then
-        return str_sub(path, 1, start - 1), str_sub(path, start + 1)
-    else
-        return path
-    end
-end
-
-local function parse_url(url)
-    local parsed, err = resty_url.split(url)
-
-    if err then return nil, err end
-
-    local uri = new_tab(0, 6)
-
-    uri.scheme = parsed[1]
-    uri.user = parsed[2]
-    uri.password = parsed[3]
-    uri.host = parsed[4]
-    uri.port = tonumber(parsed[5])
-
-    uri.path, uri.query = split_path(parsed[6])
-
-    return uri
-end
-
-
 --- Create new Upstream instance.
 --- @tparam string url
 --- @treturn Upstream|nil upstream instance
 --- @treturn nil|string error when upstream can't be initialized
 --- @static
 function _M.new(url)
-    local uri, err = parse_url(url)
-
+    local uri, err = url_helper.parse_url(url)
     if err then
         return nil, 'invalid upstream'
     end
@@ -149,7 +114,7 @@ function _M:use_host_header(host)
 end
 
 function _M:set_path(path)
-    self.uri.path = path
+    self.uri.path, self.uri.query = url_helper.split_path(path)
 end
 
 --- Rewrite request Host header to what is provided in the argument or in the URL.

--- a/gateway/src/resty/url_helper.lua
+++ b/gateway/src/resty/url_helper.lua
@@ -1,0 +1,43 @@
+local tonumber = tonumber
+
+local resty_url = require('resty.url')
+local core_base = require('resty.core.base')
+local str_find = string.find
+local str_sub = string.sub
+local new_tab = core_base.new_tab
+
+local _M = {}
+
+function _M.split_path(path)
+    if not path then return end
+
+    local start = str_find(path, '?', 1, true)
+
+    if start then
+        return str_sub(path, 1, start - 1), str_sub(path, start + 1)
+    else
+        return path
+    end
+end
+
+
+
+function _M.parse_url(url)
+    local parsed, err = resty_url.split(url)
+
+    if err then return nil, err end
+
+    local uri = new_tab(0, 6)
+
+    uri.scheme = parsed[1]
+    uri.user = parsed[2]
+    uri.password = parsed[3]
+    uri.host = parsed[4]
+    uri.port = tonumber(parsed[5])
+
+    uri.path, uri.query = _M.split_path(parsed[6])
+
+    return uri
+end
+
+return _M


### PR DESCRIPTION
Due to the changes made in the routing policy to be able to modify
request path the query args was appended, and in this case, unexcaped to
the upstream repo.

This change adds a resty/url_helper function; this code will be moved to
resty-url project in the following weeks.