### PR TITLE
Mapping Rule: Use unescaped rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix issues when OPENTRACING_FORWARD_HEADER was set [PR #1109](https://github.com/3scale/APIcast/pull/1109), [THREESCALE-1660](https://issues.jboss.org/browse/THREESCALE-1660)
 - New TLS termination policy [PR #1108](https://github.com/3scale/APIcast/pull/1108), [THREESCALE-2898](https://issues.jboss.org/browse/THREESCALE-2898)
 - Fix exception on rate limit policy when window was set as 0. [PR #1113](https://github.com/3scale/APIcast/pull/1108), [THREESCALE-3382](https://issues.jboss.org/browse/THREESCALE-3382)
+- Fix issues with escaped characters in uri [THREESCALE-3468](https://issues.jboss.org/browse/THREESCALE-3468) [PR #1123](https://github.com/3scale/APIcast/pull/1123)
 
 ## [3.6.0] - 2019-08-30
 

--- a/gateway/src/resty/http/uri_escape.lua
+++ b/gateway/src/resty/http/uri_escape.lua
@@ -1,0 +1,36 @@
+
+local ffi = require "ffi"
+
+local C = ffi.C
+local ffi_str = ffi.string
+
+ffi.cdef[[
+  uintptr_t ngx_escape_uri(unsigned char *dst, unsigned char *src, size_t size, unsigned int type);
+]]
+
+local ngx_escape_uri = C.ngx_escape_uri
+
+local _M = { }
+
+
+function _M.escape_uri(source_uri)
+  if not source_uri then
+    return ""
+  end
+
+  local source_uri_len = #source_uri
+
+  local source_str = ffi.new("unsigned char[?]", source_uri_len + 1)
+  ffi.copy(source_str, source_uri)
+
+  -- If destination is NUL ngx_escape_uri returns the number of characters that
+  -- are going to be escaped, need to calculate first to make sure to
+  -- allocate the right amount of memory.
+  local escape_len = 2 * ngx_escape_uri(nil, source_str, source_uri_len, 0)
+
+  local dst = ffi.new("unsigned char[?]", source_uri_len + 1 + tonumber(escape_len))
+  ngx_escape_uri(dst, source_str, source_uri_len, 0)
+  return ffi_str(dst) 
+end
+
+return _M

--- a/spec/resty/http/uri_escape_spec.lua
+++ b/spec/resty/http/uri_escape_spec.lua
@@ -1,0 +1,23 @@
+local escape = require("resty.http.uri_escape")
+
+describe('resty.http.uri_escape', function()
+
+  it("escapes uri correctly", function()
+    local test_cases = {
+      {"/foo /test", "/foo%20/test"},
+      {"/foo/test", "/foo/test"},
+      {"/foo/", "/foo/"},
+      {"/foo / test", "/foo%20/%20test"},
+      {"/foo    /  test", "/foo%20%20%20%20/%20%20test"},
+      {"/foo#/test", "/foo%23/test"},
+      {"/foo$/test", "/foo$/test"},
+      {"/foo=/test", "/foo=/test"},
+      {"/foo!/test", "/foo!/test"} ,
+      {"/foo,/test", "/foo,/test"},
+    }
+
+    for _,val in ipairs(test_cases) do
+      assert.are.same(escape.escape_uri(val[1]), val[2])
+    end
+  end)
+end)


### PR DESCRIPTION
This commit address the issues with the mapping rules that normalizes
the URL and mapping rules are not matching correctly.

Fix #1002
Fix THREESCALE-3468

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>