### PR TITLE
APIcast: Updated list of TLS protocols that are available.

### DIFF
--- a/gateway/http.d/apicast.conf.liquid
+++ b/gateway/http.d/apicast.conf.liquid
@@ -63,7 +63,7 @@ server {
 
   {% if https_port -%}
   listen {{ https_port }} ssl;
-
+  ssl_protocols TLSv1.2 TLSv1.3;
   {%- assign https_certificate = env.APICAST_HTTPS_CERTIFICATE -%}
   ssl_certificate {% if https_certificate -%}
     {{  https_certificate }}


### PR DESCRIPTION
Some TLS protocols are already deprecated and need to be removed from
NGinx config to avoid their use.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>