### PR TITLE
Routing: Fix issues with invalid metric update on routing policy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add an option to enable keepalive_timeout on gateway [THREESCALE-2886](https://issues.jboss.org/browse/THREESCALE-2886) [PR #1106](https://github.com/3scale/APIcast/pull/1106)
 - Added a new replace path option in routing policy [THREESCALE-3512](https://issues.jboss.org/browse/THREESCALE-3512) [PR #1119](https://github.com/3scale/APIcast/pull/1119) [PR #1121](https://github.com/3scale/APIcast/pull/1121) [PR #1122](https://github.com/3scale/APIcast/pull/1122)
 - Added usage metrics on logging policy [PR #1126](https://github.com/3scale/APIcast/pull/1126), [THREESCALE-1234](https://issues.jboss.org/browse/THREESCALE-1234)
-
+- Added owner_id on mapping rule and routing_policy [THREESCALE-3623](https://issues.jboss.org/browse/THREESCALE-3623) [PR #1125](https://github.com/3scale/APIcast/pull/1125)
 
 ### Fixed
 

--- a/gateway/src/apicast/mapping_rule.lua
+++ b/gateway/src/apicast/mapping_rule.lua
@@ -13,6 +13,11 @@ local re_match = ngx.re.match
 local insert = table.insert
 local re_gsub = ngx.re.gsub
 
+-- This is introduced by API as a product feature. There are two kinds of
+-- mapping rules owner: `BackendAPI` that means that is used by API as a
+-- product and `Proxy` that means that it's a normal mapping rule.
+local BackendAPIconst = "BackendApi"
+
 local _M = {
   any_method = "ANY"
 }
@@ -79,7 +84,7 @@ local function matches_uri(rule_pattern, uri)
   return re_match(uri, format("^%s", rule_pattern), 'oj')
 end
 
-local function new(http_method, pattern, params, querystring_params, metric, delta, last)
+local function new(http_method, pattern, params, querystring_params, metric, delta, last, owner_id, owner_type)
   local self = setmetatable({}, mt)
 
   local querystring_parameters = hash_to_array(querystring_params)
@@ -91,6 +96,11 @@ local function new(http_method, pattern, params, querystring_params, metric, del
   self.system_name = metric or error('missing metric name of rule')
   self.delta = delta
   self.last = last or false
+
+  if owner_type == BackendAPIconst then
+    self.owner_id = owner_id
+  end
+
 
   self.querystring_params = function(args)
     return matches_querystring_params(querystring_parameters, args)
@@ -123,7 +133,9 @@ function _M.from_proxy_rule(proxy_rule)
     proxy_rule.querystring_parameters,
     proxy_rule.metric_system_name,
     proxy_rule.delta,
-    proxy_rule.last
+    proxy_rule.last,
+    tonumber(proxy_rule.owner_id),
+    proxy_rule.owner_type
   )
 end
 

--- a/gateway/src/apicast/mapping_rules_matcher.lua
+++ b/gateway/src/apicast/mapping_rules_matcher.lua
@@ -52,4 +52,21 @@ function _M.matches(method, uri, args, rules)
   return false
 end
 
+function _M.clean_usage_by_owner_id(rules, owner_id)
+  local usage = Usage.new()
+  if not owner_id then
+      return usage
+  end
+
+  for _, rule in ipairs(rules) do
+    -- Checking that the rule has owner_id, if it does not have owner_id means
+    -- that does not belongs to a backendAPI.
+    if rule.owner_id and owner_id ~= rule.owner_id then
+      usage:add(rule.system_name, 0 - (rule.delta or 0))
+    end
+  end
+
+  return usage
+end
+
 return _M

--- a/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
@@ -200,6 +200,13 @@ end
 function _M:access(context)
   local backend = backend_client:new(context.service, http_ng_resty)
   local usage = context.usage
+
+  -- If routing policy changes the upstream and it only belongs to a specified
+  -- owner, we need to filter out the usage for APIs that are not used at all.
+  if context.route_upstream_usage_cleanup then
+    context:route_upstream_usage_cleanup(usage, ngx.ctx.matched_rules)
+  end
+
   local service = context.service
   local service_id = service.id
   local credentials = context.credentials

--- a/gateway/src/apicast/policy/routing/apicast-policy.json
+++ b/gateway/src/apicast/policy/routing/apicast-policy.json
@@ -158,6 +158,10 @@
               "type": "string",
               "description": "Liquid filter to modify the request path to the matched Upstream URL. When no specified, keep the original path"
             },
+            "owner_id": {
+              "type": "integer",
+              "description": "Value to only increment hits on the mapping rules owner by the same id. "
+            },
             "host_header": {
               "description": "Host for the Host header. When not specified, defaults to the host of the URL.",
               "type": "string"

--- a/gateway/src/apicast/policy/routing/rule.lua
+++ b/gateway/src/apicast/policy/routing/rule.lua
@@ -68,6 +68,7 @@ function _M.new_from_config_rule(config_rule)
 
     self.host_header = config_rule.host_header
     self.condition = init_condition(config_rule.condition)
+    self.owner_id = tonumber(config_rule.owner_id)
     return self
   else
     return nil, 'failed to initialize upstream from url: ',

--- a/gateway/src/apicast/policy/routing/upstream_selector.lua
+++ b/gateway/src/apicast/policy/routing/upstream_selector.lua
@@ -32,6 +32,11 @@ function _M.select(_, rules, context)
       if rule.host_header and rule.host_header ~= '' then
         upstream:use_host_header(rule.host_header)
       end
+
+      if rule.owner_id then
+        upstream:set_owner_id(rule.owner_id)
+      end
+
       if rule.replace_path then
         upstream:append_path(rule.replace_path:render(context))
         -- Set uri as nil if not will be appended to the upstream

--- a/gateway/src/apicast/proxy.lua
+++ b/gateway/src/apicast/proxy.lua
@@ -273,6 +273,7 @@ function _M:rewrite(service, context)
   context.usage:merge(usage)
 
   ctx.usage = context.usage
+  ctx.matched_rules = matched_rules
   ctx.credentials = credentials
 
   var.cached_key = concat(cached_key, ':')
@@ -302,8 +303,15 @@ end
 
 function _M:access(service, usage, credentials, ttl)
   local ctx = ngx.ctx
+  local final_usage = usage or ctx.usage
 
-  return self:authorize(service, usage or ctx.usage, credentials or ctx.credentials, ttl or ctx.ttl)
+  -- If routing policy changes the upstream and it only belongs to a specified
+  -- owner, we need to filter out the usage for APIs that are not used at all.
+  if ctx.context.route_upstream_usage_cleanup then
+    ctx.context:route_upstream_usage_cleanup(final_usage, ctx.matched_rules)
+  end
+  return self:authorize(service, final_usage, credentials or ctx.credentials, ttl or ctx.ttl)
+
 end
 
 local function response_codes_data(status)

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -187,4 +187,12 @@ function _M:call(context)
     return exec(self)
 end
 
+function _M:set_owner_id(owner_id)
+  self.owner_id = owner_id
+end
+
+function _M:has_owner_id()
+  return self.owner_id
+end
+
 return _M

--- a/gateway/src/apicast/usage.lua
+++ b/gateway/src/apicast/usage.lua
@@ -5,6 +5,7 @@
 local setmetatable = setmetatable
 local ipairs = ipairs
 local insert = table.insert
+local remove = table.remove
 
 local _M = {}
 
@@ -42,12 +43,31 @@ function _M:add(metric, value)
   end
 end
 
+-- Remove metric from the usage map.
+-- Note that this mutates self.
+-- @tparam string metrc Metric.
+function _M:remove_metric(metric)
+  local tablefind = function (tab,el)
+    for index, value in pairs(tab) do
+      if value == el then
+        return index
+      end
+    end
+  end
+
+  remove(self.metrics, tablefind(self.metrics, metric))
+  self.deltas[metric] = nil
+end
+
 --- Merge usages
 -- Merges two usages. This means that:
 --
 -- 1) When a metric appears in both usages, its delta is updated in self by
 --    adding the two values.
 -- 2) When a metric does not appear in self, it is added in self.
+--
+-- 3) If the metric added is negative and the result is negative or 0, metric
+-- will be deleted.
 --
 -- Note that this mutates self.
 -- @tparam another_usage Usage Usage.
@@ -58,6 +78,10 @@ function _M:merge(another_usage)
   for _, metric in ipairs(another_usage_metrics) do
     local delta = another_usage_deltas[metric]
     self:add(metric, delta)
+
+    if self.deltas[metric] <= 0 then
+      self:remove_metric(metric)
+    end
   end
 end
 

--- a/spec/policy/routing/routing_spec.lua
+++ b/spec/policy/routing/routing_spec.lua
@@ -17,12 +17,13 @@ describe('Routing policy', function()
 
       it('calls call() on the upstream passing the context as param', function()
         local routing = RoutingPolicy.new()
-        routing.upstream_selector = upstream_selector
 
+        routing.upstream_selector = upstream_selector
+        routing:access(context)
         routing:content(context)
 
         assert.stub(upstream_selector.select).was_called_with(
-          upstream_selector, routing.rules, context
+          upstream_selector, routing.rules, {request=request}
         )
 
         assert.stub(upstream_that_matches.call).was_called_with(
@@ -41,12 +42,9 @@ describe('Routing policy', function()
       it('returns nil and the msg "no upstream"', function()
         local routing = RoutingPolicy.new()
         routing.upstream_selector = upstream_selector
-
+        routing:access(context)
         local res, err = routing:content(context)
 
-        assert.stub(upstream_selector.select).was_called_with(
-          upstream_selector, routing.rules, context
-        )
         assert.is_nil(res)
         assert.equals('no upstream', err)
       end)

--- a/spec/usage_spec.lua
+++ b/spec/usage_spec.lua
@@ -65,6 +65,59 @@ describe('usage', function()
         assert.same({ a = 1 }, a_usage.deltas)
       end)
     end)
+
+    describe("when the given usage is negative", function()
+
+      local usage = Usage.new()
+
+      before_each(function()
+        usage = Usage.new()
+        usage:add("a", 3)
+      end)
+
+      it("keeps metrics if are positive", function()
+        local a_usage = Usage.new()
+        a_usage:add("a", -2)
+
+        usage:merge(a_usage)
+
+        assert.same({ a = 1 }, usage.deltas)
+        assert.same({ "a" }, usage.metrics)
+      end)
+
+      it("Delete metric if value is 0", function()
+        local a_usage = Usage.new()
+        a_usage:add("a", -3)
+
+        usage:merge(a_usage)
+
+        assert.same({  }, usage.deltas)
+        assert.same({ }, usage.metrics)
+      end)
+
+      it("Delete metric if value is equal or bellow 0", function()
+        local a_usage = Usage.new()
+        a_usage:add("a", -4)
+
+        usage:merge(a_usage)
+
+        assert.same({  }, usage.deltas)
+        assert.same({ }, usage.metrics)
+      end)
+
+      it("keep metrics value if one is bellow 0", function()
+        usage:add("b", 10)
+
+        local a_usage = Usage.new()
+        a_usage:add("a", -4)
+
+        usage:merge(a_usage)
+
+        assert.same({ b = 10 }, usage.deltas)
+        assert.same({ "b" }, usage.metrics)
+      end)
+
+    end)
   end)
 
   describe('.metrics', function()

--- a/t/apicast-oauth.t
+++ b/t/apicast-oauth.t
@@ -365,7 +365,7 @@ GET /t
             credentials_location = "query",
             api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'hits' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta=1}
             }
           }
         }
@@ -444,7 +444,7 @@ Location: http://example.com/redirect\?code=\w+&state=12345
             credentials_location = "headers",
             api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'hits' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1 }
             }
           }
         }
@@ -489,7 +489,7 @@ yay, upstream
             error_auth_missing = 'credentials missing!',
             error_status_auth_missing = 401,
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'hits' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1 }
             }
           }
         }
@@ -522,7 +522,7 @@ credentials missing!
             error_auth_missing = 'credentials missing!',
             error_status_auth_missing = 401,
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'hits' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1}
             }
           }
         }
@@ -916,7 +916,7 @@ body is necessary.
             credentials_location = "query",
             api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'hits' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1 }
             }
           }
         }

--- a/t/apicast-policy-3scale-batcher-blackbox.t
+++ b/t/apicast-policy-3scale-batcher-blackbox.t
@@ -1,0 +1,179 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+$ENV{TEST_NGINX_HTML_DIR} ||= "$Test::Nginx::Util::ServRoot/html";
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: Routing policy with owner id reported correctly
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      -- request should not be here, is using batcher.
+      ngx.exit(503)
+    }
+  }
+
+  location /transactions/authorize.xml {
+    content_by_lua_block {
+      if not ngx.shared.test_counter then
+        ngx.shared.test_counter = {}
+      end
+
+      local args = ngx.req.get_uri_args()
+
+      local function validate_key(key, args)
+        if not args[key] then
+          return
+        end
+        local key_test_counter = ngx.shared.test_counter[key] or 0
+        if key_test_counter == 0 then
+          ngx.shared.test_counter[key] = key_test_counter + 1
+          ngx.exit(200)
+        else
+          ngx.log(ngx.ERR, 'auth should be cached but called backend anyway')
+          ngx.exit(502)
+        end
+      end
+      validate_key("usage[test]", args)
+      validate_key("usage[hits]", args)
+    }
+  }
+
+  location /transactions.xml {
+    content_by_lua_block {
+      ngx.req.read_body()
+      local post_args = ngx.req.get_post_args()
+      require('luassert').same(post_args["transactions[0][usage][hits]"], "3")
+      require('luassert').same(post_args["transactions[0][usage][test]"], "1")
+      ngx.exit(200)
+    }
+  }
+
+--- upstream
+  location ~* /second/foo/bar {
+    content_by_lua_block {
+      ngx.say('yay, api backend');
+    }
+  }
+
+  location ~* /one/foo {
+    content_by_lua_block {
+      ngx.say('yay, api backend');
+    }
+  }
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version": 1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT/second/",
+                  "owner_id": 4,
+                  "condition": {
+                    "operations": [
+                      {
+                        "match": "path",
+                        "op": "matches",
+                        "value": "/foo/bar"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT/one/",
+                  "owner_id": 3,
+                  "condition": {
+                    "operations": [
+                      {
+                        "match": "path",
+                        "op": "matches",
+                        "value": "/foo"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.3scale_batcher",
+            "configuration": {
+              "batch_report_seconds" : 1
+            }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ],
+        "proxy_rules": [
+          {
+            "pattern": "/foo/bar",
+            "http_method": "GET",
+            "metric_system_name": "hits",
+            "delta": 1,
+            "owner_id": 4,
+            "owner_type": "BackendApi"
+          },
+          {
+            "pattern": "/foo",
+            "http_method": "GET",
+            "metric_system_name": "test",
+            "delta": 1,
+            "owner_id": 3,
+            "owner_type": "BackendApi"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- test env
+content_by_lua_block {
+  local function request(path)
+    local sock = ngx.socket.tcp()
+    sock:settimeout(2000)
+
+    local ok, err = sock:connect(ngx.var.server_addr, ngx.var.apicast_port)
+    if not ok then
+        ngx.say("failed to connect: ", err)
+        return
+    end
+
+    ngx.say("connected: ", ok)
+
+    sock:send("GET " .. path .. "?user_key=123 HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    local data = sock:receive()
+    ngx.say(data)
+  end
+
+  request('/foo/bar')
+  request('/foo/bar')
+  request('/foo/bar')
+
+  request('/foo')
+  ngx.sleep(2)
+}
+--- response_body
+connected: 1
+HTTP/1.1 200 OK
+connected: 1
+HTTP/1.1 200 OK
+connected: 1
+HTTP/1.1 200 OK
+connected: 1
+HTTP/1.1 200 OK
+--- error_code: 200
+--- no_error_log
+[error]

--- a/t/apicast-request-logs.t
+++ b/t/apicast-request-logs.t
@@ -20,7 +20,7 @@ __DATA__
           proxy = {
             api_backend = 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api/',
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'bar' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'bar', delta = 1}
             }
           }
         },
@@ -76,14 +76,14 @@ env APICAST_RESPONSE_CODES=1;
           proxy = {
             api_backend = 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api/',
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'bar' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'bar', delta = 1}
             }
           }
         },
       }
     })
 
-    ngx.shared.api_keys:set('42:somekey:usage%5Bbar%5D=0', 200)
+    ngx.shared.api_keys:set('42:somekey:usage%5Bbar%5D=1', 200)
   }
   lua_shared_dict api_keys 1m;
 --- config
@@ -131,14 +131,14 @@ env APICAST_REPORTING_THREADS=4;
           proxy = {
             api_backend = 'http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api/',
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'bar' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'bar', delta = 1}
             }
           }
         },
       }
     })
 
-    ngx.shared.api_keys:set('42:somekey:usage%5Bbar%5D=0', 200)
+    ngx.shared.api_keys:set('42:somekey:usage%5Bbar%5D=1', 200)
   }
   lua_shared_dict api_keys 1m;
 --- config

--- a/t/apicast.t
+++ b/t/apicast.t
@@ -155,7 +155,7 @@ status code (403).
           proxy = {
             api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'hits' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1}
             }
           }
         }
@@ -194,7 +194,7 @@ The message is configurable and default status is 403.
             api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
             error_status_auth_failed = 402,
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'hits' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1}
             }
           }
         }
@@ -408,7 +408,7 @@ X-3scale-usage: usage%5Bbar%5D=3
           proxy = {
             api_backend = 'https://127.0.0.1:$TEST_NGINX_RANDOM_PORT/api/',
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'hits' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1}
             }
           }
         }
@@ -644,7 +644,7 @@ status code (429).
           proxy = {
             api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'hits' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1}
             }
           }
         }
@@ -691,7 +691,7 @@ Limits exceeded
             api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
             error_status_limits_exceeded = 402,
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'hits' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1}
             }
           }
         }
@@ -787,7 +787,7 @@ credentials missing!
           proxy = {
             api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'hits' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1}
             }
           }
         }
@@ -835,7 +835,7 @@ This test checks that APIcast does not call authrep.
           proxy = {
             api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'hits' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1}
             },
             policy_chain = {
               {
@@ -884,7 +884,7 @@ This test checks that APIcast does not call authrep.
           proxy = {
             api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'hits' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1}
             },
             policy_chain = {
               {
@@ -933,7 +933,7 @@ GET /?user_key=value
           proxy = {
             api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
             proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'hits' }
+              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1}
             }
           }
         }

--- a/t/configuration-loading-lazy.t
+++ b/t/configuration-loading-lazy.t
@@ -88,7 +88,7 @@ GET /t?user_key=fake
           "endpoint": "http://127.0.0.1:$Test::Nginx::Util::ServerPortForClient"
         },
         "proxy_rules": [
-          { "pattern": "/t", "http_method": "GET", "metric_system_name": "test" }
+          { "pattern": "/t", "http_method": "GET", "metric_system_name": "test","delta": 1 }
         ]
       }
     }]
@@ -167,7 +167,7 @@ GET /t?user_key=fake
           "endpoint": "http://127.0.0.1:$Test::Nginx::Util::ServerPortForClient"
         },
         "proxy_rules": [
-          { "pattern": "/t", "http_method": "GET", "metric_system_name": "test" }
+          { "pattern": "/t", "http_method": "GET", "metric_system_name": "test", "delta": 1}
         ]
       }
     }]

--- a/t/configuration-loading-with-oidc.t
+++ b/t/configuration-loading-with-oidc.t
@@ -86,7 +86,8 @@ echo '
           {
             "pattern": "/",
             "http_method": "GET",
-            "metric_system_name": "test"
+            "metric_system_name": "test",
+            "delta": 1
           }
         ]
       }
@@ -143,7 +144,7 @@ echo '
               "endpoint": "http://test:$TEST_NGINX_SERVER_PORT"
             },
             "proxy_rules": [
-              { "pattern": "/", "http_method": "GET", "metric_system_name": "test" }
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "test", "delta": 1}
             ]
           }
         }
@@ -170,7 +171,7 @@ echo '
               "endpoint": "http://test:$TEST_NGINX_SERVER_PORT"
             },
             "proxy_rules": [
-              { "pattern": "/", "http_method": "GET", "metric_system_name": "test" }
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "test", "delta": 1}
             ]
           }
         }


### PR DESCRIPTION
Due to the changes in APIAP in 3Scale, a service can have multiple
backends(using routing policy) and multiple mapping rules can be hit and
it creates a bad behaviour around metrics reported to Apisonator.

This commit adds ownership on routing and mapping rules, where a
ownership can be used to filter the mapping rules that you want to
report. Here an example:

Routing policy:

```
path      backend           owner
----------------------------------
/foo/bar  http://1.1.1.1/   t1
/foo      http://2.2.2.2/   t2
```

Mapping rules:

```
path      metric        owner
-----------------------------------
/foo      hits          t2
/foo/bar  barMetric     t1
```

In this case, due to the request is going to /foo/bar the metric that
will be updated will be `barMetric` and it'll use `2.2.2.2` backend, the
mapping rules to match will filter by the owner, in this case, t2.
