### PR TITLE
Return 404 to client if no upstream defined.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Return 404 back if the upstream is not defined [THREESCALE-3775](https://issues.jboss.org/browse/THREESCALE-3775) [PR #1129](https://github.com/3scale/APIcast/pull/1129)
+
+## [Unreleased]
+
+### Added
+
 - Introduce possibility of specifying policy order restrictions in their schemas. APIcast now shows a warning when those restrictions are not respected [#1088](https://github.com/3scale/APIcast/pull/1088), [THREESCALE-2896](https://issues.jboss.org/browse/THREESCALE-2896)
 - Added new parameters to logging policy to allow custom access log [PR #1089](https://github.com/3scale/APIcast/pull/1089), [THREESCALE-1234](https://issues.jboss.org/browse/THREESCALE-1234)[THREESCALE-2876](https://issues.jboss.org/browse/THREESCALE-2876), [PR #1116] (https://github.com/3scale/APIcast/pull/1116)
 - Added http_proxy policy to use an HTTP proxy in api_backed calls. [THREESCALE-2696](https://issues.jboss.org/browse/THREESCALE-2696), [PR #1080](https://github.com/3scale/APIcast/pull/1080)

--- a/gateway/src/apicast/errors.lua
+++ b/gateway/src/apicast/errors.lua
@@ -53,4 +53,13 @@ function _M.service_not_found(host)
   return exit()
 end
 
+
+function _M.upstream_not_found(service)
+  ngx.status = 404
+  ngx.print('')
+  ngx.log(ngx.WARN, 'could not find upstream for service: ', service.id)
+  return exit()
+end
+
+
 return _M

--- a/gateway/src/apicast/policy/apicast/apicast.lua
+++ b/gateway/src/apicast/policy/apicast/apicast.lua
@@ -1,4 +1,5 @@
 local balancer = require('apicast.balancer')
+local errors = require('apicast.errors')
 
 local math = math
 local setmetatable = setmetatable
@@ -104,7 +105,7 @@ end
 function _M:content(context)
   if not context[self].upstream then
     ngx.log(ngx.WARN, "Upstream server not found for this request")
-    return
+    return errors.upstream_not_found(context.service)
   end
 
   local upstream = assert(context[self].upstream, 'missing upstream')

--- a/t/apicast-blackbox.t
+++ b/t/apicast-blackbox.t
@@ -170,3 +170,36 @@ GET /bar?user_key=value
 path: /foo/bar
 --- no_error_log
 [error]
+
+=== TEST 5: api backend  is not defined and return 404
+The request url is correct in the mapping rules but no api_backend is defined
+  and no routing policy matches.
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "proxy": {
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+location /transactions/authrep.xml {
+    echo 'ok';
+}
+--- upstream
+location / {
+    echo 'path: $uri';
+}
+--- request
+GET /?user_key=value
+--- error_code: 404
+--- error_log
+could not find upstream for service: 42
+--- no_error_log
+[error]

--- a/t/apicast-policy-routing.t
+++ b/t/apicast-policy-routing.t
@@ -2086,3 +2086,42 @@ yay, api backend
 --- no_error_log
 [error]
 
+=== TEST 31: No match in routing policy return 404 back
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "proxy": {
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      },
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [ ]
+            }
+          },
+          {"name": "apicast.policy.apicast"}
+        ]
+    }
+  ]
+}
+--- backend
+location /transactions/authrep.xml {
+    echo 'ok';
+}
+--- upstream
+location / {
+    echo 'path: $uri';
+}
+--- request
+GET /?user_key=value
+--- error_code: 404
+--- error_log
+could not find upstream for service: 42
+--- no_error_log
+[error]


### PR DESCRIPTION
Due to the large use of routing policy, nowadays and upstream maybe is
not defined at all, APIcast returns 200 back and logs a new message
that a upstream is not defined.

Due to the work in THREESCALE-3775, the team decided to return a 404
back to the client to be aware that the upstream is not correct. Is not
a 502 status code due to the gateway is not defined at all and can be
confusing.

Related-to THREESCALE-3775
Related-to https://github.com/3scale/porta/pull/1385

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>