### PR TITLE
Build: Bump argparse version to 0.6.0

### DIFF
--- a/gateway/Roverfile.lock
+++ b/gateway/Roverfile.lock
@@ -1,4 +1,4 @@
-argparse 0.5.0-1||production
+argparse 0.6.0-1||production
 busted 2.0.rc12-1||testing
 dkjson 2.5-2||testing
 inspect 3.1.1-0||production


### PR DESCRIPTION
Due to the changes in Lua Rover a problem in the current version of the
argparse has been found, using the rockspec tried to copy doc directory
but it does not exist.

Failed rockspec:

```
$ curl https://luarocks.org/manifests/mpeterv/argparse-0.5.0-1.rockspec
package = "argparse"
version = "0.5.0-1"
source = {
   url = "git://github.com/mpeterv/argparse",
   tag = "0.5.0"
}
description = {
   summary = "A feature-rich command-line argument parser",
   detailed = "Argparse supports positional arguments, options, flags, optional arguments, subcommands and more. Argparse automatically generates usage, help and error messages.",
   homepage = "https://github.com/mpeterv/argparse",
   license = "MIT/X11"
}
dependencies = {
   "lua >= 5.1, < 5.4"
}
build = {
   type = "builtin",
   modules = {
      argparse = "src/argparse.lua"
   },
   copy_directories = {"doc", "spec"}
}
$
```

Source for 0.5.0:
https://github.com/mpeterv/argparse/tree/0.5.0

There are no significant changes in 0.6.0 that affect the current APICast
version.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>