### PR TITLE
Policy: TLS termination changed name.

### DIFF
--- a/gateway/src/apicast/policy/tls/apicast-policy.json
+++ b/gateway/src/apicast/policy/tls/apicast-policy.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://apicast.io/policy-v1/schema#manifest#",
-  "name": "tls",
-  "summary": "Configure TLS certificates",
+  "name": "TLS Termination",
+  "summary": "Configure TLS termination certificates",
   "description": [
       "Configure APIcast to serve TLS certificates for HTTPS connections."
   ],


### PR DESCRIPTION
Update display name for the TLS termination policy to be more
user-friendly.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>