### PR TITLE
Configuration: Lazy mode issue with SSL certificate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Fix issues when TLS is enabled in Lazy mode [#1135](https://github.com/3scale/APIcast/pull/1135), [THREESCALE-3713](https://issues.jboss.org/browse/THREESCALE-3713)
+
 ### Added
 
 - Introduce possibility of specifying policy order restrictions in their schemas. APIcast now shows a warning when those restrictions are not respected [#1088](https://github.com/3scale/APIcast/pull/1088), [THREESCALE-2896](https://issues.jboss.org/browse/THREESCALE-2896)

--- a/gateway/src/apicast/policy/load_configuration/load_configuration.lua
+++ b/gateway/src/apicast/policy/load_configuration/load_configuration.lua
@@ -33,12 +33,13 @@ function _M:rewrite(context)
     context.configuration = configuration_loader.rewrite(self.configuration, context.host)
 end
 
-function _M.ssl_certificate(_, context)
+function _M:ssl_certificate(context)
     if not context.host then
         local server_name, err = ssl.server_name()
 
         if server_name then
             context.host = server_name
+            context.configuration = configuration_loader.rewrite(self.configuration, context.host)
         elseif err then
             ngx.log(ngx.DEBUG, 'could not get TLS SNI server name: ', err)
         end


### PR DESCRIPTION
When Lazy mode is set and it's using SSL connection, the
configuration_store was not initialized, so the config was not found and
lazy mode can't found the service for the host.

Fix THREESCALE-3713

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>