### PR TITLE
Upstream: return error if the value given is cjson.null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Fix issues when TLS is enabled in Lazy mode [#1135](https://github.com/3scale/APIcast/pull/1135), [THREESCALE-3713](https://issues.jboss.org/browse/THREESCALE-3713)
+- Fix exception if api_backend is null [THREESCALE-3869](https://issues.jboss.org/browse/THREESCALE-3869) [PR #1136](https://github.com/3scale/APIcast/pull/1136)
 
 ### Added
 
 - Return 404 back if the upstream is not defined [THREESCALE-3775](https://issues.jboss.org/browse/THREESCALE-3775) [PR #1129](https://github.com/3scale/APIcast/pull/1129)
+
 
 ## [Unreleased]
 

--- a/gateway/src/apicast/proxy.lua
+++ b/gateway/src/apicast/proxy.lua
@@ -187,7 +187,6 @@ function _M.get_upstream(service)
   if not service then
     return errors.service_not_found()
   end
-
   local upstream, err = Upstream.new(service.api_backend)
 
   if not upstream then

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -15,6 +15,7 @@ local url_helper = require('resty.url_helper')
 
 local http_proxy = require('apicast.http_proxy')
 local format = string.format
+local cjson = require('cjson')
 
 local _M = {
 
@@ -34,6 +35,10 @@ local mt = {
 --- @treturn nil|string error when upstream can't be initialized
 --- @static
 function _M.new(url)
+    if not url or url == cjson.null then
+        return nil, 'Upstream cannot be null'
+    end
+
     local uri, err = url_helper.parse_url(url)
     if err then
         return nil, 'invalid upstream'

--- a/t/apicast-blackbox.t
+++ b/t/apicast-blackbox.t
@@ -203,3 +203,36 @@ GET /?user_key=value
 could not find upstream for service: 42
 --- no_error_log
 [error]
+
+=== TEST 6: api backend  is null andreturns 404
+The request url is correct in the mapping rules but api_backend is null 
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": null,
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+location /transactions/authrep.xml {
+    echo 'ok';
+}
+--- upstream
+location / {
+    echo 'path: $uri';
+}
+--- request
+GET /?user_key=value
+--- error_code: 404
+--- error_log
+could not find upstream for service: 42
+--- no_error_log
+[error]


### PR DESCRIPTION
On read JSON config the null values are not consider nil. Due to the
latest changes on porta related to the null api_backend, APIcast will
raise an exception and things started to fail.

Related-to: https://github.com/3scale/porta/pull/1385
Fix: THREESCALE-3869

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>