### PR TITLE
Proxy: Format usage

### DIFF
--- a/gateway/src/apicast/proxy.lua
+++ b/gateway/src/apicast/proxy.lua
@@ -91,21 +91,6 @@ local function output_debug_headers(service, usage, credentials)
   end
 end
 
--- Converts a usage to the format expected by the 3scale backend client.
-local function format_usage(usage)
-  local res = {}
-
-  local usage_metrics = usage.metrics
-  local usage_deltas = usage.deltas
-
-  for _, metric in ipairs(usage_metrics) do
-    local delta = usage_deltas[metric]
-    res['usage[' .. metric .. ']'] = delta
-  end
-
-  return res
-end
-
 local function matched_patterns(matched_rules)
   local patterns = {}
 
@@ -123,7 +108,7 @@ end
 function _M:authorize(service, usage, credentials, ttl)
   if not usage or not credentials then return nil, 'missing usage or credentials' end
 
-  local formatted_usage = format_usage(usage)
+  local formatted_usage = usage:format()
 
   local encoded_usage = encode_args(formatted_usage)
   if encoded_usage == '' then
@@ -347,7 +332,7 @@ function _M:post_action(context)
   local service = ngx.ctx.service or self.configuration:find_by_id(service_id)
 
   local credentials = context.credentials
-  local formatted_usage = format_usage(context.usage)
+  local formatted_usage = context.usage:format()
 
   reporting_executor:post(post_action, self, cached_key, service, credentials, formatted_usage, ngx.var.status)
 end

--- a/gateway/src/apicast/usage.lua
+++ b/gateway/src/apicast/usage.lua
@@ -85,4 +85,20 @@ function _M:merge(another_usage)
   end
 end
 
+
+-- Converts a usage to the format expected by the 3scale backend client.
+function _M:format()
+  local res = {}
+
+  local usage_metrics = self.metrics
+  local usage_deltas = self.deltas
+
+  for _, metric in ipairs(usage_metrics) do
+    local delta = usage_deltas[metric]
+    res['usage[' .. metric .. ']'] = delta
+  end
+
+  return res
+end
+
 return _M

--- a/spec/usage_spec.lua
+++ b/spec/usage_spec.lua
@@ -140,4 +140,32 @@ describe('usage', function()
           (metrics[1] == 'some_metric' and metrics[2] == 'hits'))
     end)
   end)
+
+  describe(".format", function()
+    it("returns valid response with data", function()
+      local usage = Usage.new()
+      usage:add('hits', 2)
+      usage:add('some_metric', 1)
+      local result = {
+        ["usage[hits]"] = 2,
+        ["usage[some_metric]"] = 1,
+      }
+      assert.are.same(usage:format(), result)
+    end)
+
+    it("returns empty if no metrics added", function()
+      local usage = Usage.new()
+      local result = {}
+      assert.are.same(usage:format(), result)
+    end)
+
+    it("returns 0 values correctly", function()
+      local usage = Usage.new()
+      usage:add('hits', 0)
+      local result = {
+        ["usage[hits]"] = 0,
+      }
+      assert.are.same(usage:format(), result)
+    end)
+  end)
 end)


### PR DESCRIPTION
This is a cleanup in the usage format. A few places used the code that
was equal, also format should be method in the usage table and not a
separate function.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>