### PR TITLE
OIDC: Using caching to retrieve issuer configs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
--  Avoid OIDC flip-flops issues when OIDC connectivity fails, now issuer configuration is cached. [THREESCALE-3809](https://issues.jboss.org/browse/THREESCALE-3809) [PR #1141](https://github.com/3scale/APIcast/pull/1141)
+-  Now the configuration of the issuer is cached to avoid flip-flop issues when OIDC connectivity fails.  [THREESCALE-3809](https://issues.jboss.org/browse/THREESCALE-3809) [PR #1141](https://github.com/3scale/APIcast/pull/1141)
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+-  Avoid OIDC flip-flops issues when OIDC connectivity fails, now issuer configuration is cached. [THREESCALE-3809](https://issues.jboss.org/browse/THREESCALE-3809) [PR #1141](https://github.com/3scale/APIcast/pull/1141)
+
+
+### Fixed
+
+
 ## [3.7.0] - 2019-11-27
 
 `3.7.0-rc2` was considered final and became `3.7.0`.

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -26,7 +26,7 @@ Specifies the period (in seconds) that the configuration will be stored in the c
 - a positive number ( > 0 ): specifies the interval in seconds between configuration reload. For example, when APIcast is started with `APICAST_CONFIGURATION_CACHE=300` and `APICAST_CONFIGURATION_CACHE=boot`, it will load the configuration on boot, and will reload it every 5 minutes (300 seconds).
 - a negative number ( < 0 ): disables reloading. The cache entries will never be removed from the cache once stored, and the configuration will never be reloaded.
 
-This parameter is also used to store OpenID discovery configuration in the local cache, as the same behaviour as described above.
+This parameter is also used to store OpenID discovery configuration in the local cache, as the same behavior as described above.
 
 ### `APICAST_CONFIGURATION_LOADER`
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -26,6 +26,8 @@ Specifies the period (in seconds) that the configuration will be stored in the c
 - a positive number ( > 0 ): specifies the interval in seconds between configuration reload. For example, when APIcast is started with `APICAST_CONFIGURATION_CACHE=300` and `APICAST_CONFIGURATION_CACHE=boot`, it will load the configuration on boot, and will reload it every 5 minutes (300 seconds).
 - a negative number ( < 0 ): disables reloading. The cache entries will never be removed from the cache once stored, and the configuration will never be reloaded.
 
+This parameter is also used to store OpenID discovery configuration in the local cache, as the same behaviour as described above.
+
 ### `APICAST_CONFIGURATION_LOADER`
 
 **Values:** boot | lazy  

--- a/gateway/src/resty/oidc/discovery.lua
+++ b/gateway/src/resty/oidc/discovery.lua
@@ -8,10 +8,16 @@ local resty_env = require 'resty.env'
 local Mime = require 'resty.mime'
 local cjson = require('cjson')
 local jwk = require('resty.oidc.jwk')
+local resty_lrucache = require "resty.lrucache"
+
 
 local oidc_log_level = ngx[string.upper(resty_env.value('APICAST_OIDC_LOG_LEVEL') or 'err')] or ngx.ERR
 
-local _M = { }
+local cache_max_size = 100
+
+local _M = {
+  _TYPE = "oidc_discovery"
+}
 
 local mt = { __index = _M }
 
@@ -40,10 +46,41 @@ function _M.new(http_backend)
             ssl = { verify = resty_env.enabled('OPENSSL_VERIFY') }
         }
     }
+    return _M.new_with_http_client(http_client)
+end
 
-    local self = { http_client = http_client }
+function _M.new_with_http_client(http_client)
+    local self = setmetatable({ http_client = http_client }, mt)
+    self:init_cache()
+    return self
+end
 
-    return setmetatable(self, mt)
+
+function _M:init_cache()
+  self.cache = resty_lrucache.new(cache_max_size)
+  return self
+end
+
+
+--- Fetch and return OIDC configuration from cache if it exists.
+function _M:issuer_in_cache(issuer)
+  if not self.cache then
+    return nil
+  end
+
+  return self.cache:get(issuer)
+end
+
+--- Insert the OIDC configuration for the issuer in the local cache with a
+--limit. If no ttl set will be 0
+function _M:save_issuer_in_cache(issuer, config, ttl)
+  local expires = tonumber(ttl) or 0
+
+  if not self.cache then
+    return nil
+  end
+  self.cache:set(issuer, config, expires)
+  ngx.log(ngx.DEBUG, "OIDC configuration for issuer='"..issuer.."' stored in cache for "..expires.." seconds")
 end
 
 --- Fetch and return OIDC configuration from well known endpoint <issuer>/.well-known/openid-configuration
@@ -75,12 +112,10 @@ function _M:openid_configuration(issuer)
     end
 
     local config = decode_json(res)
-
     if not config then
         ngx.log(oidc_log_level, 'invalid OIDC Provider, expected application/json got:  ', res.headers.content_type, ' body: ', res.body)
         return nil, 'invalid JSON'
     end
-
     return config
 end
 
@@ -115,18 +150,35 @@ end
 
 --- Fetch whole OIDC configuration through OIDC Discovery.
 -- @tparam string issuer URL to the Issuer (without the .well-known/openid-configuration)
+-- @tparam integer ttl for storing the issuer configuration in the local cache.
 -- @treturn table
-function _M:call(issuer)
-    local http_client = self.http_client
+function _M:call(issuer, ttl)
+  if not issuer then
+    return nil
+  end
 
-    if not http_client then
-        return nil, 'not initialized'
-    end
+  local http_client = self.http_client
 
-    local config, err = _M.openid_configuration(self, issuer)
-    if not config then return nil, err end
+  if not http_client then
+    return nil, 'not initialized'
+  end
 
-    return { config = config, issuer = config.issuer, keys = _M.jwks(self, config) }
+  local cached = self:issuer_in_cache(issuer)
+  if cached then
+    ngx.log(ngx.DEBUG, "retrieve OIDC configuration for issuer='"..issuer.."' from cache")
+    return cached
+  end
+
+  local config, err = _M.openid_configuration(self, issuer)
+  if not config then return nil, err end
+
+  local result =  {
+    config = config,
+    issuer = config.issuer,
+    keys = _M.jwks(self, config)
+  }
+  self:save_issuer_in_cache(issuer, result, tonumber(ttl))
+  return result
 end
 
 return _M

--- a/spec/resty/oidc/discovery_spec.lua
+++ b/spec/resty/oidc/discovery_spec.lua
@@ -15,6 +15,55 @@ describe('OIDC Discovery', function()
         end)
     end)
 
+    describe("Issuer cache information", function()
+
+      local issuer_url = "https://idp.example.com/"
+      local issuer_config_url = issuer_url .. ".well-known/openid-configuration"
+
+      it('Stored the info in the cache', function()
+
+        test_backend
+                .expect{ url =  issuer_config_url }
+                .respond_with{ status = 200, headers = { content_type = 'application/json' }, body = '{}' }
+
+        spy.on(discovery, "save_issuer_in_cache")
+        discovery:call(issuer_url, 10)
+        assert.spy(discovery.save_issuer_in_cache).was_called()
+      end)
+
+      it('Stored the info for 0 seconds', function()
+
+        test_backend
+                .expect{ url =  issuer_config_url }
+                .respond_with{ status = 200, headers = { content_type = 'application/json' }, body = '{}' }
+
+        spy.on(discovery, "save_issuer_in_cache")
+        discovery:call(issuer_url, 0)
+        assert.spy(discovery.save_issuer_in_cache).was_called()
+
+        discovery:call(issuer_url, 0)
+        assert.spy(discovery.save_issuer_in_cache).was_called()
+      end)
+
+      it('use the cache info if is in place', function()
+
+        test_backend
+                .expect{ url =  issuer_config_url }
+                .respond_with{ status = 200, headers = { content_type = 'application/json' }, body = '{}' }
+
+        spy.on(discovery, "save_issuer_in_cache")
+        local result = discovery:call(issuer_url, 10)
+        assert.spy(discovery.save_issuer_in_cache).was_called()
+
+        spy.on(discovery, "issuer_in_cache")
+        discovery:call(issuer_url, 10)
+
+        assert.spy(discovery.issuer_in_cache).was_called()
+        assert.spy(discovery.issuer_in_cache).returned_with(result)
+
+      end)
+    end)
+
     describe(':openid_configuration(endpoint)', function()
         it('loads configuration from the discovery endpoint', function()
             test_backend


### PR DESCRIPTION
This commit fix issues with the flipflop connections to the issuer.
Multiple users have hundred of services with the same issuer, and
multiple requests happen at the same time.

This commit has two pourposes:
  - Make the issuer config retrieve a bit faster in the APIcast and do
  not make multiple requests to retrieve the same info.
  - In case that the issuer has internment issues, avoid that one service
  loads correctly, and others do not load at all.

Fix [THREESCALE-3809](https://issues.redhat.com/projects/THREESCALE/issues/THREESCALE-3809)

- [ ] Should this caching be enabled with an Env variable?
