### PR TITLE
added {} to the regexp that matches the URI parameters

### DIFF
--- a/gateway/src/apicast/mapping_rule.lua
+++ b/gateway/src/apicast/mapping_rule.lua
@@ -37,7 +37,7 @@ end
 local function regexpify(pattern)
   pattern = re_gsub(pattern, [[\?.*]], '', 'oj')
   -- dollar sign is escaped by another $, see https://github.com/openresty/lua-nginx-module#ngxresub
-  pattern = re_gsub(pattern, [[\{.+?\}]], [[([\w-.~%!$$&'()*+,;=@:]+)]], 'oj')
+  pattern = re_gsub(pattern, [[\{.+?\}]], [[([{}\w-.~%!$$&'()*+,;=@:]+)]], 'oj')
   pattern = re_gsub(pattern, [[\.]], [[\.]], 'oj')
   return pattern
 end


### PR DESCRIPTION
In addition to https://issues.jboss.org/browse/THREESCALE-3468 It is still not possible to match "%7B%7D" in parameters, this pull request should solve this.
