### PR TITLE
PATH-routing: url was not escaped correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
--  Now the configuration of the issuer is cached to avoid flip-flop issues when OIDC connectivity fails.  [THREESCALE-3809](https://issues.jboss.org/browse/THREESCALE-3809) [PR #1141](https://github.com/3scale/APIcast/pull/1141)
+-  Now the configuration of the issuer is cached to avoid flip-flop issues when OIDC connectivity fails. [THREESCALE-3809](https://issues.jboss.org/browse/THREESCALE-3809) [PR #1141](https://github.com/3scale/APIcast/pull/1141)
+
+### Fixed
+
+- When PATH routing was enabled the URL was not correctly escaped [THREESCALE-3468](https://issues.jboss.org/browse/THREESCALE-3468) [PR #1150](https://github.com/3scale/APIcast/pull/1150)
 
 
 ### Fixed

--- a/gateway/src/apicast/policy/find_service/path_based_finder.lua
+++ b/gateway/src/apicast/policy/find_service/path_based_finder.lua
@@ -1,4 +1,5 @@
 local mapping_rules_matcher = require 'apicast.mapping_rules_matcher'
+local escape = require("resty.http.uri_escape")
 
 local _M = {}
 
@@ -6,7 +7,7 @@ function _M.find_service(config_store, host)
   local found
   local services = config_store:find_by_host(host)
   local method = ngx.req.get_method()
-  local uri = ngx.var.uri
+  local uri = escape.escape_uri(ngx.var.uri)
 
   for s=1, #services do
     local service = services[s]


### PR DESCRIPTION
If PATH routing was defined, the uri was not escaped correctly so the
mapping rules will not work as expected.

Reported by: Carlo Palmiari <cpalmier@redhat.com>
Fix: THREESCALE-3468
Related-to:112fdfa502483983b462fb82a5e789003ab9f750

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>