### PR TITLE
Websocket support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Now the configuration of the issuer is cached to avoid flip-flop issues when OIDC connectivity fails. [THREESCALE-3809](https://issues.jboss.org/browse/THREESCALE-3809) [PR #1141](https://github.com/3scale/APIcast/pull/1141)
 - Openresty dependencies comes now from RedHat build system. [THREESCALE-3771](https://issues.jboss.org/browse/THREESCALE-3771) [PR #1145](https://github.com/3scale/APIcast/pull/1145)
 - Added HTTP2 support [THREESCALE-3271](https://issues.jboss.org/browse/THREESCALE-3271) [PR #1128](https://github.com/3scale/APIcast/pull/1128)
-
+- Websocket support. [THREESCALE-4019](https://issues.jboss.org/browse/THREESCALE-4019) [PR #1152](https://github.com/3scale/APIcast/pull/1152)
 
 ### Fixed
 

--- a/gateway/conf.d/apicast.conf
+++ b/gateway/conf.d/apicast.conf
@@ -85,7 +85,8 @@ location @upstream {
   proxy_set_header Host $http_host;
   proxy_set_header X-3scale-proxy-secret-token $secret_token;
   proxy_set_header X-3scale-debug "";
-  proxy_set_header Connection "";
+  proxy_set_header Connection $upstream_connection_header;
+  proxy_set_header Upgrade $upstream_upgrade_header;
 
   # This is a bit tricky. It uses liquid to set a SSL client certificate. In
   # NGINX, all this is not executed as it is commented with '#'. However, in
@@ -150,6 +151,10 @@ location / {
 
   set $post_action_impact '';
   set $original_request_id '';
+
+  # Variables needed by Websocket policy
+  set $upstream_connection_header '';
+  set $upstream_upgrade_header $http_upgrade;
 
   # {% if http_keepalive_timeout != empty %}
   #   {% capture keepalive_timeout %}

--- a/gateway/src/apicast/policy/websocket/README.md
+++ b/gateway/src/apicast/policy/websocket/README.md
@@ -1,0 +1,8 @@
+# Websocket policy
+
+A policy which enables Websocket connection from the endpoint to the Upstream
+API.
+
+## Properties
+
+This policy does not have properties.

--- a/gateway/src/apicast/policy/websocket/apicast-policy.json
+++ b/gateway/src/apicast/policy/websocket/apicast-policy.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
+  "name": "Websocket",
+  "summary": "Allows websocket connection pass through.",
+  "description": [
+    "A policy which allows Websocket traffic for the service"
+  ],
+  "version": "builtin",
+  "configuration": {
+    "type": "object",
+    "properties": {
+    }
+  }
+}

--- a/gateway/src/apicast/policy/websocket/init.lua
+++ b/gateway/src/apicast/policy/websocket/init.lua
@@ -1,0 +1,1 @@
+return require('websocket')

--- a/gateway/src/apicast/policy/websocket/websocket.lua
+++ b/gateway/src/apicast/policy/websocket/websocket.lua
@@ -1,0 +1,23 @@
+-- This policy enables Web socket pass through on APIcast
+
+local _M = require('apicast.policy').new('Websocket', 'builtin')
+
+local new = _M.new
+
+function _M.new(configuration)
+  local policy = new(configuration)
+  return policy
+end
+
+local function is_websocket_connection()
+  local headers = ngx.req.get_headers()
+  return headers["Upgrade"] ~= nil and headers["Sec-WebSocket-Key"] ~= nil
+end
+
+function _M:rewrite()
+  if is_websocket_connection() then
+    ngx.var.upstream_connection_header = "Upgrade"
+  end
+end
+
+return _M

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -22,7 +22,16 @@ local _M = {
 }
 
 local function proxy_pass(upstream)
-    return str_format('%s://%s', upstream.uri.scheme, upstream.upstream_name)
+    local scheme = upstream.uri.scheme
+    if upstream.uri.scheme == "wss" then
+        scheme = "https"
+    end
+
+    if upstream.uri.scheme == "ws" then
+        scheme = "http"
+    end
+
+    return str_format('%s://%s', scheme, upstream.upstream_name)
 end
 
 local mt = {
@@ -38,7 +47,6 @@ function _M.new(url)
     if not url or url == cjson.null then
         return nil, 'Upstream cannot be null'
     end
-
     local uri, err = url_helper.parse_url(url)
     if err then
         return nil, 'invalid upstream'

--- a/spec/upstream_spec.lua
+++ b/spec/upstream_spec.lua
@@ -248,6 +248,17 @@ describe('Upstream', function()
 
                 assert.equal('http://upstream', ngx.var.proxy_pass)
             end)
+
+            it('works with websocket url', function()
+                local upstream = Upstream.new('ws://example.com')
+                upstream:call({})
+                assert.equal('http://upstream', ngx.var.proxy_pass)
+
+                upstream = Upstream.new('wss://example.com')
+                upstream:call({})
+                assert.equal('https://upstream', ngx.var.proxy_pass)
+            end)
+
         end)
     end)
 

--- a/t/apicast-policy-websocket.t
+++ b/t/apicast-policy-websocket.t
@@ -1,0 +1,164 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+repeat_each(2);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: Simple Websocket connection pass through
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "hosts": [
+          "127.0.0.1"
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast",
+            "version": "builtin",
+            "configuration": {}
+          },
+          {
+            "name": "websocket",
+            "version": "builtin",
+            "configuration": {}
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+--- upstream env
+location / {
+  access_by_lua_block {
+    local server = require "resty.websocket.server"
+
+    local wb, err = server:new{
+      timeout = 5000,  -- in milliseconds
+      max_payload_len = 65535,
+    }
+    if not wb then
+      ngx.log(ngx.ERR, "failed to new websocket: ", err)
+      return ngx.exit(444)
+    end
+
+    local data, typ, err = wb:recv_frame()
+    if not data then
+      if not string.find(err, "timeout", 1, true) then
+        ngx.log(ngx.ERR, "failed to receive a frame: ", err)
+        return ngx.exit(444)
+      end
+    end
+
+    bytes, err = wb:send_text("Data: "..data.." Type: "..typ)
+    if not bytes then
+      ngx.log(ngx.ERR, "failed to send a text frame: ", err)
+      return ngx.exit(444)
+    end
+  }
+}
+
+--- test
+content_by_lua_block {
+  local client = require "resty.websocket.client"
+  local wb, err = client:new()
+  local server = ngx.var.server_addr
+  local apicast_port = ngx.var.apicast_port
+  local uri = "ws://"..server.. ":"..apicast_port.."/?user_key=foo"
+  local ok, err = wb:connect(uri)
+  if not ok then
+    ngx.say("failed to connect: " .. err)
+    return
+  end
+
+  local bytes, err = wb:send_text("Sending from client")
+  if not bytes then
+    ngx.say("failed to send frame: ", err)
+    return
+  end
+
+  local data, typ, err = wb:recv_frame()
+  if not data then
+    ngx.say("failed to receive the frame: ",apicast_port, err)
+    return
+  end
+
+  ngx.say("received: ", data)
+}
+--- response_body env
+received: Data: Sending from client Type: text
+--- error_code: 200
+--- timeout: 10
+--- no_error_log
+[error]
+
+
+=== TEST 2: No websocket connection with policy does not change Upgrade header
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "hosts": [
+          "localhost"
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast",
+            "version": "builtin",
+            "configuration": {}
+          },
+          {
+            "name": "websocket",
+            "version": "builtin",
+            "configuration": {}
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+--- upstream env
+location / {
+  content_by_lua_block {
+    local headers  = ngx.req.get_headers()
+    assert(headers["Upgrade"] == nil)
+  }
+}
+--- request
+GET /?user_key=value
+--- error_code: 200
+--- no_error_log
+[error]

--- a/t/apicast-policy-websocket.t
+++ b/t/apicast-policy-websocket.t
@@ -162,3 +162,160 @@ GET /?user_key=value
 --- error_code: 200
 --- no_error_log
 [error]
+
+
+=== TEST 3: Websocket using ws url in the api_backend
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "hosts": [
+          "127.0.0.1"
+        ],
+        "api_backend": "ws://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast",
+            "version": "builtin",
+            "configuration": {}
+          },
+          {
+            "name": "websocket",
+            "version": "builtin",
+            "configuration": {}
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+--- upstream env
+location / {
+  access_by_lua_block {
+    local server = require "resty.websocket.server"
+
+    local wb, err = server:new{
+      timeout = 5000,  -- in milliseconds
+      max_payload_len = 65535,
+    }
+    if not wb then
+      ngx.log(ngx.ERR, "failed to new websocket: ", err)
+      return ngx.exit(444)
+    end
+
+    local data, typ, err = wb:recv_frame()
+    if not data then
+      if not string.find(err, "timeout", 1, true) then
+        ngx.log(ngx.ERR, "failed to receive a frame: ", err)
+        return ngx.exit(444)
+      end
+    end
+
+    bytes, err = wb:send_text("Data: "..data.." Type: "..typ)
+    if not bytes then
+      ngx.log(ngx.ERR, "failed to send a text frame: ", err)
+      return ngx.exit(444)
+    end
+  }
+}
+
+--- test
+content_by_lua_block {
+  local client = require "resty.websocket.client"
+  local wb, err = client:new()
+  local server = ngx.var.server_addr
+  local apicast_port = ngx.var.apicast_port
+  local uri = "ws://"..server.. ":"..apicast_port.."/?user_key=foo"
+  local ok, err = wb:connect(uri)
+  if not ok then
+    ngx.say("failed to connect: " .. err)
+    return
+  end
+
+  local bytes, err = wb:send_text("Sending from client")
+  if not bytes then
+    ngx.say("failed to send frame: ", err)
+    return
+  end
+
+  local data, typ, err = wb:recv_frame()
+  if not data then
+    ngx.say("failed to receive the frame: ",apicast_port, err)
+    return
+  end
+
+  ngx.say("received: ", data)
+}
+--- response_body env
+received: Data: Sending from client Type: text
+--- error_code: 200
+--- timeout: 10
+--- no_error_log
+[error]
+
+
+=== TEST 2: No websocket connection with policy does not change Upgrade header
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "hosts": [
+          "localhost"
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast",
+            "version": "builtin",
+            "configuration": {}
+          },
+          {
+            "name": "websocket",
+            "version": "builtin",
+            "configuration": {}
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+--- upstream env
+location / {
+  content_by_lua_block {
+    local headers  = ngx.req.get_headers()
+    assert(headers["Upgrade"] == nil)
+  }
+}
+--- request
+GET /?user_key=value
+--- error_code: 200
+--- no_error_log
+[error]


### PR DESCRIPTION
This commit adds the option to enable Websocket pass trough to the
upstream API if the original connection is a websocket connection.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>