### PR TITLE
Policies: Normalize policy names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - When PATH routing was enabled the URL was not correctly escaped [THREESCALE-3468](https://issues.jboss.org/browse/THREESCALE-3468) [PR #1150](https://github.com/3scale/APIcast/pull/1150)
 - Add the correct host header when using an http proxy [THREESCALE-4178](https://issues.jboss.org/browse/THREESCALE-4178) [PR #1143](https://github.com/3scale/APIcast/pull/1143)
+- Normalize policy names capitalization [THREESCALE-4150](https://issues.jboss.org/browse/THREESCALE-4150) [PR #1154](https://github.com/3scale/APIcast/pull/1154)
+
 
 
 

--- a/gateway/src/apicast/policy/3scale_batcher/apicast-policy.json
+++ b/gateway/src/apicast/policy/3scale_batcher/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
-  "name": "3scale batcher",
+  "name": "3scale Batcher",
   "summary": "Caches auths from 3scale backend and batches reports.",
   "description":
     ["This policy caches authorizations from the 3scale backend ",

--- a/gateway/src/apicast/policy/caching/apicast-policy.json
+++ b/gateway/src/apicast/policy/caching/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
-  "name": "3scale auth caching",
+  "name": "3scale Auth Caching",
   "summary": "Controls how to cache authorizations returned by the 3scale backend.",
   "description":
     ["Configures a cache for the authentication calls against the 3scale ",

--- a/gateway/src/apicast/policy/conditional/apicast-policy.json
+++ b/gateway/src/apicast/policy/conditional/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
-  "name": "Conditional policy [Tech preview]",
+  "name": "Conditional Policy [Tech preview]",
   "summary": "Executes a policy chain conditionally.",
   "description": [
     "Evaluates a condition, and when it's true, it calls its policy chain. ",

--- a/gateway/src/apicast/policy/cors/apicast-policy.json
+++ b/gateway/src/apicast/policy/cors/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
-  "name": "CORS",
+  "name": "CORS Request Handling",
   "summary": "Enables CORS (Cross Origin Resource Sharing) request handling.",
   "description":
     ["This policy enables Cross Origin Resource Sharing (CORS) request ",

--- a/gateway/src/apicast/policy/grpc/apicast-policy.json
+++ b/gateway/src/apicast/policy/grpc/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
-  "name": "HTTP2 endpoint",
+  "name": "HTTP2 Endpoint",
   "summary": "Main functionality to enable HTTP2 endpoint reply.",
   "description":
     ["To enable full HTTP2 traffic from the user to the final endpoint "],

--- a/gateway/src/apicast/policy/headers/apicast-policy.json
+++ b/gateway/src/apicast/policy/headers/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
-  "name": "Header modification",
+  "name": "Header Modification",
   "summary": "Allows to include custom headers.",
   "description":
     ["This policy allows to include custom headers that will be sent to the ",

--- a/gateway/src/apicast/policy/ip_check/apicast-policy.json
+++ b/gateway/src/apicast/policy/ip_check/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
-  "name": "IP check",
+  "name": "IP Check",
   "summary": "Accepts or denies a request based on the IP.",
   "description": [
     "Accepts or denies requests according to a whitelist or a blacklist of ",

--- a/gateway/src/apicast/policy/keycloak_role_check/apicast-policy.json
+++ b/gateway/src/apicast/policy/keycloak_role_check/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
-  "name": "RH-SSO/Keycloak role check",
+  "name": "RH-SSO/Keycloak Role Check",
   "summary": "Adds role check with Keycloak.",
   "description": [
     "This policy adds role check with Keycloak.\n",

--- a/gateway/src/apicast/policy/liquid_context_debug/apicast-policy.json
+++ b/gateway/src/apicast/policy/liquid_context_debug/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
-  "name": "Liquid context debug",
+  "name": "Liquid Context Debug",
   "summary": "Inspects the available liquid context.",
   "description": [
     "This is a policy intended only for debugging purposes. This policy ",

--- a/gateway/src/apicast/policy/rate_limit/apicast-policy.json
+++ b/gateway/src/apicast/policy/rate_limit/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
-  "name": "Edge limiting",
+  "name": "Edge Limiting",
   "summary": "Adds rate limit.",
   "description": ["This policy adds rate limit."],
   "version": "builtin",

--- a/gateway/src/apicast/policy/rewrite_url_captures/apicast-policy.json
+++ b/gateway/src/apicast/policy/rewrite_url_captures/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
-  "name": "URL rewriting with captures",
+  "name": "URL Rewriting with Captures",
   "summary": "Captures arguments in a URL and rewrites the URL using them.",
   "description":
     ["Captures arguments in a URL and rewrites the URL using these arguments. ",

--- a/gateway/src/apicast/policy/upstream_connection/apicast-policy.json
+++ b/gateway/src/apicast/policy/upstream_connection/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
-  "name": "Upstream connection",
+  "name": "Upstream Connection",
   "summary": "Allows to configure several options for the connections to the upstream",
   "description": "Allows to configure several options for the connections to the upstream",
   "version": "builtin",

--- a/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
+++ b/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
-  "name": "URL rewriting",
+  "name": "URL Rewriting",
   "summary": "Allows to modify the path of a request.",
   "description":
     ["This policy allows to modify the path of a request. ",


### PR DESCRIPTION
To have a consistent capitalization over all policies.

Fix THREESCALE-4150

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>