### PR TITLE
Logs: Add request_id on debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Openresty dependencies comes now from RedHat build system. [THREESCALE-3771](https://issues.jboss.org/browse/THREESCALE-3771) [PR #1145](https://github.com/3scale/APIcast/pull/1145)
 - Added HTTP2 support [THREESCALE-3271](https://issues.jboss.org/browse/THREESCALE-3271) [PR #1128](https://github.com/3scale/APIcast/pull/1128)
 - Websocket support. [THREESCALE-4019](https://issues.jboss.org/browse/THREESCALE-4019) [PR #1152](https://github.com/3scale/APIcast/pull/1152)
+- Added Request_id on ngx.log function. [THREESCALE-3644](https://issues.jboss.org/browse/THREESCALE-3644) [PR #1156](https://github.com/3scale/APIcast/pull/1156)
 
 ### Fixed
 

--- a/gateway/conf.d/apicast.conf
+++ b/gateway/conf.d/apicast.conf
@@ -156,6 +156,7 @@ location / {
   set $upstream_connection_header '';
   set $upstream_upgrade_header $http_upgrade;
 
+  set $original_request_id $request_id;
   # {% if http_keepalive_timeout != empty %}
   #   {% capture keepalive_timeout %}
   #{#}   keepalive_timeout {{ http_keepalive_timeout}};

--- a/gateway/http.d/init.conf
+++ b/gateway/http.d/init.conf
@@ -3,6 +3,9 @@ init_by_lua_block {
     -- require('jit.p').start('vl')
     -- require('jit.dump').start('bsx', 'jit.log')
 
+    local log = require('resty.log.log')
+    log:patch_ngx_log_on_debug()
+
     if os.getenv('CI') == 'true' then
       pcall(require, 'luacov.runner')
     end

--- a/gateway/src/resty/log/log.lua
+++ b/gateway/src/resty/log/log.lua
@@ -1,0 +1,89 @@
+local errlog = require "ngx.errlog"
+local base = require "resty.core.base"
+local ffi = require 'ffi'
+
+local C = ffi.C
+local FFI_BAD_CONTEXT = base.FFI_BAD_CONTEXT
+local find = string.find
+local getinfo = debug.getinfo
+local reverse = string.reverse
+local select = select
+local sub = string.sub
+local tostring = tostring
+
+local get_request = base.get_request
+
+
+ffi.cdef[[
+int ngx_http_lua_ffi_get_phase(ngx_http_request_t *r, char **err)
+]]
+
+local _M = {}
+
+local function get_prefix_from_info(info)
+  local reverse_str = reverse(info.short_src)
+  local first_match = find(reverse_str, "/")
+  if not first_match  then
+    return info.short_src
+  end
+  local reverse_filename = sub(reverse_str, 0, first_match - 1)
+
+  local result = string.reverse(reverse_filename) .. ":" .. info.currentline
+
+  -- If the function name is present, just append to the prefix.
+  if info.name then
+    result = result .. ": " .. info.name .. "()"
+  end
+  return result
+end
+
+-- is_valid_request returns true if is a request. base.get_request returns a
+-- request on init_worker and timer phases, so we need to validate that a valid
+-- request is made.
+local function is_valid_request()
+  local r = get_request()
+  if not r then
+    return nil
+  end
+
+  local id = C.ngx_http_lua_ffi_req_get_method(r)
+  return id ~= FFI_BAD_CONTEXT
+
+end
+
+local function send_log(level, msg, ...)
+  local suffix = ""
+
+  -- Only append the request_id if it's a request, if not will raise an
+  -- exception.
+  if is_valid_request() then
+    suffix =  ", requestID=" .. ngx.var.request_id
+  end
+
+  local prefix = get_prefix_from_info(getinfo(2, "Snl")) .. ": "
+  local n = select("#", ...)
+  if n>0 then
+    for i=1,n do
+      msg = msg .. tostring(select(i, ...))
+    end
+  end
+
+  local final_message = prefix .. msg .. suffix
+
+  errlog.raw_log(level, final_message)
+end
+
+_M.log = send_log
+
+function _M:patch_ngx_log()
+  ngx.log = send_log
+end
+
+function _M:patch_ngx_log_on_debug()
+  local log_level = errlog.get_sys_filter_level()
+  if log_level == ngx.DEBUG then
+    self:patch_ngx_log()
+  end
+end
+
+return _M

--- a/t/apicast-log.t
+++ b/t/apicast-log.t
@@ -1,0 +1,91 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+repeat_each(2);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: validate that request_id is present.
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(200)
+    }
+  }
+--- upstream
+  location / {
+     echo 'yay, api backend: $http_host';
+  }
+--- request
+GET /?user_key=value
+--- response_body env
+yay, api backend: test:$TEST_NGINX_SERVER_PORT
+--- error_code: 200
+--- error_log eval
+qr/requestID=[0-9,a-z]{32}/
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: request_id are not present if LOG_LEVEL!=debug.
+--- log_level: info
+--- env eval
+(
+  'APICAST_LOG_LEVEL' => 'info',
+)
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(200)
+    }
+  }
+--- upstream
+  location / {
+     echo 'yay, api backend: $http_host';
+  }
+--- request
+GET /?user_key=value
+--- response_body env
+yay, api backend: test:$TEST_NGINX_SERVER_PORT
+--- error_code: 200
+--- no_error_log
+requestID=
+--- no_error_log
+[error]


### PR DESCRIPTION
When running APICast with a lot of requests is hard to know what log is
from each HTTP request, and it's hard to grep the logs easily.

This PR, patch ngx.log to use a custom implementation in Lua, that
provides the same info, but it appends a request_id in all log messages
produced by Lua, so it's easy to understand what happens.

This feature has a performance impact, so this is only enabled in
*debug* log level, so users will not be affected at all.

Sadly, some Nginx errors will not change, the HTTP log handler[1] does
not allow any outside interaction, but hopefully, this will help to
debug some complex scenarios like THREESCALE-4078

Example log request:

````
2020/01/17 11:23:11 [debug] 1377#1377: *9 executor.lua:26: rewrite(): executor phase: rewrite, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 policy_chain.lua:199: rewrite(): policy chain execute phase: rewrite, policy: Load Configuration, i: 1, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 policy_chain.lua:199: rewrite(): policy chain execute phase: rewrite, policy: Find Service Policy, i: 2, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [warn] 1377#1377: *9 find_service.lua:43: Using service id=42, requestID=547d2de951bb8a27912fd39327e0f9e8, client: 172.19.0.1, server: _, request: "GET /lola/?user_key=132&sleep=1 HTTP/1.1", host: "one"
2020/01/17 11:23:11 [debug] 1377#1377: *9 policy_chain.lua:199: rewrite(): policy chain execute phase: rewrite, policy: Local Policy Chain, i: 3, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 env.lua:86: fetch(): env: APICAST_BACKEND_CACHE_HANDLER = nil, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 cache_handler.lua:23: new(): backend cache handler: strict, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 policy_chain.lua:199: rewrite(): policy chain execute phase: rewrite, policy: APIcast, i: 1, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 service.lua:236: get_usage(): [mapping] service 42 has 1 rules, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 policy_chain.lua:199: rewrite(): policy chain execute phase: rewrite, policy: Metrics, i: 4, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 executor.lua:26: access(): executor phase: access, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 policy_chain.lua:199: access(): policy chain execute phase: access, policy: Load Configuration, i: 1, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 policy_chain.lua:199: access(): policy chain execute phase: access, policy: Find Service Policy, i: 2, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 policy_chain.lua:199: access(): policy chain execute phase: access, policy: Local Policy Chain, i: 3, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 policy_chain.lua:199: policy chain execute phase: access, policy: APIcast, i: 1, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [info] 1377#1377: *9 proxy.lua:82: output_debug_headers(): usage: usage%5Bhits%5D=2 credentials: user_key=132, requestID=547d2de951bb8a27912fd39327e0f9e8, client: 172.19.0.1, server: _, request: "GET /lola/?user_key=132&sleep=1 HTTP/1.1", host: "one"
2020/01/17 11:23:11 [info] 1377#1377: *9 proxy.lua:136: apicast cache miss key: 42:132:usage%5Bhits%5D=2 value: nil, requestID=547d2de951bb8a27912fd39327e0f9e8, client: 172.19.0.1, server: _, request: "GET /lola/?user_key=132&sleep=1 HTTP/1.1", host: "one"
2020/01/17 11:23:11 [debug] 1377#1377: *9 resolver.lua:195: new(): resolver search domains: , requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 resolver.lua:326: lookup(): resolver query: echo-api.3scale.net, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 cache.lua:122: fetch_answers(): resolver cache miss echo-api.3scale.net, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 cache.lua:188: get(): resolver cache miss: echo-api.3scale.net, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 resolver.lua:292: search_dns(): resolver query: echo-api.3scale.net search:  query: echo-api.3scale.net., requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 cache.lua:122: fetch_answers(): resolver cache miss echo-api.3scale.net., requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 cache.lua:188: get(): resolver cache miss: echo-api.3scale.net., requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 dns_client.lua:43: init_resolvers(): initializing 2 nameservers, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 dns_client.lua:56: init_resolvers(): nameserver 127.0.0.11:53 initialized, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 dns_client.lua:56: init_resolvers(): nameserver 127.0.0.11:53 initialized, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 dns_client.lua:68: query(): resolver query: echo-api.3scale.net. nameserver: 127.0.0.11:53, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 cache.lua:74: store(): resolver cache write echo-api.3scale.net with TLL 300, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 cache.lua:74: store(): resolver cache write tf-lb-0081dad066b2afef5328e0256a-2081992367.us-east-1.elb.amazonaws.com with TLL 60, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 resolver.lua:346: lookup(): resolver query: echo-api.3scale.net finished with 3 answers, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 resolver.lua:386: get_servers(): query for echo-api.3scale.net finished with 3 answers, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 resolver.lua:326: lookup(): resolver query: 54.86.250.161, requestID=547d2de951bb8a27912fd39327e0f9e8
2020/01/17 11:23:11 [debug] 1377#1377: *9 resolver.lua:331: lookup(): host is ip address: 54.86.250.161, requestID=547d2de951bb8a27912fd39327e0f9e8
```

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>