### PR TITLE
Policy: find_service log service id

### DIFF
--- a/gateway/src/apicast/policy/find_service/find_service.lua
+++ b/gateway/src/apicast/policy/find_service/find_service.lua
@@ -39,9 +39,12 @@ end
 local function find_service(policy, context)
   context.service = context.service or policy.find_service(context.configuration, context.host)
 
-  if not context.service then
+  if context.service then
+    ngx.log(ngx.DEBUG, "Using service id=", context.service.id)
+  else
     ngx.log(ngx.DEBUG, 'Could not find a service for the request')
   end
+
 end
 
 _M.rewrite = find_service


### PR DESCRIPTION
This commit adds the log with the service id used in the request.

This will help to know what service is hit, in some cases,  like the
combination of  PATH_ROUTING, LAZY mode, and multiple matched mapping
rules, so identify the service used will be used with this log.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>