### PR TITLE
Roverfile: Upgrade liquid to 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - When PATH routing was enabled the URL was not correctly escaped [THREESCALE-3468](https://issues.jboss.org/browse/THREESCALE-3468) [PR #1150](https://github.com/3scale/APIcast/pull/1150)
 - Add the correct host header when using an http proxy [THREESCALE-4178](https://issues.jboss.org/browse/THREESCALE-4178) [PR #1143](https://github.com/3scale/APIcast/pull/1143)
 - Normalize policy names capitalization [THREESCALE-4150](https://issues.jboss.org/browse/THREESCALE-4150) [PR #1154](https://github.com/3scale/APIcast/pull/1154)
-
-
+- Fix issues with non-alphanumeric variables in liquid [THREESCALE-3968](https://issues.jboss.org/browse/THREESCALE-3968) [PR #1158](https://github.com/3scale/APIcast/pull/1158)
 
 
 ### Fixed

--- a/gateway/Roverfile.lock
+++ b/gateway/Roverfile.lock
@@ -10,7 +10,7 @@ fifo 0.2-0||development
 http 0.3-0||development
 inspect 3.1.1-0||production
 ldoc 1.4.6-2||development
-liquid 0.1.3-1||production
+liquid 0.1.4-1||production
 ljsonschema 0.1.0-1||testing
 lpeg 1.0.2-1||development
 lpeg_patterns 0.5-0||development


### PR DESCRIPTION
Upgrade liquid-lua to support non alphanumeric variables.

Fix THREESCALE-3968

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>