### PR TITLE
Logging policy: add support to log JWT payload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added HTTP2 support [THREESCALE-3271](https://issues.jboss.org/browse/THREESCALE-3271) [PR #1128](https://github.com/3scale/APIcast/pull/1128)
 - Websocket support. [THREESCALE-4019](https://issues.jboss.org/browse/THREESCALE-4019) [PR #1152](https://github.com/3scale/APIcast/pull/1152)
 - Added Request_id on ngx.log function. [THREESCALE-3644](https://issues.jboss.org/browse/THREESCALE-3644) [PR #1156](https://github.com/3scale/APIcast/pull/1156)
+- Logging policy add the option to log JWT claims [THREESCALE-4326](https://issues.jboss.org/browse/THREESCALE-4326) [PR #1160](https://github.com/3scale/APIcast/pull/1160)
+
 
 ### Fixed
 

--- a/gateway/src/apicast/policy/logging/logging.lua
+++ b/gateway/src/apicast/policy/logging/logging.lua
@@ -79,6 +79,7 @@ local function get_request_context(context)
   ctx.usage = context.usage
   ctx.service = context.service or {}
   ctx.original_request = context.original_request
+  ctx.jwt = context.jwt or {}
   return LinkedList.readonly(ctx, ngx.var)
 end
 

--- a/t/apicast-policy-logging.t
+++ b/t/apicast-policy-logging.t
@@ -1,6 +1,9 @@
 use lib 't';
 use Test::APIcast::Blackbox 'no_plan';
 
+our $private_key = `cat t/fixtures/rsa.pem`;
+our $public_key = `cat t/fixtures/rsa.pub`;
+
 # Test::Nginx does not allow to grep access logs, so we redirect them to
 # stderr to be able to use "grep_error_log" by setting APICAST_ACCESS_LOG_FILE
 $ENV{APICAST_ACCESS_LOG_FILE} = "$Test::Nginx::Util::ErrLogFile";
@@ -461,3 +464,66 @@ GET /
 [qr/^Status\:\:200 42 echo localhost/]
 --- no_error_log eval
 [qr/\[error/, qr/GET \/ HTTP\/1.1\" 200/]
+
+
+=== TEST 12: Verify JWT information on logs
+--- configuration env eval
+use JSON qw(to_json);
+
+to_json({
+  services => [{
+    id => 42,
+    backend_version => 'oauth',
+    backend_authentication_type => 'provider_key',
+    backend_authentication_value => 'fookey',
+    proxy => {
+        authentication_method => 'oidc',
+        oidc_issuer_endpoint => 'https://example.com/auth/realms/apicast',
+        api_backend => "http://test:$TEST_NGINX_SERVER_PORT/",
+        proxy_rules => [
+          { pattern => '/', http_method => 'GET', metric_system_name => 'hits', delta => 1  }
+        ],
+        policy_chain => [
+            {
+                name => "apicast.policy.logging",
+                configuration => {
+                    custom_logging => "AUD::{{jwt.aud}}",
+                    enable_json_logs => JSON::false
+                }
+            },
+            { name => "apicast.policy.apicast" }
+        ]
+    }
+  }],
+  oidc => [{
+    issuer => 'https://example.com/auth/realms/apicast',
+    config => { id_token_signing_alg_values_supported => [ 'RS256' ] },
+    keys => { somekid => { pem => $::public_key } },
+  }]
+});
+--- upstream
+  location /test {
+    echo "yes";
+  }
+--- backend
+  location = /transactions/oauth_authrep.xml {
+    content_by_lua_block {
+      local expected = "provider_key=fookey&service_id=42&usage%5Bhits%5D=1&app_id=appid"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- request: GET /test
+--- error_code: 200
+--- more_headers eval
+use Crypt::JWT qw(encode_jwt);
+my $jwt = encode_jwt(payload => {
+  aud => 'something',
+  azp => 'appid',
+  sub => 'someone',
+  iss => 'https://example.com/auth/realms/apicast',
+  exp => time + 3600 }, key => \$::private_key, alg => 'RS256', extra_headers => { kid => 'somekid' });
+"Authorization: Bearer $jwt"
+--- error_log eval
+[qr/^AUD::something/]
+--- no_error_log
+[error]


### PR DESCRIPTION
This is useful to help users to log custom information in access log
that is part of JWT headers.

FIX THREESCALE-4326

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>