### PR TITLE
Policy::Logging: Fix crash on invalid config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Fixed naming issues in policies [THREESCALE-4150](https://issues.jboss.org/browse/THREESCALE-4150) [PR #1167](https://github.com/3scale/APIcast/pull/1167)
+- Fixed issues on invalid config in logging policy [THREESCALE-4605](https://issues.jboss.org/browse/THREESCALE-4605) [PR #1168](https://github.com/3scale/APIcast/pull/1168)
 
 ## [3.7.0-alpha2]
 

--- a/gateway/src/apicast/policy/logging/logging.lua
+++ b/gateway/src/apicast/policy/logging/logging.lua
@@ -56,7 +56,7 @@ function _M:load_condition(config)
 
   ngx.log(ngx.DEBUG, 'Enabling extended log with conditions')
   local operations = {}
-  for _, operation in ipairs(config.condition.operations) do
+  for _, operation in ipairs(config.condition.operations or {}) do
     table.insert( operations,
       Operation.new(
         operation.match, operation.match_type,


### PR DESCRIPTION
If the logging config is not correct,operations are not defined,the loop
will not work and it'll crash.

Fix #1165
Fix THREESCALE-4605

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>