### PR TITLE
Makefile: set env variable for luaossl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,9 @@ $(S2I_CONTEXT)/Roverfile.lock : $(S2I_CONTEXT)/Roverfile $(S2I_CONTEXT)/apicast-
 	$(ROVER) lock --roverfile=$(S2I_CONTEXT)/Roverfile
 
 lua_modules: $(ROVER) $(S2I_CONTEXT)/Roverfile.lock
-	$(ROVER) install --roverfile=$(S2I_CONTEXT)/Roverfile > /dev/null
+	# This variable is to skip issues with openssl 1.1.1
+	# https://github.com/wahern/luaossl/issues/175
+	EXTRA_CFLAGS="-DHAVE_EVP_KDF_CTX=1" $(ROVER) install --roverfile=$(S2I_CONTEXT)/Roverfile
 
 lua_modules/bin/rover:
 	@LUAROCKS_CONFIG=$(S2I_CONTEXT)/config-5.1.lua luarocks install --server=http://luarocks.org/dev lua-rover --tree=lua_modules 1>&2


### PR DESCRIPTION
This is a fix to build luaossl with OpenSSL 1.1.1.

Related issue: https://github.com/wahern/luaossl/issues/175

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>