### PR TITLE
Initial content caching policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added Rate-limit headers policy [THREESCALE-3795](https://issues.jboss.org/browse/THREESCALE-3795) [PR #1166](https://github.com/3scale/APIcast/pull/1166)
+- Added Content-caching policy [THREESCALE-2894](https://issues.jboss.org/browse/THREESCALE-2894) [PR #1182](https://github.com/3scale/APIcast/pull/1182)
 
 ## [3.8.0] - 2020-03-24
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -459,15 +459,20 @@ this environment variable, the response content will be cached in NGINX for the
 Headers cache time value, or the maximum time defined by
 `APICAST_CACHE_MAX_TIME` env variable.
 
+This parameter is only used by the services that are using content caching
+policy.
 
 ### `APICAST_CACHE_MAX_TIME`
 
 **Default:** 1m
 **Value:** string
 
-When the response is selected to be cached in the system, the value of this variable indicates
-the maximum time to be cached. If no header is set, the time to be cached will
-be the defined one.
+When the response is selected to be cached in the system, the value of this
+variable indicates the maximum time to be cached. If cache-control header is not
+set, the time to be cached will be the defined one.
 
 The format for this value is defined by the [`proxy_cache_valid` NGINX
 directive](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_valid)
+
+This parameter is only used by the services that are using content caching
+policy.

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -447,3 +447,27 @@ connections.
 
 By default Gateway does not enable it, and the keepalive timeout on nginx is set
 to [75 seconds](http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout)
+
+
+### `APICAST_CACHE_STATUS_CODES`
+
+**Default:** 200 302
+**Value:** string
+
+When the response code from upstream match one of the status code defined in
+this environment varible, the response content will be cached in Nginx for the
+Headers cache time value, or the maximum time defined by
+`APICAST_CACHE_MAX_TIME` env variable.
+
+
+### `APICAST_CACHE_MAX_TIME`
+
+**Default:** 1m
+**Value:** string
+
+When the response is selected to be cached in the system, this variable decides
+the maximum time to be cached. If no header is set, the time to be cached will
+be the defined one.
+
+The format for this value is defined by [`proxy_cache_valid` nginx
+directive](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_valid)

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -454,8 +454,8 @@ to [75 seconds](http://nginx.org/en/docs/http/ngx_http_core_module.html#keepaliv
 **Default:** 200 302
 **Value:** string
 
-When the response code from upstream match one of the status code defined in
-this environment varible, the response content will be cached in Nginx for the
+When the response code from upstream matches one of the status codes defined in
+this environment variable, the response content will be cached in NGINX for the
 Headers cache time value, or the maximum time defined by
 `APICAST_CACHE_MAX_TIME` env variable.
 
@@ -465,9 +465,9 @@ Headers cache time value, or the maximum time defined by
 **Default:** 1m
 **Value:** string
 
-When the response is selected to be cached in the system, this variable decides
+When the response is selected to be cached in the system, the value of this variable indicates
 the maximum time to be cached. If no header is set, the time to be cached will
 be the defined one.
 
-The format for this value is defined by [`proxy_cache_valid` nginx
+The format for this value is defined by the [`proxy_cache_valid` NGINX
 directive](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_valid)

--- a/gateway/conf.d/apicast.conf
+++ b/gateway/conf.d/apicast.conf
@@ -15,7 +15,6 @@ location = /___http_call {
   set $url '';
 
   set $proxy_pass '';
-
   set $host_header '';
   set $connection_header 'close';
   set $options '';
@@ -77,6 +76,15 @@ location @upstream {
   rewrite_by_lua_block {
     require('resty.ctx').apply()
   }
+
+  #{% capture proxy_cache_valid %}
+  #{#} proxy_cache apicast_cache;
+  #{#} proxy_cache_key $scheme$request_method$proxy_host$request_uri$service_id;
+  #{#} proxy_no_cache $cache_request;
+  #{#} proxy_cache_valid {{ env.APICAST_CACHE_STATUS_CODES | default: '200 302'}} {{ env.APICAST_CACHE_MAX_TIME | default: '1m' }};
+  #{% endcapture %}
+  #{{ proxy_cache_valid | replace: "#{#}", "" }}
+  #
 
   proxy_pass $proxy_pass;
 
@@ -156,7 +164,11 @@ location / {
   set $upstream_connection_header '';
   set $upstream_upgrade_header $http_upgrade;
 
+  # Variable to enable/disable content cache
+  set $cache_request 'true';
+
   set $original_request_id $request_id;
+
   # {% if http_keepalive_timeout != empty %}
   #   {% capture keepalive_timeout %}
   #{#}   keepalive_timeout {{ http_keepalive_timeout}};

--- a/gateway/conf/nginx.conf.liquid
+++ b/gateway/conf/nginx.conf.liquid
@@ -40,6 +40,7 @@ http {
 
 
 
+  proxy_cache_path /tmp/cache levels=1:2 keys_zone=apicast_cache:10m;
   # Enabling the Lua code cache is strongly encouraged for production use
   # Disabling it should only be done for testing and development purposes
   lua_code_cache {{  lua_code_cache | default: 'on' }};

--- a/gateway/src/apicast/policy/content_caching/Readme.md
+++ b/gateway/src/apicast/policy/content_caching/Readme.md
@@ -1,6 +1,6 @@
 # APICast Policy caching
 
-This policy allows to enable/disable caching based on a custom conditions. These
+This policy allows to enable and disable caching based on customized conditions. These
 conditions can only be applied on the client request, where upstream responses
 cannot be used in this policy.
 
@@ -35,17 +35,16 @@ cannot be used in this policy.
 
 ## Recommended configuration
 
-- For POST/PUT/DELETE method, the recommendation is not have this enabled.
+- Set `APICast Policy caching` as disabled, for any of the following methods: POST, PUT, DELETE.
 - If one condition matches, and it enables the cache, the execution will be
-  stopped and it'll be not disabled. Sort by priority is important here.
+  stopped and it will be not disabled. Sort by priority is important here.
 
 ## Upstream response headers
 
-At the moment, nginx [`proxy_cache_valid`
+At the moment, the NGINX [`proxy_cache_valid`
 directive](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_valid)
 information can only be set globally, with the `APICAST_CACHE_STATUS_CODES` and
-`APICAST_CACHE_MAX_TIME`. If your upstream need to have a different behavior
+`APICAST_CACHE_MAX_TIME`. If your upstream requires a different behavior
 regarding timeouts, the [`Cache-control`
 header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
 can be used and users can take advantage of that.
-

--- a/gateway/src/apicast/policy/content_caching/Readme.md
+++ b/gateway/src/apicast/policy/content_caching/Readme.md
@@ -4,6 +4,8 @@ This policy allows to enable and disable caching based on customized conditions.
 conditions can only be applied on the client request, where upstream responses
 cannot be used in this policy.
 
+This policy will respect all Cache-Control headers, if the endpoint send a
+different timeout, no-cache, etc. this policy will keep the upstream response.
 
 ## Example configuration
 
@@ -36,7 +38,7 @@ cannot be used in this policy.
 ## Recommended configuration
 
 - Set `APICast Policy caching` as disabled, for any of the following methods: POST, PUT, DELETE.
-- If one condition matches, and it enables the cache, the execution will be
+- If one rule matches, and it enables the cache, the execution will be
   stopped and it will be not disabled. Sort by priority is important here.
 
 ## Upstream response headers

--- a/gateway/src/apicast/policy/content_caching/Readme.md
+++ b/gateway/src/apicast/policy/content_caching/Readme.md
@@ -1,0 +1,51 @@
+# APICast Policy caching
+
+This policy allows to enable/disable caching based on a custom conditions. These
+conditions can only be applied on the client request, where upstream responses
+cannot be used in this policy.
+
+
+## Example configuration
+
+```
+{
+  "name": "apicast.policy.content_caching",
+  "version": "builtin",
+  "configuration": {
+    "rules": [
+      {
+        "cache": true,
+        "header": "X-Cache-Status-POLICY",
+        "condition": {
+          "combine_op": "and",
+          "operations": [
+            {
+              "left": "{{method}}",
+              "left_type": "liquid",
+              "op": "==",
+              "right": "GET"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+## Recommended configuration
+
+- For POST/PUT/DELETE method, the recommendation is not have this enabled.
+- If one condition matches, and it enables the cache, the execution will be
+  stopped and it'll be not disabled. Sort by priority is important here.
+
+## Upstream response headers
+
+At the moment, nginx [`proxy_cache_valid`
+directive](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_valid)
+information can only be set globally, with the `APICAST_CACHE_STATUS_CODES` and
+`APICAST_CACHE_MAX_TIME`. If your upstream need to have a different behavior
+regarding timeouts, the [`Cache-control`
+header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
+can be used and users can take advantage of that.
+

--- a/gateway/src/apicast/policy/content_caching/apicast-policy.json
+++ b/gateway/src/apicast/policy/content_caching/apicast-policy.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "Content caching",
+  "summary": "Option to enable content caching on responses.",
+  "description": [
+    "With this policy a new way to enable caching in APICast is enabled based on any liquid filter operation"
+  ],
+  "version": "builtin",
+  "configuration": {
+    "type": "object",
+    "definitions": {
+      "operation": {
+        "type": "object",
+        "$id": "#/definitions/operation",
+        "properties": {
+          "left": {
+            "type": "string"
+          },
+          "op": {
+            "description": "Operation to apply. The matches op supports PCRE (Perl compatible regular expressions)",
+            "type": "string",
+            "enum": [
+              "==",
+              "!=",
+              "matches"
+            ]
+          },
+          "right": {
+            "type": "string"
+          },
+          "left_type": {
+            "description": "How to evaluate 'left'",
+            "type": "string",
+            "default": "plain",
+            "oneOf": [
+              {
+                "enum": [
+                  "plain"
+                ],
+                "title": "Evaluate 'left' as plain text."
+              },
+              {
+                "enum": [
+                  "liquid"
+                ],
+                "title": "Evaluate 'left' as liquid."
+              }
+            ]
+          },
+          "right_type": {
+            "description": "How to evaluate 'right'",
+            "type": "string",
+            "default": "plain",
+            "oneOf": [
+              {
+                "enum": [
+                  "plain"
+                ],
+                "title": "Evaluate 'right' as plain text."
+              },
+              {
+                "enum": [
+                  "liquid"
+                ],
+                "title": "Evaluate 'right' as liquid."
+              }
+            ]
+          }
+        },
+        "required": [
+          "left",
+          "op",
+          "right"
+        ]
+      },
+      "rule": {
+        "type": "object",
+        "$id": "#/definitions/rule",
+        "title": "Rule",
+        "required": [
+          "cache"
+        ],
+        "properties": {
+          "cache": {
+            "type": "boolean",
+            "title": "Enable cache if match",
+            "default": false
+          },
+          "header": {
+            "type": "string",
+            "title": "Header name ",
+            "description": "Header name to return with the cache status (HIT, MISS,EXPIRED)",
+            "default": "X-Cache-Status"
+          },
+          "condition": {
+            "type": "object",
+            "title": "Condition",
+            "required": [
+              "combine_op",
+              "operations"
+            ],
+            "properties": {
+              "combine_op": {
+                "title": "Combine operation",
+                "type": "string",
+                "default": "and",
+                "enum": [
+                  "and",
+                  "or"
+                ]
+              },
+              "operations": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/operation"
+                },
+                "minItems": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    "properties": {
+      "rules": {
+        "type": "array",
+        "title": "Rules",
+        "description": "Rules to enable/disable caching",
+        "items": {
+          "$ref": "#/definitions/rule"
+        },
+        "minItems": 1
+      }
+    }
+  }
+}

--- a/gateway/src/apicast/policy/content_caching/apicast-policy.json
+++ b/gateway/src/apicast/policy/content_caching/apicast-policy.json
@@ -3,7 +3,7 @@
   "name": "Content caching",
   "summary": "Option to enable content caching on responses.",
   "description": [
-    "With this policy a new way to enable caching in APICast is enabled based on any liquid filter operation"
+    "With this policy a new way to enable caching in APICast is enabled based on any Liquid filter operation"
   ],
   "version": "builtin",
   "configuration": {

--- a/gateway/src/apicast/policy/content_caching/content_caching.lua
+++ b/gateway/src/apicast/policy/content_caching/content_caching.lua
@@ -1,0 +1,55 @@
+local policy = require('apicast.policy')
+local _M = policy.new('Content Caching', 'builtin')
+
+local tab_insert = table.insert
+local tab_new = require('resty.core.base').new_tab
+
+local Rule = require("rule")
+
+local new = _M.new
+
+function _M.new(config)
+  local self = new(config)
+
+  self.rules = tab_new(#config.rules, 0)
+  for _, config_rule in ipairs(config.rules or {}) do
+    local rule, err = Rule.new_from_config_rule(config_rule)
+    if rule then
+      tab_insert(self.rules, rule)
+    else
+      ngx.log(ngx.WARN, "Cannot load content caching rule, err:", err)
+    end
+  end
+  return self
+
+end
+
+function _M:access(context)
+  ngx.var.cache_request = "true"
+  for _, rule in ipairs(self.rules or {}) do
+    local cond_is_true = rule.condition:evaluate(context)
+    if cond_is_true and rule.cache then
+      -- This is because `proxy_no_cache` directive is used, so we need to make
+      -- the negative here.
+      ngx.var.cache_request = (rule.cache and "" or "true")
+      if rule.header then
+        context[self] = {header = rule.header}
+      end
+      return
+    end
+  end
+end
+
+function _M:header_filter(context)
+  -- Is not cached, no need to add the header
+  if ngx.var.cache_request ~= "" then
+    return
+  end
+
+  if context[self] and context[self].header then
+    ngx.header[context[self].header] = ngx.var.upstream_cache_status
+  end
+
+end
+
+return _M

--- a/gateway/src/apicast/policy/content_caching/init.lua
+++ b/gateway/src/apicast/policy/content_caching/init.lua
@@ -1,0 +1,1 @@
+return require("content_caching")

--- a/gateway/src/apicast/policy/content_caching/rule.lua
+++ b/gateway/src/apicast/policy/content_caching/rule.lua
@@ -1,0 +1,42 @@
+local setmetatable = setmetatable
+local ipairs = ipairs
+local tab_insert = table.insert
+local tab_new = require('resty.core.base').new_tab
+
+local Condition = require('apicast.conditions.condition')
+local Operation = require('apicast.conditions.operation')
+
+local _M = {}
+
+local mt = { __index = _M }
+
+local function init_operation(config_operation)
+  local left = config_operation.left
+  local left_type = config_operation.left_type or "plain"
+  local op = config_operation.op
+  local right = config_operation.right
+  local right_type = config_operation.right_type
+  return Operation.new(left, left_type, op, right, right_type)
+end
+
+local function init_condition(config_condition)
+  local operations = tab_new(#config_condition.operations, 0)
+
+  for _, operation in ipairs(config_condition.operations) do
+    tab_insert(operations, init_operation(operation))
+  end
+
+  return Condition.new(operations, config_condition.combine_op or "and")
+end
+
+
+function _M.new_from_config_rule(config_rule)
+  local self = setmetatable({}, mt)
+
+  self.cache = config_rule.cache or false
+  self.header = config_rule.header or nil
+  self.condition = init_condition(config_rule.condition)
+  return self
+end
+
+return _M

--- a/spec/policy/content_caching/content_caching_spec.lua
+++ b/spec/policy/content_caching/content_caching_spec.lua
@@ -1,0 +1,279 @@
+local content_caching =  require("apicast.policy.content_caching")
+
+describe('Content Caching policy', function()
+  local context = {}
+
+  before_each(function()
+    ngx.var = {}
+    ngx.header = {}
+    context = {}
+  end)
+
+  describe("and condition", function()
+    it('matches', function()
+      local config = {
+        rules = {
+          {
+            cache = true,
+            header = nil,
+            condition = {
+              combine_op = "and",
+              operations = {
+                { left = "bar", op = "==", right = "bar" },
+                { left = "foo", op = "==", right = "foo" }
+              }
+            }
+          }
+        }
+      }
+
+      local policy = content_caching.new(config)
+      policy:access(context)
+      assert.equals(ngx.var.cache_request, "")
+      assert.is_nil(context[policy], nil)
+    end)
+
+    it('does not match', function()
+      local config = {
+        rules = {
+          {
+            cache = true,
+            header = nil,
+            condition = {
+              combine_op = "and",
+              operations = {
+                { left = "bar", op = "==", right = "bar" },
+                { left = "test", op = "==", right = "foo" }
+              }
+            }
+          }
+        }
+      }
+
+      local policy = content_caching.new(config)
+      policy:access(context)
+      assert.equals(ngx.var.cache_request, "true")
+      assert.is_nil(context[policy], nil)
+    end)
+  end)
+
+  describe('OR condition', function()
+
+    it('matches', function()
+      local config = {
+        rules = {
+          {
+            cache = true,
+            header = nil,
+            condition = {
+              combine_op = "or",
+              operations = {
+                { left = "bar", op = "==", right = "bar" },
+                { left = "test", op = "==", right = "foo" }
+              }
+            }
+          }
+        }
+      }
+
+      local policy = content_caching.new(config)
+      policy:access(context)
+      assert.equals(ngx.var.cache_request, "")
+      assert.is_nil(context[policy], nil)
+    end)
+
+
+    it('does not match', function()
+      local config = {
+        rules = {
+          {
+            cache = true,
+            header = nil,
+            condition = {
+              combine_op = "or",
+              operations = {
+                { left = "test", op = "==", right = "bar" },
+                { left = "test", op = "==", right = "foo" }
+              }
+            }
+          }
+        }
+      }
+
+      local policy = content_caching.new(config)
+      policy:access(context)
+      assert.equals(ngx.var.cache_request, "true")
+      assert.is_nil(context[policy], nil)
+    end)
+
+  end)
+
+  describe("response header is set", function()
+
+    local header = "RESP:HEADER"
+
+    before_each(function()
+      ngx.var.upstream_cache_status = "CACHED_RESPONSE"
+    end)
+
+    it("If hader is set", function()
+      local config = {
+        rules = {
+          {
+            cache = true,
+            header = header,
+            condition = {
+              combine_op = "and",
+              operations = {
+                { left = "bar", op = "==", right = "bar" }
+              }
+            }
+          }
+        }
+      }
+
+      local policy = content_caching.new(config)
+
+      policy:access(context)
+      assert.equals(ngx.var.cache_request, "")
+      assert.not_equals(context[policy], nil)
+      assert.equals(context[policy].header, header)
+
+      policy:header_filter(context)
+      assert.equals(ngx.header[header], ngx.var.upstream_cache_status)
+    end)
+
+    it("Not elegible to cache, no response header is added", function()
+      local config = {
+        rules = {
+          {
+            cache = true,
+            header = header,
+            condition = {
+              combine_op = "and",
+              operations = {
+                { left = "foo", op = "==", right = "bar" }
+              }
+            }
+          }
+        }
+      }
+
+      local policy = content_caching.new(config)
+
+      policy:access(context)
+      assert.equals(ngx.var.cache_request, "true")
+      assert.is_nil(context[policy], nil)
+
+      policy:header_filter(context)
+      assert.is_nil(ngx.header[header])
+    end)
+
+  end)
+
+  describe("Multiple rules", function()
+
+    it("One rule match", function()
+
+      local config = {
+        rules = {
+          {
+            cache = true,
+            header = nil,
+            condition = {
+              combine_op = "and",
+              operations = {
+                { left = "foo", op = "==", right = "bar"}
+              }
+            }
+          },
+          {
+            cache = true,
+            header = nil,
+            condition = {
+              combine_op = "and",
+              operations = {
+                { left = "bar", op = "==", right = "bar"}
+              }
+            }
+          }
+        }
+      }
+
+      local policy = content_caching.new(config)
+
+      policy:access(context)
+      assert.equals(ngx.var.cache_request, "")
+      assert.is_nil(context[policy], nil)
+    end)
+
+    it("No rule match", function()
+
+      local config = {
+        rules = {
+          {
+            cache = true,
+            header = nil,
+            condition = {
+              combine_op = "and",
+              operations = {
+                { left = "foo", op = "==", right = "bar"}
+              }
+            }
+          },
+          {
+            cache = true,
+            header = nil,
+            condition = {
+              combine_op = "and",
+              operations = {
+                { left = "foo", op = "==", right = "bar"}
+              }
+            }
+          }
+        }
+      }
+
+      local policy = content_caching.new(config)
+
+      policy:access(context)
+      assert.equals(ngx.var.cache_request, "true")
+      assert.is_nil(context[policy], nil)
+    end)
+
+    it("First rule match stop executing", function()
+      local config = {
+        rules = {
+          {
+            cache = true,
+            header = nil,
+            condition = {
+              combine_op = "and",
+              operations = {
+                { left = "foo", op = "==", right = "foo"}
+              }
+            }
+          },
+          {
+            cache = false,
+            header = nil,
+            condition = {
+              combine_op = "and",
+              operations = {
+                { left = "foo", op = "==", right = "foo"}
+              }
+            }
+          }
+        }
+      }
+
+      local policy = content_caching.new(config)
+
+      policy:access(context)
+      assert.equals(ngx.var.cache_request, "")
+      assert.is_nil(context[policy], nil)
+    end)
+
+  end)
+
+end)

--- a/spec/policy/content_caching/rule_spec.lua
+++ b/spec/policy/content_caching/rule_spec.lua
@@ -1,0 +1,85 @@
+local caching_rule =  require("apicast.policy.content_caching.rule")
+local ngx_variable = require 'apicast.policy.ngx_variable'
+
+describe('Content Caching rule', function()
+  local context = {}
+
+  before_each(function()
+    ngx.var = {}
+    ngx.header = {}
+    context = {
+      foo = "foobar",
+      bar = "barfoo"
+    }
+    stub(ngx_variable, 'available_context', function(ctx) return ctx end)
+  end)
+
+  describe("Plaintext test", function()
+    it("default", function()
+      local config = {
+        cache = true,
+        header = nil,
+        condition = {
+          combine_op = "and",
+          operations = {
+            { left = "bar", op = "==", right = "bar" }
+          }
+        }
+      }
+
+      local rule = caching_rule.new_from_config_rule(config)
+      assert.is_true(rule.condition:evaluate(context))
+    end)
+
+    it("plaintext does not match", function()
+      local config = {
+        cache = true,
+        header = nil,
+        condition = {
+          combine_op = "and",
+          operations = {
+            { left = "bar", op = "==", right = "foobar" }
+          }
+        }
+      }
+
+      local rule = caching_rule.new_from_config_rule(config)
+      assert.is_falsy(rule.condition:evaluate(context))
+    end)
+  end)
+
+  describe("liquid test", function()
+
+    it("left_type", function()
+      local config = {
+        cache = true,
+        header = nil,
+        condition = {
+          combine_op = "and",
+          operations = {
+            { left = "{{foo}}", left_type = "liquid", op = "==", right = "foobar" }
+          }
+        }
+      }
+
+      local rule = caching_rule.new_from_config_rule(config)
+      assert.is_true(rule.condition:evaluate(context))
+    end)
+
+    it("right_type", function()
+      local config = {
+        cache = true,
+        header = nil,
+        condition = {
+          combine_op = "and",
+          operations = {
+            { left = "barfoo", op = "==", right = "{{bar}}", right_type = "liquid" }
+          }
+        }
+      }
+
+      local rule = caching_rule.new_from_config_rule(config)
+      assert.is_true(rule.condition:evaluate(context))
+    end)
+  end)
+end)

--- a/t/apicast-policy-content-caching.t
+++ b/t/apicast-policy-content-caching.t
@@ -1,0 +1,419 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+use File::Path 'rmtree';
+
+# This is to make sure tha cache is cleaned after all and before each request
+sub clean_cache {
+  rmtree([ "/tmp/cache/" ]);
+}
+add_block_preprocessor(sub {
+    clean_cache();
+});
+
+add_cleanup_handler(sub {
+    clean_cache();
+});
+
+use Cwd qw(getcwd abs_path);
+my $cwd = getcwd();
+$ENV{LUA_PATH} = "$ENV{LUA_PATH};$cwd/t/helpers/?.lua";
+
+# Can't run twice because it matters for caching
+repeat_each(1);
+run_tests();
+
+__DATA__
+
+=== TEST 1: Enables content caching
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.content_caching",
+            "version": "builtin",
+            "configuration": {
+              "rules": [
+                {
+                  "cache": true,
+                  "header": "X-Cache-Status",
+                  "condition": {
+                    "combine_op": "and",
+                    "operations": [
+                      {
+                        "left": "oo",
+                        "op": "==",
+                        "right": "oo"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/", "url": "http://test:$TEST_NGINX_SERVER_PORT/" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request eval
+["GET /foo", "GET /foo"]
+--- response_body eval
+["yay, api backend\n", "yay, api backend\n"]
+--- error_code eval
+[200, 200]
+--- response_headers eval
+["X-Cache-Status: MISS", "X-Cache-Status: HIT"]
+--- no_error_log
+[error]
+
+=== TEST 2: No operation match do not cache the request
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.content_caching",
+            "version": "builtin",
+            "configuration": {
+              "rules": [
+                {
+                  "cache": true,
+                  "header": "X-Cache-Status",
+                  "condition": {
+                    "combine_op": "and",
+                    "operations": [
+                      {
+                        "left": "oo",
+                        "op": "==",
+                        "right": "false"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/", "url": "http://test:$TEST_NGINX_SERVER_PORT/" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request eval
+["GET /foo"]
+--- response_body eval
+["yay, api backend\n"]
+--- error_code: 200
+--- response_headers
+!X-Cache-Status
+--- no_error_log
+[error]
+
+=== TEST 3: Multiple rules
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.content_caching",
+            "version": "builtin",
+            "configuration": {
+              "rules": [
+                {
+                  "cache": true,
+                  "header": "X-Cache-Status",
+                  "condition": {
+                    "combine_op": "and",
+                    "operations": [
+                      {
+                        "left": "oo",
+                        "op": "==",
+                        "right": "false"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "cache": true,
+                  "header": "X-Cache-Second",
+                  "condition": {
+                    "combine_op": "and",
+                    "operations": [
+                      {
+                        "left": "oo",
+                        "op": "==",
+                        "right": "oo"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/", "url": "http://test:$TEST_NGINX_SERVER_PORT/" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request eval
+["GET /foo", "GET /foo"]
+--- response_body eval
+["yay, api backend\n", "yay, api backend\n"]
+--- error_code eval
+[200, 200]
+--- response_headers eval
+["X-Cache-Second: MISS", "X-Cache-Second: HIT"]
+--- no_error_log
+[error]
+
+=== TEST 5: Not matching path is not hitting the cache
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.content_caching",
+            "version": "builtin",
+            "configuration": {
+              "rules": [
+                {
+                  "cache": true,
+                  "header": "X-Cache-Status",
+                  "condition": {
+                    "combine_op": "and",
+                    "operations": [
+                      {
+                        "left": "{{uri}}",
+                        "left_type": "liquid",
+                        "op": "==",
+                        "right": "/foo"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/", "url": "http://test:$TEST_NGINX_SERVER_PORT/" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request eval
+["GET /foo", "GET /test"]
+--- response_body eval
+["yay, api backend\n", "yay, api backend\n"]
+--- error_code eval
+[200, 200]
+--- response_headers eval
+["X-Cache-Status: MISS", "!X-Cache-Status"]
+--- no_error_log
+[error]
+
+=== TEST 6: Different cache status codes
+--- env eval
+(
+  'APICAST_CACHE_STATUS_CODES' => "201 302",
+)
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.content_caching",
+            "version": "builtin",
+            "configuration": {
+              "rules": [
+                {
+                  "cache": true,
+                  "header": "X-Cache-Status",
+                  "condition": {
+                    "combine_op": "and",
+                    "operations": [
+                      {
+                        "left": "oo",
+                        "op": "==",
+                        "right": "oo"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/", "url": "http://test:$TEST_NGINX_SERVER_PORT/" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /foo {
+     content_by_lua_block {
+       ngx.say('ok');
+     }
+  }
+
+  location /redirect {
+     content_by_lua_block {
+       ngx.status = 302
+       ngx.print('ok');
+     }
+  }
+
+  location /create {
+     content_by_lua_block {
+       ngx.status = 201
+       ngx.print('ok');
+     }
+  }
+--- request eval
+["GET /foo", "GET /foo", "GET /redirect", "GET /redirect", "GET /create", "GET /create"]
+--- response_body eval
+["ok\n", "ok\n", "ok", "ok", "ok", "ok"]
+--- error_code eval
+[200, 200, 302, 302, 201, 201]
+--- response_headers eval
+[
+  "X-Cache-Status: MISS",
+  "X-Cache-Status: MISS",
+  "X-Cache-Status: MISS",
+  "X-Cache-Status: HIT",
+  "X-Cache-Status: MISS",
+  "X-Cache-Status: HIT"
+]
+--- no_error_log
+[error]
+
+=== TEST 7: Cache-control header
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.content_caching",
+            "version": "builtin",
+            "configuration": {
+              "rules": [
+                {
+                  "cache": true,
+                  "header": "X-Cache-Status",
+                  "condition": {
+                    "combine_op": "and",
+                    "operations": [
+                      {
+                        "left": "oo",
+                        "op": "==",
+                        "right": "oo"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/", "url": "http://test:$TEST_NGINX_SERVER_PORT/" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.header["Cache-Control"] = "no-cache"
+       ngx.say('yay, api backend');
+     }
+  }
+--- request eval
+["GET /foo", "GET /foo"]
+--- response_body eval
+["yay, api backend\n", "yay, api backend\n"]
+--- error_code eval
+[200, 200]
+--- response_headers eval
+["X-Cache-Status: MISS", "X-Cache-Status: MISS"]
+--- no_error_log
+[error]


### PR DESCRIPTION
This policy enables content caching in Nginx based on the request information and some new env variables added into the process.

This policy heavily uses proxy_cache directives, where we can enable/disable based on the policy.

Around response status codes, and headers, some details have been shared on Jira issues[0]

[0] https://issues.redhat.com/browse/THREESCALE-4064?focusedCommentId=13981036&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13981036

Fix THREESCALE-4064
Fix THREESCALE-2894
Fix THREESCALE-487

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>