### PR TITLE
GRPC: Routing rewrite upstream and GRPC one was not used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+
 ## [Unreleased]
 
 - Fixed naming issues in policies [THREESCALE-4150](https://issues.jboss.org/browse/THREESCALE-4150) [PR #1167](https://github.com/3scale/APIcast/pull/1167)
 - Fixed issues on invalid config in logging policy [THREESCALE-4605](https://issues.jboss.org/browse/THREESCALE-4605) [PR #1168](https://github.com/3scale/APIcast/pull/1168)
+- Fixed issues with routing policy and GRPC one [THREESCALE-4684](https://issues.jboss.org/browse/THREESCALE-4684) [PR #1177](https://github.com/3scale/APIcast/pull/1177)
 
 ## [3.7.0-alpha2]
 

--- a/gateway/src/apicast/policy/grpc/grpc.lua
+++ b/gateway/src/apicast/policy/grpc/grpc.lua
@@ -21,6 +21,19 @@ function _M:rewrite(context)
   end
 end
 
+function _M:content(context)
+  -- This is needed within the combination of the routing policy, if not the
+  -- upstream got overwritten and balancer phase is called before.
+  if not context.upstream_location_name then
+    return
+  end
+
+  if ngx.var.server_protocol ~= "HTTP/2.0" then
+    ngx.var.host = context.upstream_location_name
+  end
+
+end
+
 function _M:balancer(context)
   if not context.upstream_location_name then
     return
@@ -37,7 +50,7 @@ function _M:balancer(context)
   local peers = balancer:peers(upstream.servers)
   local peer, err = balancer:select_peer(peers)
   if err then
-    ngx.log(ngx.WARN, "Cannot get a peer for the given upstream", err)
+    ngx.log(ngx.WARN, "Cannot get a peer for the given upstream: ", err)
     return
   end
 


### PR DESCRIPTION
This is a fix for GRPC when routing policy is used, where it uses the
old http1 endpoint.

Sample Config
```
"policy_chain": [
  {
    "name": "routing",
    "version": "builtin",
    "enabled": true,
    "configuration": {
      "rules": [
        {
          "url": "https://home-ip.acalustra.com:8080/",
          "owner_id": 3,
          "owner_type": "BackendApi",
          "condition": {
            "operations": [
              {
                "match": "path",
                "op": "matches",
                "value": "/default/.*|/default/?"
              }
            ]
          },
          "replace_path": "{{original_request.path | remove_first: '/default'}}"
        }
      ]
    }
  },
  {
    "name": "grpc",
    "version": "builtin",
    "configuration": {}
  },
  {
    "name": "apicast.policy.apicast"
  }
]
```

Fix THREESCALE-4684

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>