### PR TITLE
[3.8] GRPC policy: Fix routing upstream issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fixed naming issues in policies [THREESCALE-4150](https://issues.jboss.org/browse/THREESCALE-4150) [PR #1167](https://github.com/3scale/APIcast/pull/1167)
 - Fixed issues on invalid config in logging policy [THREESCALE-4605](https://issues.jboss.org/browse/THREESCALE-4605) [PR #1168](https://github.com/3scale/APIcast/pull/1168)
-- Fixed issues with routing policy and GRPC one [THREESCALE-4684](https://issues.jboss.org/browse/THREESCALE-4684) [PR #1177](https://github.com/3scale/APIcast/pull/1177)
+- Fixed issues with routing policy and GRPC one [THREESCALE-4684](https://issues.jboss.org/browse/THREESCALE-4684) [PR #1177](https://github.com/3scale/APIcast/pull/1177) [PR #1179](https://github.com/3scale/APIcast/pull/1179)
 
 ## [3.8.0-alpha2] - 2019-02-18
 

--- a/gateway/src/apicast/policy/grpc/grpc.lua
+++ b/gateway/src/apicast/policy/grpc/grpc.lua
@@ -2,12 +2,9 @@
 
 local policy = require('apicast.policy')
 local _M = policy.new('grpc', "builtin")
-local resty_url = require('resty.url')
-local round_robin = require 'resty.balancer.round_robin'
 
+local apicast_balancer = require('apicast.balancer')
 local new = _M.new
-
-local balancer = round_robin.new()
 
 function _M.new(config)
   local self = new(config)
@@ -15,53 +12,11 @@ function _M.new(config)
 end
 
 function _M:rewrite(context)
-  if ngx.var.server_protocol == "HTTP/2.0" then
     -- upstream defined in gateway/conf.d/http2.conf
     context.upstream_location_name = "@grpc_upstream"
-  end
+    ngx.var.proxy_host = "upstream"
 end
 
-function _M:content(context)
-  -- This is needed within the combination of the routing policy, if not the
-  -- upstream got overwritten and balancer phase is called before.
-  if not context.upstream_location_name then
-    return
-  end
-
-  if ngx.var.server_protocol ~= "HTTP/2.0" then
-    ngx.var.host = context.upstream_location_name
-  end
-
-end
-
-function _M:balancer(context)
-  if not context.upstream_location_name then
-    return
-  end
-
-  -- balancer need to be used due to grpc_pass does not support variables and
-  -- upstream block need to be in place.
-  local upstream = context:get_upstream()
-  if not upstream then
-    ngx.log(ngx.WARN, "Upstream is not present in the balancer")
-    return
-  end
-
-  local peers = balancer:peers(upstream.servers)
-  local peer, err = balancer:select_peer(peers)
-  if err then
-    ngx.log(ngx.WARN, "Cannot get a peer for the given upstream: ", err)
-    return
-  end
-
-  local ip = peer[1]
-  local port = peer[2] or upstream.uri.port or resty_url.default_port(upstream.uri.scheme)
-  local _, err = balancer:set_current_peer(ip, port)
-
-  if err then
-    ngx.log(ngx.WARN, "Cannot set balancer IP and port '", ip, ":", port, "'")
-    return
-  end
-end
+_M.balancer = apicast_balancer.call
 
 return _M

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -221,7 +221,9 @@ function _M:call(context)
     end
 
     if not self.servers then self:resolve() end
-
+    if context.upstream_location_name then
+        self.location_name = context.upstream_location_name
+    end
     context[self.upstream_name] = self
 
     return exec(self)


### PR DESCRIPTION
This commit makes things super simpler in GRPC, and avoid the
miss-configuration that was made previously around upstream&balancers.

Before on GRPC we set the balancer, and all the balancer logic happened
on the policy itself, instead of using the apicast.upstream and
apicast.balancer.

With this change, the location is changed on the upstream.lua, so it
does not matter if was set in the apicast.policy, or in another policy,
in this case the routing policy.

This finally fix THREESCALE-4684

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>