### PR TITLE
Policy: MTLS upstream policy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ executors:
   openresty:
     working_directory: /opt/app-root/apicast
     docker:
-    - image: quay.io/3scale/s2i-openresty-centos7:1.17.4.1-0-centos8
+    - image: quay.io/3scale/s2i-openresty-centos7:1.17.5.1-0-centos8
     - image: redis:3.2.8-alpine
     environment:
       TEST_NGINX_BINARY: openresty

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ executors:
     environment:
       S2I_VERSION: "1.1.12-2a783420"
       DOCKER_COMPOSE_VERSION: "1.16.1"
-      OPENRESTY_VERSION: "1.17.4.1-0-centos8"
+      OPENRESTY_VERSION: "1.17.5.1-0-centos8"
 
   openresty:
     working_directory: /opt/app-root/apicast

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added upstream MTLS policy [THREESCALE-672](https://issues.jboss.org/browse/THREESCALE-672) [PR #1182](https://github.com/3scale/APIcast/pull/1182)
 - Added Rate-limit headers policy [THREESCALE-3795](https://issues.jboss.org/browse/THREESCALE-3795) [PR #1166](https://github.com/3scale/APIcast/pull/1166)
 - Added Content-caching policy [THREESCALE-2894](https://issues.jboss.org/browse/THREESCALE-2894) [PR #1182](https://github.com/3scale/APIcast/pull/1182)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added upstream MTLS policy [THREESCALE-672](https://issues.jboss.org/browse/THREESCALE-672) [PR #1182](https://github.com/3scale/APIcast/pull/1182)
+- Added upstream Mutual TLS policy [THREESCALE-672](https://issues.jboss.org/browse/THREESCALE-672) [PR #1182](https://github.com/3scale/APIcast/pull/1182)
 - Added Rate-limit headers policy [THREESCALE-3795](https://issues.jboss.org/browse/THREESCALE-3795) [PR #1166](https://github.com/3scale/APIcast/pull/1166)
 - Added Content-caching policy [THREESCALE-2894](https://issues.jboss.org/browse/THREESCALE-2894) [PR #1182](https://github.com/3scale/APIcast/pull/1182)
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -165,7 +165,7 @@ It can be used to first load policies from a development directory or to load ex
 
 The path to the key of the client SSL certificate.
 
-This parameter can be override by the Upstream_TLS policy.
+This parameter can be overridden by the Upstream_TLS policy.
 
 ### `APICAST_PROXY_HTTPS_CERTIFICATE`
 
@@ -177,7 +177,7 @@ The path to the client SSL certificate that APIcast will use when connecting
 with the upstream. Notice that this certificate will be used for all the
 services in the configuration.
 
-This parameter can be override by the Upstream_TLS policy.
+This parameter can be overridden by the Upstream_TLS policy.
 
 ### `APICAST_PROXY_HTTPS_PASSWORD_FILE`
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -165,6 +165,8 @@ It can be used to first load policies from a development directory or to load ex
 
 The path to the key of the client SSL certificate.
 
+This parameter can be override by the Upstream_TLS policy.
+
 ### `APICAST_PROXY_HTTPS_CERTIFICATE`
 
 **Default:**  
@@ -174,6 +176,8 @@ The path to the key of the client SSL certificate.
 The path to the client SSL certificate that APIcast will use when connecting
 with the upstream. Notice that this certificate will be used for all the
 services in the configuration.
+
+This parameter can be override by the Upstream_TLS policy.
 
 ### `APICAST_PROXY_HTTPS_PASSWORD_FILE`
 

--- a/gateway/Roverfile
+++ b/gateway/Roverfile
@@ -9,7 +9,7 @@ luarocks {
     group 'testing' {
         module { 'busted' },
         module { 'luacov' },
-        module { 'ljsonschema' },
+        module { 'jsonschema' },
     },
 
     group 'development' {

--- a/gateway/Roverfile.lock
+++ b/gateway/Roverfile.lock
@@ -11,7 +11,7 @@ http 0.3-0||development
 inspect 3.1.1-0||production
 ldoc 1.4.6-2||development
 liquid 0.1.5-1||production
-ljsonschema 0.1.0-1||testing
+jsonschema 0.8-0|aa4740624cca4c10585bd7d086b42aa0b9ab14fa|testing
 lpeg 1.0.2-1||development
 lpeg_patterns 0.5-0||development
 lua-resty-env 0.4.0-1||production

--- a/gateway/src/apicast/policy/content_caching/content_caching.lua
+++ b/gateway/src/apicast/policy/content_caching/content_caching.lua
@@ -32,7 +32,7 @@ function _M:access(context)
       -- This is because `proxy_no_cache` directive is used, so we need to make
       -- the negative here.
       ngx.var.cache_request = (rule.cache and "" or "true")
-      if rule.header then
+      if rule.header and rule.header ~= "" then
         context[self] = {header = rule.header}
       end
       return

--- a/gateway/src/apicast/policy/rate_limit/apicast-policy.json
+++ b/gateway/src/apicast/policy/rate_limit/apicast-policy.json
@@ -197,7 +197,7 @@
             "window": {
               "type": "integer",
               "description": "The time window in seconds before the request count is reset",
-              "exclusiveMinimum": 0,
+              "minimum": 0,
               "default": 1
             }
           }

--- a/gateway/src/apicast/policy/upstream_mtls/Readme.md
+++ b/gateway/src/apicast/policy/upstream_mtls/Readme.md
@@ -1,6 +1,6 @@
-# Upstream MTLs policy.
+# Upstream Mutual TLS policy
 
-This policy enables the MTLS policy per service, so connection to the upstream
+This policy enables the Mutual TLS policy per API, so connection to the upstream
 API will use the certificates defined in this policy.
 
 ## Configuration
@@ -39,6 +39,6 @@ When using http forms and file upload
 
 ## Additional considerations
 
-This policy will overwrite `APICAST_PROXY_HTTPS_CERTIFICATE_KEY` and
-`APICAST_PROXY_HTTPS_CERTIFICATE` values and it'll use the certificates set by
-the policy, so those ENV variables will have no effect.
+This policy overwrites `APICAST_PROXY_HTTPS_CERTIFICATE_KEY` and
+`APICAST_PROXY_HTTPS_CERTIFICATE` values and it uses the certificates set by
+the policy, so those environment variables will have no effect.

--- a/gateway/src/apicast/policy/upstream_mtls/Readme.md
+++ b/gateway/src/apicast/policy/upstream_mtls/Readme.md
@@ -1,0 +1,44 @@
+# Upstream MTLs policy.
+
+This policy enables the MTLS policy per service, so connection to the upstream
+API will use the certificates defined in this policy.
+
+## Configuration
+
+### Path configuration
+
+Using certificates Path, both for Openshift and Kubernetes secrets.
+
+```
+{
+  "name": "apicast.policy.upstream_mtls",
+  "configuration": {
+      "certificate": "/secrets/client.cer",
+      "certificate_type": "path",
+      "certificate_key": "/secrets/client.key",
+      "certificate_key_type": "path"
+  }
+}
+```
+
+### Embedded configuration
+
+When using http forms and file upload
+
+```
+{
+  "name": "apicast.policy.upstream_mtls",
+  "configuration": {
+    "certificate_type": "embedded",
+    "certificate_key_type": "embedded",
+    "certificate": "data:application/pkix-cert;name=client.cer;base64,XXXXXXXXXxx",
+    "certificate_key": "data:application/x-iwork-keynote-sffkey;name=client.key;base64,XXXXXXXX"
+  }
+}
+```
+
+## Additional considerations
+
+This policy will overwrite `APICAST_PROXY_HTTPS_CERTIFICATE_KEY` and
+`APICAST_PROXY_HTTPS_CERTIFICATE` values and it'll use the certificates set by
+the policy, so those ENV variables will have no effect.

--- a/gateway/src/apicast/policy/upstream_mtls/apicast-policy.json
+++ b/gateway/src/apicast/policy/upstream_mtls/apicast-policy.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
+  "name": "Upstream Mutual TLS",
+  "summary": "Certificates to be used with the upstream API",
+  "description": "With this policy a new TLS connection with the upstream API will be used with the certificates set in the config",
+  "version": "builtin",
+  "configuration": {
+    "title": "Upstream MTLS",
+    "description": "Built-in Upstream MTLS APIcast policy",
+    "type": "object",
+    "required": [
+      "certificate_type",
+      "certificate_key_type"
+    ],
+    "properties": {
+      "certificate_type": {
+        "title": "Certificate type",
+        "type": "string",
+        "enum": [
+          "path",
+          "embedded"
+        ],
+        "default": "path"
+      },
+      "certificate_key_type": {
+        "title": "Certificate key type",
+        "type": "string",
+        "enum": [
+          "path",
+          "embedded"
+        ],
+        "default": "path"
+      }
+    },
+    "dependencies": {
+      "certificate_type": {
+        "oneOf": [
+          {
+            "properties": {
+              "certificate_type": {
+                "const": "embedded"
+              },
+              "certificate": {
+                "title": "Certificate",
+                "format": "data-url",
+                "type": "string"
+              }
+            }
+          },
+          {
+            "properties": {
+              "certificate_type": {
+                "const": "path"
+              },
+              "certificate": {
+                "title": "Certificate",
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "certificate_key_type": {
+        "oneOf": [
+          {
+            "properties": {
+              "certificate_key_type": {
+                "const": "embedded"
+              },
+              "certificate_key": {
+                "title": "Certificate Key",
+                "format": "data-url",
+                "type": "string"
+              }
+            }
+          },
+          {
+            "properties": {
+              "certificate_key_type": {
+                "const": "path"
+              },
+              "certificate_key": {
+                "title": "Certificate Key",
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/gateway/src/apicast/policy/upstream_mtls/init.lua
+++ b/gateway/src/apicast/policy/upstream_mtls/init.lua
@@ -1,0 +1,1 @@
+return require("upstream_mtls")

--- a/gateway/src/apicast/policy/upstream_mtls/upstream_mtls.lua
+++ b/gateway/src/apicast/policy/upstream_mtls/upstream_mtls.lua
@@ -1,0 +1,123 @@
+-- This policy enables MTLS with the upstream API endpoint
+
+local ssl = require('ngx.ssl')
+local ffi = require "ffi"
+local base = require "resty.core.base"
+local data_url = require('resty.data_url')
+
+local C = ffi.C
+local get_request = base.get_request
+local open = io.open
+
+
+ffi.cdef([[
+  int ngx_http_apicast_ffi_set_proxy_cert_key(
+    ngx_http_request_t *r, void *cdata_chain, void *cdata_key);
+]])
+
+
+local policy = require('apicast.policy')
+local _M = policy.new('mtls', "builtin")
+
+local path_type = "path"
+local embedded_type = "embedded"
+
+local new = _M.new
+
+
+local function read_file(path)
+  ngx.log(ngx.DEBUG, "reading path:", path)
+
+  local file = open(path, "rb")
+  if not file then
+    ngx.log(ngx.ERR, "Cannot read path: ", path)
+    return nil
+  end
+
+  local content = file:read("*a")
+  file:close()
+  return content
+end
+
+
+local function get_cert(value, value_type)
+  if value_type == path_type then
+    return read_file(value)
+  end
+
+  if value_type == embedded_type then
+    local parsed_data, err = data_url.parse(value)
+    if err then
+      ngx.log(ngx.ERR, "Cannot parse certificate content: ", err)
+      return nil
+    end
+    return parsed_data.data
+  end
+end
+
+local function read_certificate(value, value_type)
+  local data = get_cert(value, value_type)
+  if data == nil then
+    ngx.log(ngx.ERR, "Certificate value is invalid")
+    return
+  end
+  return ssl.parse_pem_cert(data)
+end
+
+local function read_certificate_key(value, value_type)
+
+  local data = get_cert(value, value_type)
+
+  if data == nil then
+    ngx.log(ngx.ERR, "Certificate value is invalid")
+    return
+  end
+
+  if data == nil then
+    ngx.log(ngx.ERR, "Certificate key value is invalid")
+    return
+  end
+
+  return ssl.parse_pem_priv_key(data)
+
+end
+
+function _M.new(config)
+  local self = new(config)
+  if config == nil then
+    config = {}
+  end
+
+  self.cert = read_certificate(
+    config.certificate,
+    config.certificate_type or path_type)
+  self.cert_key = read_certificate_key(
+    config.certificate_key,
+    config.certificate_key_type or path_type)
+  return self
+end
+
+
+-- Set the certs for the upstream connection. Need to receive the pointers from
+-- parse_* functions.
+--- Public function to be able to unittest this.
+function _M.set_certs(cert, key)
+  local r = get_request()
+  if not r then
+    ngx.log(ngx.ERR, "No valid request")
+    return
+  end
+
+  local val = C.ngx_http_apicast_ffi_set_proxy_cert_key(r, cert, key)
+  if val ~= ngx.OK then
+    ngx.log(ngx.ERR, "Certificate cannot be set correctly")
+  end
+end
+
+function _M:balancer(context)
+  if self.cert and self.cert_key then
+    self.set_certs(self.cert, self.cert_key)
+  end
+end
+
+return _M

--- a/gateway/src/apicast/policy/upstream_mtls/upstream_mtls.lua
+++ b/gateway/src/apicast/policy/upstream_mtls/upstream_mtls.lua
@@ -104,7 +104,7 @@ end
 function _M.set_certs(cert, key)
   local r = get_request()
   if not r then
-    ngx.log(ngx.ERR, "No valid request")
+    ngx.log(ngx.ERR, "Invalid request")
     return
   end
 

--- a/spec/policy/content_caching/content_caching_spec.lua
+++ b/spec/policy/content_caching/content_caching_spec.lua
@@ -15,7 +15,7 @@ describe('Content Caching policy', function()
         rules = {
           {
             cache = true,
-            header = nil,
+            header = "",
             condition = {
               combine_op = "and",
               operations = {
@@ -64,7 +64,7 @@ describe('Content Caching policy', function()
         rules = {
           {
             cache = true,
-            header = nil,
+            header = "",
             condition = {
               combine_op = "or",
               operations = {
@@ -179,7 +179,7 @@ describe('Content Caching policy', function()
         rules = {
           {
             cache = true,
-            header = nil,
+            header = "",
             condition = {
               combine_op = "and",
               operations = {
@@ -189,7 +189,7 @@ describe('Content Caching policy', function()
           },
           {
             cache = true,
-            header = nil,
+            header = "",
             condition = {
               combine_op = "and",
               operations = {
@@ -213,7 +213,7 @@ describe('Content Caching policy', function()
         rules = {
           {
             cache = true,
-            header = nil,
+            header = "",
             condition = {
               combine_op = "and",
               operations = {
@@ -223,7 +223,7 @@ describe('Content Caching policy', function()
           },
           {
             cache = true,
-            header = nil,
+            header = "",
             condition = {
               combine_op = "and",
               operations = {
@@ -246,7 +246,7 @@ describe('Content Caching policy', function()
         rules = {
           {
             cache = true,
-            header = nil,
+            header = "",
             condition = {
               combine_op = "and",
               operations = {
@@ -256,7 +256,7 @@ describe('Content Caching policy', function()
           },
           {
             cache = false,
-            header = nil,
+            header = "",
             condition = {
               combine_op = "and",
               operations = {

--- a/spec/policy/rate_limit/rate_limit_spec.lua
+++ b/spec/policy/rate_limit/rate_limit_spec.lua
@@ -66,13 +66,13 @@ describe('Rate limit policy', function()
       it('does not crash', function()
         local rate_limit_policy = RateLimitPolicy.new({
           connection_limiters = {
-            { key = { name = 'test1', scope = 'global' }, conn = 0, burst = 0, delay = 0 }
+            { key = { name = 'test1', scope = 'global' }, conn = 1, burst = 0, delay = 0.5 }
           },
           leaky_bucket_limiters = {
-            { key = { name = 'test2', scope = 'global' }, rate = 0, burst = 0 }
+            { key = { name = 'test2', scope = 'global' }, rate = 1, burst = 0 }
           },
           fixed_window_limiters = {
-            { key = { name = 'test3', scope = 'global' }, count = 0, window = 0 }
+            { key = { name = 'test3', scope = 'global' }, count = 1, window = 1 }
           },
         })
 
@@ -98,7 +98,7 @@ describe('Rate limit policy', function()
       it('works with multiple limiters', function()
         local rate_limit_policy = RateLimitPolicy.new({
           connection_limiters = {
-            { key = { name = 'test1', scope = 'global' }, conn = 20, burst = 10, delay = 0.5 }
+            { key = { name = 'test1', scope = 'global' }, conn = 20, burst = 10, delay = 0.4 }
           },
           leaky_bucket_limiters = {
             { key = { name = 'test2', scope = 'global' }, rate = 18, burst = 9 }

--- a/t/apicast-policy-upstream_mtls.t
+++ b/t/apicast-policy-upstream_mtls.t
@@ -1,0 +1,264 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+repeat_each(1);
+run_tests();
+
+
+__DATA__
+
+=== TEST 1: MTLS policy with correct certificate
+--- init eval
+$Test::Nginx::Util::ENDPOINT_SSL_PORT = Test::APIcast::get_random_port();
+--- user_files fixture=mutual_ssl.pl eval
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- configuration eval
+<<EOF
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "https://test:$Test::Nginx::Util::ENDPOINT_SSL_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" },
+          {
+            "name": "apicast.policy.upstream_mtls",
+            "configuration": {
+                "certificate": "$ENV{TEST_NGINX_SERVER_ROOT}/html/client.crt",
+                "certificate_type": "path",
+                "certificate_key": "$ENV{TEST_NGINX_SERVER_ROOT}/html/client.key",
+                "certificate_key_type": "path"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+EOF
+--- upstream eval
+<<EOF
+  listen $Test::Nginx::Util::ENDPOINT_SSL_PORT ssl;
+
+  ssl_certificate $ENV{TEST_NGINX_SERVER_ROOT}/html/server.crt;
+  ssl_certificate_key $ENV{TEST_NGINX_SERVER_ROOT}/html/server.key;
+
+  ssl_client_certificate $ENV{TEST_NGINX_SERVER_ROOT}/html/client.crt;
+  ssl_verify_client on;
+
+  location / {
+     echo 'ssl_client_s_dn: \$ssl_client_s_dn';
+     echo 'ssl_client_i_dn: \$ssl_client_i_dn';
+  }
+EOF
+--- request
+GET /?user_key=value
+--- response_body
+ssl_client_s_dn: CN=localhost,OU=APIcast,O=3scale
+ssl_client_i_dn: CN=localhost,OU=APIcast,O=3scale
+--- error_code: 200
+--- no_error_log
+[error]
+
+
+=== TEST 2: MTLS policy takes precedence over env variables
+In this test we set the env variables to an invalid keys, to make sure that the
+correct ones are used.
+--- init eval
+$Test::Nginx::Util::ENDPOINT_SSL_PORT = Test::APIcast::get_random_port();
+--- user_files fixture=mutual_ssl.pl eval
+--- env random_port eval
+(
+  'APICAST_PROXY_HTTPS_CERTIFICATE' => "$Test::Nginx::Util::ServRoot/html/server.crt",
+  'APICAST_PROXY_HTTPS_CERTIFICATE_KEY' => "$Test::Nginx::Util::ServRoot/html/server.key",
+)
+
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- configuration eval
+<<EOF
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "https://test:$Test::Nginx::Util::ENDPOINT_SSL_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" },
+          {
+            "name": "apicast.policy.upstream_mtls",
+            "configuration": {
+                "certificate": "$ENV{TEST_NGINX_SERVER_ROOT}/html/client.crt",
+                "certificate_type": "path",
+                "certificate_key": "$ENV{TEST_NGINX_SERVER_ROOT}/html/client.key",
+                "certificate_key_type": "path"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+EOF
+--- upstream eval
+<<EOF
+  listen $Test::Nginx::Util::ENDPOINT_SSL_PORT ssl;
+
+  ssl_certificate $ENV{TEST_NGINX_SERVER_ROOT}/html/server.crt;
+  ssl_certificate_key $ENV{TEST_NGINX_SERVER_ROOT}/html/server.key;
+
+  ssl_client_certificate $ENV{TEST_NGINX_SERVER_ROOT}/html/client.crt;
+  ssl_verify_client on;
+
+  location / {
+     echo 'ssl_client_s_dn: \$ssl_client_s_dn';
+     echo 'ssl_client_i_dn: \$ssl_client_i_dn';
+  }
+EOF
+--- request
+GET /?user_key=value
+--- response_body
+ssl_client_s_dn: CN=localhost,OU=APIcast,O=3scale
+ssl_client_i_dn: CN=localhost,OU=APIcast,O=3scale
+--- error_code: 200
+--- no_error_log
+[error]
+
+
+=== TEST 3: MTLS  policy only affects a single service.
+Just validate that if two services are used, only the service that matches use
+the correct certificate.
+--- init eval
+$Test::Nginx::Util::ENDPOINT_SSL_PORT = Test::APIcast::get_random_port();
+$Test::Nginx::Util::ENDPOINT_SSL_PORT_SECOND = Test::APIcast::get_random_port();
+--- user_files fixture=mutual_ssl.pl eval
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      return ngx.exit(200)
+    }
+  }
+--- configuration eval
+<<EOF
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "hosts": [
+          "one"
+        ],
+        "api_backend": "https://test:$Test::Nginx::Util::ENDPOINT_SSL_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" },
+          {
+            "name": "apicast.policy.upstream_mtls",
+            "configuration": {
+                "certificate": "$ENV{TEST_NGINX_SERVER_ROOT}/html/client.crt",
+                "certificate_type": "path",
+                "certificate_key": "$ENV{TEST_NGINX_SERVER_ROOT}/html/client.key",
+                "certificate_key_type": "path"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": 24,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "hosts": [
+          "two"
+        ],
+        "api_backend": "https://test:$Test::Nginx::Util::ENDPOINT_SSL_PORT_SECOND/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" },
+          {
+            "name": "apicast.policy.upstream_mtls",
+            "configuration": {
+                "certificate": "$ENV{TEST_NGINX_SERVER_ROOT}/html/client.crt",
+                "certificate_type": "path",
+                "certificate_key": "$ENV{TEST_NGINX_SERVER_ROOT}/html/client.key",
+                "certificate_key_type": "path"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+EOF
+--- upstream eval
+<<EOF
+  listen $Test::Nginx::Util::ENDPOINT_SSL_PORT ssl;
+
+  ssl_certificate $ENV{TEST_NGINX_SERVER_ROOT}/html/server.crt;
+  ssl_certificate_key $ENV{TEST_NGINX_SERVER_ROOT}/html/server.key;
+
+  ssl_client_certificate $ENV{TEST_NGINX_SERVER_ROOT}/html/client.crt;
+  ssl_verify_client on;
+
+  location /test/ {
+     echo 'ssl_client_s_dn: \$ssl_client_s_dn';
+     echo 'ssl_client_i_dn: \$ssl_client_i_dn';
+  }
+  }
+  # This is a bit hacky to listen in multiple ports
+  server {
+  listen $Test::Nginx::Util::ENDPOINT_SSL_PORT_SECOND ssl;
+
+  ssl_certificate $ENV{TEST_NGINX_SERVER_ROOT}/html/server.crt;
+  ssl_certificate_key $ENV{TEST_NGINX_SERVER_ROOT}/html/server.key;
+
+  location / {
+     echo 'yay, API backend';
+  }
+EOF
+--- request eval
+["GET /test/?user_key=value", "GET /test/?user_key=value"]
+--- more_headers eval
+["Host: one", "Host: two"]
+--- response_body eval
+[
+  "ssl_client_s_dn: CN=localhost,OU=APIcast,O=3scale\nssl_client_i_dn: CN=localhost,OU=APIcast,O=3scale\n",
+  "yay, API backend\n"
+]
+--- error_code eval
+[200, 200]
+--- no_error_log
+[error]


### PR DESCRIPTION
By default, at the moment if a user wants to use MTLS with the upstream
API, the only way is using `APICAST_PROXY_SSL_CERTIFICATE`, and this
certificate will be used in all services.

With this policy, that includes an Nginx patch, and a new Nginx-module,
different client certificates can be used by service, so one APICast
instance can host more than MTLS connections to different upstreams.

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>