### PR TITLE
Adds APICAST_CONFIGURATION_CACHE_STALE env variable

### DIFF
--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -8,8 +8,8 @@ Note that when deploying APIcast v2 with OpenShift, some of these parameters can
 
 ### `APICAST_BACKEND_CACHE_HANDLER`
 
-**Values:** strict | resilient  
-**Default:** strict  
+**Values:** strict | resilient
+**Default:** strict
 **Deprecated:** Use [Caching](../gateway/src/apicast/policy/caching/apicast-policy.json) policy instead.
 
 Defines how the authorization cache behaves when backend is unavailable.
@@ -18,7 +18,7 @@ Resilient will do so only on getting authorization denied from backend.
 
 ### `APICAST_CONFIGURATION_CACHE`
 
-**Values:** _a number_  
+**Values:** _a number_
 **Default:** 0
 
 Specifies the period (in seconds) that the configuration will be stored in the cache for. Can take the following values:
@@ -27,6 +27,25 @@ Specifies the period (in seconds) that the configuration will be stored in the c
 - a negative number ( < 0 ): disables reloading. The cache entries will never be removed from the cache once stored, and the configuration will never be reloaded.
 
 This parameter is also used to store OpenID discovery configuration in the local cache, as the same behavior as described above.
+
+### `APICAST_CONFIGURATION_CACHE_STALE`
+
+**Values:** _a positive number_
+**Default:** 0
+
+When configuration cannot be gather correctly due to network errors, or any
+other issues, older configuration, that it's stored in the cache, can be used
+for the specified number of times, so request will not fail due service it's not
+found.
+
+The number means, that `APICAST_CONFIGURATION_CACHE` time will be multiplied by
+the number that has been used in `APICAST_CONFIGURATION_CACHE_STALE`
+
+Example:
+  - APICAST_CONFIGURATION_CACHE_STALE: 1 && APICAST_CONFIGURATION_CACHE: 30:
+    Cache will be stored for 30 seconds.
+  - APICAST_CONFIGURATION_CACHE_STALE: 5 && APICAST_CONFIGURATION_CACHE: 30:
+    Cache will be stored for 150 seconds.
 
 ### `APICAST_CONFIGURATION_LOADER`
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -33,10 +33,14 @@ This parameter is also used to store OpenID discovery configuration in the local
 **Values:** _a positive number_
 **Default:** 0
 
-When configuration cannot be gather correctly due to network errors, or any
-other issues, older configuration, that it's stored in the cache, can be used
-for the specified number of times, so request will not fail due service it's not
-found.
+You can use this variable to specify the number of times that gather
+configuration can consequently fail. This is useful when any external issue on
+reload Apicast configuration, so APICast will use stale information, and it'll
+not delete the caching configuration. 
+
+Note, if a service is deleted, and this value is set, the service will be
+present in APICast configuration for the number of times that this parameter
+set.
 
 The number means, that `APICAST_CONFIGURATION_CACHE` time will be multiplied by
 the number that has been used in `APICAST_CONFIGURATION_CACHE_STALE`

--- a/gateway/src/apicast/configuration_loader.lua
+++ b/gateway/src/apicast/configuration_loader.lua
@@ -26,6 +26,16 @@ local _M = {
   _VERSION = '0.1'
 }
 
+-- stale_ttl_multiplier returns a positive integer for multiplied ttl value for
+-- apicast cache config
+local function stale_ttl_multiplier()
+  local result = tonumber(env.value('APICAST_CONFIGURATION_CACHE_STALE') or 1) or 1
+  if result <= 0 then
+    return 1
+  end
+  return result
+end
+
 function _M.load(host)
   local configuration = env.get('APICAST_CONFIGURATION')
   local uri = resty_url.parse(configuration, [[\w+]])
@@ -87,7 +97,7 @@ function _M.configure(configuration, contents)
   end
 
   if config then
-    configuration:store(config, ttl())
+    configuration:store(config, ttl() * stale_ttl_multiplier())
     collectgarbage()
     return config
   end

--- a/spec/configuration_loader_spec.lua
+++ b/spec/configuration_loader_spec.lua
@@ -1,4 +1,5 @@
 local env = require 'resty.env'
+local match = require("luassert.match")
 
 insulate('Configuration object', function()
 
@@ -89,6 +90,65 @@ insulate('Configuration object', function()
       }})))
 
       assert.truthy(config:find_by_id('42'))
+    end)
+
+    describe('Cache TTL', function()
+      local config = {}
+
+      before_each(function()
+        config = configuration_store.new()
+        env.set('APICAST_CONFIGURATION_CACHE', 120)
+      end)
+
+      it('stale is not set', function()
+        stub(configuration_store, "store")
+        assert.truthy(_M.configure(config, '{}'))
+
+        assert.stub(configuration_store.store).was.called()
+        assert.stub(configuration_store.store).was_called_with(
+          match.is_not_nil(), match.is_not_nil(), 120)
+      end)
+
+      it('stale is 0', function()
+        env.set('APICAST_CONFIGURATION_CACHE_STALE', 0)
+        stub(configuration_store, "store")
+        assert.truthy(_M.configure(config, '{}'))
+
+        assert.stub(configuration_store.store).was.called()
+        assert.stub(configuration_store.store).was_called_with(
+          match.is_not_nil(), match.is_not_nil(), 120)
+      end)
+
+      it('stale is negative', function()
+        env.set('APICAST_CONFIGURATION_CACHE_STALE', -1)
+        stub(configuration_store, "store")
+        assert.truthy(_M.configure(config, '{}'))
+
+        assert.stub(configuration_store.store).was.called()
+        assert.stub(configuration_store.store).was_called_with(
+          match.is_not_nil(), match.is_not_nil(), 120)
+      end)
+
+      it('stale is positive', function()
+        env.set('APICAST_CONFIGURATION_CACHE_STALE', 2)
+        stub(configuration_store, "store")
+        assert.truthy(_M.configure(config, '{}'))
+
+        assert.stub(configuration_store.store).was.called()
+        assert.stub(configuration_store.store).was_called_with(
+          match.is_not_nil(), match.is_not_nil(), 240)
+      end)
+
+      it('stale is positive but not a number', function()
+        env.set('APICAST_CONFIGURATION_CACHE_STALE', 'foobar')
+        stub(configuration_store, "store")
+        assert.truthy(_M.configure(config, '{}'))
+
+        assert.stub(configuration_store.store).was.called()
+        assert.stub(configuration_store.store).was_called_with(
+          match.is_not_nil(), match.is_not_nil(), 120)
+      end)
+
     end)
   end)
 


### PR DESCRIPTION
This commit adds a way to store more time the configuration in the
cache if the config reload fails, it'll use the stale configuration for
the time that is specified.

FIX THREESCALE-4136

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>