### PR TITLE
Rewrite by verb 1130

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added Content-caching policy [THREESCALE-2894](https://issues.jboss.org/browse/THREESCALE-2894) [PR #1182](https://github.com/3scale/APIcast/pull/1182)
 
 - Added Nginx request_id variable to context [PR #1184](https://github.com/3scale/APIcast/pull/1184)
+- Added HTTP verb on url_rewriten [PR #1187](https://github.com/3scale/APIcast/pull/1187)  [THREESCALE-5259](https://issues.jboss.org/browse/THREESCALE-5259)
 
 ## [3.8.0] - 2020-03-24
 

--- a/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
+++ b/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
@@ -14,6 +14,59 @@
      "chain, then the mapping rules will apply to the original path."],
   "version": "builtin",
   "configuration": {
+    "definitions": {
+      "methods": {
+        "$id": "#/definitions/methods",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "oneOf": [
+            {
+              "enum": [
+                "GET"
+              ],
+              "title": "GET"
+            },
+            {
+              "enum": [
+                "POST"
+              ],
+              "title": "POST"
+            },
+            {
+              "enum": [
+                "PUT"
+              ],
+              "title": "PUT"
+            },
+            {
+              "enum": [
+                "PATCH"
+              ],
+              "title": "PATCH"
+            },
+            {
+              "enum": [
+                "DELETE"
+              ],
+              "title": "DELETE"
+            },
+            {
+              "enum": [
+                "HEAD"
+              ],
+              "title": "HEAD"
+            },
+            {
+              "enum": [
+                "OPTIONS"
+              ],
+              "title": "OPTIONS"
+            }
+          ]
+        }
+      }
+    },
     "type": "object",
     "properties": {
       "commands": {
@@ -54,40 +107,7 @@
             },
             "methods": {
               "description": "Array of HTTP methods this rule must be applied to. If left blank it will be applied to all HTTP methods",
-              "type": "array",
-              "items": {
-                "type": "string",
-                "oneOf": [
-                  {
-                    "enum": ["GET"],
-                    "title": "GET"
-                  },
-                  {
-                    "enum": ["POST"],
-                    "title": "POST"
-                  },
-                  {
-                    "enum": ["PUT"],
-                    "title": "PUT"
-                  },
-                  {
-                    "enum": ["PATCH"],
-                    "title": "PATCH"
-                  },
-                  {
-                    "enum": ["DELETE"],
-                    "title": "DELETE"
-                  },
-                  {
-                    "enum": ["HEAD"],
-                    "title": "HEAD"
-                  },
-                  {
-                    "enum": ["OPTIONS"],
-                    "title": "OPTIONS"
-                  }
-                ]
-              }
+              "ref": "#/definitions/methods"
             }
           },
           "required": ["op", "regex", "replace"]
@@ -147,54 +167,7 @@
           },
           "methods": {
             "description": "Array of HTTP methods this rule must be applied to. If left blank it will be applied to all HTTP methods",
-            "type": "array",
-            "items": {
-              "type": "string",
-              "oneOf": [
-                {
-                  "enum": [
-                    "GET"
-                  ],
-                  "title": "GET"
-                },
-                {
-                  "enum": [
-                    "POST"
-                  ],
-                  "title": "POST"
-                },
-                {
-                  "enum": [
-                    "PUT"
-                  ],
-                  "title": "PUT"
-                },
-                {
-                  "enum": [
-                    "PATCH"
-                  ],
-                  "title": "PATCH"
-                },
-                {
-                  "enum": [
-                    "DELETE"
-                  ],
-                  "title": "DELETE"
-                },
-                {
-                  "enum": [
-                    "HEAD"
-                  ],
-                  "title": "HEAD"
-                },
-                {
-                  "enum": [
-                    "OPTIONS"
-                  ],
-                  "title": "OPTIONS"
-                }
-              ]
-            }
+            "ref": "#/definitions/methods"
           }
         },
         "required": ["op", "arg", "value"]

--- a/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
+++ b/gateway/src/apicast/policy/url_rewriting/apicast-policy.json
@@ -51,6 +51,43 @@
             "break": {
               "description": "when set to true, if the command rewrote the URL, it will be the last one applied",
               "type": "boolean"
+            },
+            "methods": {
+              "description": "Array of HTTP methods this rule must be applied to. If left blank it will be applied to all HTTP methods",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "oneOf": [
+                  {
+                    "enum": ["GET"],
+                    "title": "GET"
+                  },
+                  {
+                    "enum": ["POST"],
+                    "title": "POST"
+                  },
+                  {
+                    "enum": ["PUT"],
+                    "title": "PUT"
+                  },
+                  {
+                    "enum": ["PATCH"],
+                    "title": "PATCH"
+                  },
+                  {
+                    "enum": ["DELETE"],
+                    "title": "DELETE"
+                  },
+                  {
+                    "enum": ["HEAD"],
+                    "title": "HEAD"
+                  },
+                  {
+                    "enum": ["OPTIONS"],
+                    "title": "OPTIONS"
+                  }
+                ]
+              }
             }
           },
           "required": ["op", "regex", "replace"]
@@ -106,6 +143,57 @@
                 }
               ],
               "default": "plain"
+            }
+          },
+          "methods": {
+            "description": "Array of HTTP methods this rule must be applied to. If left blank it will be applied to all HTTP methods",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "oneOf": [
+                {
+                  "enum": [
+                    "GET"
+                  ],
+                  "title": "GET"
+                },
+                {
+                  "enum": [
+                    "POST"
+                  ],
+                  "title": "POST"
+                },
+                {
+                  "enum": [
+                    "PUT"
+                  ],
+                  "title": "PUT"
+                },
+                {
+                  "enum": [
+                    "PATCH"
+                  ],
+                  "title": "PATCH"
+                },
+                {
+                  "enum": [
+                    "DELETE"
+                  ],
+                  "title": "DELETE"
+                },
+                {
+                  "enum": [
+                    "HEAD"
+                  ],
+                  "title": "HEAD"
+                },
+                {
+                  "enum": [
+                    "OPTIONS"
+                  ],
+                  "title": "OPTIONS"
+                }
+              ]
             }
           }
         },


### PR DESCRIPTION
This resolves #1130 by taking an array of HTTP methods in the config for either the commands or the query_args_command. When the one or HTTP methods are applied in the config the rewrite rule only executes if the request method matches one in the config. If no methods are provided in the config the rewrite command will execute on all request methods. 