### PR TITLE
Policy: Add custom metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added Content-caching policy [THREESCALE-2894](https://issues.jboss.org/browse/THREESCALE-2894) [PR #1182](https://github.com/3scale/APIcast/pull/1182)
 - Added Nginx request_id variable to context [PR #1184](https://github.com/3scale/APIcast/pull/1184)
 - Added HTTP verb on url_rewriten [PR #1187](https://github.com/3scale/APIcast/pull/1187)  [THREESCALE-5259](https://issues.jboss.org/browse/THREESCALE-5259)
+- Added custom_metrics policy [PR #1188](https://github.com/3scale/APIcast/pull/1188) [THREESCALE-5098](https://issues.jboss.org/browse/THREESCALE-5098)
 
 ## [3.8.0] - 2020-03-24
 

--- a/gateway/src/apicast/policy/custom_metrics/Readme.md
+++ b/gateway/src/apicast/policy/custom_metrics/Readme.md
@@ -1,0 +1,73 @@
+# Custom metrics policies
+
+This policy adds the availability to add metrics after the Upstream API
+response.  The main use case for this policy is to add metrics based on response
+code status, headers or different Nginx variables.
+
+## Caveats:
+
+Due to this needs some information from the upstream API, if the authrep with
+backend happens before the upstream call (Is not cached) the metric will not be
+incremented. This policy only increments metrics when the authrep is cached.
+
+This policy does not work with batching policy.
+
+## Configuration examples
+
+This policy increments the metric error, by the header increment, if the
+Upstream API returns a 400 status:
+
+```
+{
+  "name": "apicast.policy.custom_metrics",
+  "configuration": {
+    "rules": [
+      {
+        "metric": "error",
+        "increment": "{{ resp.headers['increment'] }}",
+        "condition": {
+          "operations": [
+            {
+              "right": "{{status}}",
+              "right_type": "liquid",
+              "left": "400",
+              "op": "=="
+            }
+          ],
+          "combine_op": "and"
+        }
+      }
+    ]
+  }
+}
+```
+
+Increment the `hits` metric with the information status_code information if the
+Upstream API return a 200 status:
+
+```
+{
+  "name": "apicast.policy.custom_metrics",
+  "configuration": {
+    "rules": [
+      {
+        "metric": "hits_{{status}}",
+        "increment": "1",
+        "condition": {
+          "operations": [
+            {
+              "right": "{{status}}",
+              "right_type": "liquid",
+              "left": "200",
+              "op": "=="
+            }
+          ],
+          "combine_op": "and"
+        }
+      }
+    ]
+  }
+}
+```
+
+

--- a/gateway/src/apicast/policy/custom_metrics/apicast-policy.json
+++ b/gateway/src/apicast/policy/custom_metrics/apicast-policy.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
+  "name": "Custom Metrics",
+  "summary": "Custom metrics on Nginx post actions ",
+  "description": [
+    "With this policy, on post_actions the Authrep call will report any new ",
+    "metric if one of the conditions match. The main use case for this is to ",
+    "report any metric based on response headers, status codes, or any other ",
+    "liquid exposed variable."
+  ],
+  "version": "builtin",
+  "configuration": {
+    "definitions": {
+      "operation": {
+        "type": "object",
+        "$id": "#/definitions/operation",
+        "properties": {
+          "left": {
+            "type": "string"
+          },
+          "op": {
+            "description": "Operation to apply. The matches op supports PCRE (Perl compatible regular expressions)",
+            "type": "string",
+            "enum": [
+              "==",
+              "!=",
+              "matches"
+            ]
+          },
+          "right": {
+            "type": "string"
+          },
+          "left_type": {
+            "description": "How to evaluate 'left'",
+            "type": "string",
+            "default": "plain",
+            "oneOf": [
+              {
+                "enum": [
+                  "plain"
+                ],
+                "title": "Evaluate 'left' as plain text."
+              },
+              {
+                "enum": [
+                  "liquid"
+                ],
+                "title": "Evaluate 'left' as liquid."
+              }
+            ]
+          },
+          "right_type": {
+            "description": "How to evaluate 'right'",
+            "type": "string",
+            "default": "plain",
+            "oneOf": [
+              {
+                "enum": [
+                  "plain"
+                ],
+                "title": "Evaluate 'right' as plain text."
+              },
+              {
+                "enum": [
+                  "liquid"
+                ],
+                "title": "Evaluate 'right' as liquid."
+              }
+            ]
+          }
+        },
+        "required": [
+          "left",
+          "op",
+          "right"
+        ]
+      },
+      "custom_metrics_rule": {
+        "type": "object",
+         "required": [ "metric", "condition", "increment" ],
+        "properties": {
+          "metric": {
+            "type": "string",
+            "title": "Metric to increment ",
+            "description": "Metric name to increment in case of condition match (liquid input)",
+            "default": ""
+          },
+          "increment": {
+            "type": "string",
+            "title": "Increment ",
+            "description": "How many hits should be incremented, liquid value ",
+            "default": "1"
+          },
+          "condition": {
+            "type": "object",
+            "title": "Condition",
+            "required": [
+              "combine_op",
+              "operations"
+            ],
+            "properties": {
+              "combine_op": {
+                "title": "Combine operation",
+                "type": "string",
+                "default": "and",
+                "enum": [
+                  "and",
+                  "or"
+                ]
+              },
+              "operations": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/operation"
+                },
+                "minItems": 1
+              }
+            }
+          }
+        }
+      }
+    },
+    "properties": {
+      "rules": {
+        "type": "array",
+        "items": {
+            "$ref": "#/definitions/custom_metrics_rule"
+         },
+        "minItems": 1
+      }
+    }
+  }
+}

--- a/gateway/src/apicast/policy/custom_metrics/apicast-policy.json
+++ b/gateway/src/apicast/policy/custom_metrics/apicast-policy.json
@@ -9,6 +9,14 @@
     "liquid exposed variable."
   ],
   "version": "builtin",
+  "order": {
+    "before": [
+      {
+        "name": "apicast",
+        "version": "builtin"
+      }
+    ]
+  },
   "configuration": {
     "definitions": {
       "operation": {

--- a/gateway/src/apicast/policy/custom_metrics/custom_metrics.lua
+++ b/gateway/src/apicast/policy/custom_metrics/custom_metrics.lua
@@ -1,0 +1,102 @@
+--- Custom metrics policy
+
+local _M  = require('apicast.policy').new('Custom Metrics', 'builtin')
+
+local Condition = require('apicast.conditions.condition')
+local LinkedList = require('apicast.linked_list')
+local Operation = require('apicast.conditions.operation')
+local TemplateString = require('apicast.template_string')
+local Usage = require('apicast.usage')
+
+local tinsert = table.insert
+local str_len = string.len
+local default_combine_op = "and"
+local default_template_type = "plain"
+local liquid_template_type = "liquid"
+
+local new = _M.new
+
+
+local function get_context(context)
+
+  local ctx = { }
+  ctx.req = {
+    headers=ngx.req.get_headers(),
+  }
+
+  ctx.resp = {
+    headers=ngx.resp.get_headers(),
+  }
+
+  ctx.usage = context.usage
+  ctx.service = context.service or {}
+  ctx.original_request = context.original_request
+  ctx.jwt = context.jwt or {}
+  return LinkedList.readonly(ctx, ngx.var)
+end
+
+
+local function load_condition(condition_config)
+  if not condition_config then
+    return nil
+  end
+  local operations = {}
+  for _, operation in ipairs(condition_config.operations or {}) do
+    tinsert( operations,
+      Operation.new(
+        operation.left,
+        operation.left_type or default_template_type,
+        operation.op,
+        operation.right,
+        operation.right_type or default_template_type))
+  end
+
+  return Condition.new(
+    operations,
+    condition_config.combine_op or default_combine_op)
+end
+
+
+local function load_rules(self, config_rules)
+  if not config_rules then
+    return
+  end
+  local rules = {}
+  for _,rule in pairs(config_rules) do
+      tinsert(rules, {
+        condition = load_condition(rule.condition),
+        metric = TemplateString.new(rule.metric or "", liquid_template_type),
+        increment = TemplateString.new(rule.increment or "0", liquid_template_type)
+      })
+  end
+  self.rules = rules
+end
+
+
+function _M.new(config)
+  local self = new(config)
+
+  self.rules = {}
+  load_rules(self, config.rules or {})
+
+  return self
+end
+
+
+function _M:post_action(context)
+  -- context with all variables are needed to retrieve information about API
+  -- response
+  local ctx = get_context(context)
+  for _, rule in ipairs(self.rules) do
+    if rule.condition:evaluate(ctx) then
+      local metric = rule.metric:render(ctx)
+      if str_len(metric) > 0 then
+        local usage = Usage.new()
+        usage:add(metric, tonumber(rule.increment:render(ctx)) or 0)
+        context.usage:merge(usage)
+      end
+    end
+  end
+end
+
+return _M

--- a/gateway/src/apicast/policy/custom_metrics/init.lua
+++ b/gateway/src/apicast/policy/custom_metrics/init.lua
@@ -1,0 +1,1 @@
+return require("custom_metrics")

--- a/t/apicast-policy-custom-metrics.t
+++ b/t/apicast-policy-custom-metrics.t
@@ -63,6 +63,16 @@ __DATA__
       end
     }
   }
+  # Report transactions for the first one
+  location /transactions.xml {
+    content_by_lua_block {
+      ngx.req.read_body()
+      local post_args = ngx.req.get_post_args()
+      require('luassert').same(post_args["transactions[0][usage][foo]"], "1")
+      require('luassert').same(post_args["transactions[0][user_key]"], "value")
+      ngx.exit(200)
+    }
+  }
 --- upstream
   location / {
      content_by_lua_block {
@@ -131,6 +141,17 @@ __DATA__
         require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
         ngx.exit(200)
       end
+    }
+  }
+
+  # Report transactions for the first one
+  location /transactions.xml {
+    content_by_lua_block {
+      ngx.req.read_body()
+      local post_args = ngx.req.get_post_args()
+      require('luassert').same(post_args["transactions[0][usage][foo]"], "2")
+      require('luassert').same(post_args["transactions[0][user_key]"], "value")
+      ngx.exit(200)
     }
   }
 --- upstream
@@ -206,6 +227,17 @@ __DATA__
       end
     }
   }
+
+  # Report transactions for the first one
+  location /transactions.xml {
+    content_by_lua_block {
+      ngx.req.read_body()
+      local post_args = ngx.req.get_post_args()
+      require('luassert').same(post_args["transactions[0][usage][foo_200]"], "1")
+      require('luassert').same(post_args["transactions[0][user_key]"], "value")
+      ngx.exit(200)
+    }
+  }
 --- upstream
   location / {
      content_by_lua_block {
@@ -219,7 +251,7 @@ __DATA__
 --- no_error_log
 [error]
 
-=== TEST 4: Rule does not left, metric is not added
+=== TEST 4: Rule does not match, metric is not added
 --- configuration
 {
   "services": [
@@ -275,6 +307,17 @@ __DATA__
         require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
         ngx.exit(200)
       end
+    }
+  }
+
+  # Report transactions for the first one
+  location /transactions.xml {
+    content_by_lua_block {
+      ngx.req.read_body()
+      local post_args = ngx.req.get_post_args()
+      require('luassert').same(post_args["transactions[0][usage][foo_400]"], "1")
+      require('luassert').same(post_args["transactions[0][user_key]"], "value")
+      ngx.exit(200)
     }
   }
 --- upstream
@@ -357,6 +400,18 @@ __DATA__
         require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
         ngx.exit(200)
       end
+    }
+  }
+
+  # Report transactions for the first one
+  location /transactions.xml {
+    content_by_lua_block {
+      ngx.req.read_body()
+      local post_args = ngx.req.get_post_args()
+      require('luassert').same(post_args["transactions[0][usage][foo]"], "1")
+      require('luassert').same(post_args["transactions[0][usage][hits_200]"], "1")
+      require('luassert').same(post_args["transactions[0][user_key]"], "value")
+      ngx.exit(200)
     }
   }
 --- upstream

--- a/t/apicast-policy-custom-metrics.t
+++ b/t/apicast-policy-custom-metrics.t
@@ -1,0 +1,374 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: Enables extra metric with a rule
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.custom_metrics",
+            "configuration": {
+              "rules": [
+                {
+                  "condition": {
+                    "operations": [
+                      {"op": "==", "left": "{{status}}", "left_type": "liquid", "right": "200"}
+                    ],
+                    "combine_op": "and"
+                  },
+                  "metric": "foo",
+                  "increment": "1"
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+
+--- backend
+  location /transactions/authrep.xml {
+
+    content_by_lua_block {
+      local test_counter = ngx.shared.test_counter or 1
+      if test_counter == 1 then
+        ngx.shared.test_counter = test_counter + 1
+        ngx.exit(200)
+      end
+
+      if test_counter == 2 then
+        local expected = "service_token=token-value&service_id=42&usage%5Bfoo%5D=1&usage%5Bhits%5D=1&user_key=value"
+        require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+        ngx.exit(200)
+      end
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request eval
+["GET /?user_key=value", "GET /?user_key=value"]
+--- error_code eval
+[200, 200]
+--- no_error_log
+[error]
+
+=== TEST 2: Enables extra metric with increment based on header
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.custom_metrics",
+            "configuration": {
+              "rules": [
+                {
+                  "condition": {
+                    "operations": [
+                      {"op": "==", "left": "{{status}}", "left_type": "liquid", "right": "200"}
+                    ],
+                    "combine_op": "and"
+                  },
+                  "metric": "foo",
+                  "increment": "{{ resp.headers['increment'] }}"
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+
+    content_by_lua_block {
+      local test_counter = ngx.shared.test_counter or 1
+      if test_counter == 1 then
+        ngx.shared.test_counter = test_counter + 1
+        ngx.exit(200)
+      end
+
+      if test_counter == 2 then
+        local expected = "service_token=token-value&service_id=42&usage%5Bfoo%5D=2&usage%5Bhits%5D=1&user_key=value"
+        require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+        ngx.exit(200)
+      end
+    }
+  }
+--- upstream
+  location / {
+    content_by_lua_block {
+      ngx.header['increment'] = '2'
+      ngx.say('yay, api backend');
+    }
+  }
+--- request eval
+["GET /?user_key=value", "GET /?user_key=value"]
+--- error_code eval
+[200, 200]
+--- no_error_log
+[error]
+
+
+=== TEST 3: Enables extra metric using liquid filter
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.custom_metrics",
+            "configuration": {
+              "rules": [
+                {
+                  "condition": {
+                    "operations": [
+                      {"op": "==", "left": "{{status}}", "left_type": "liquid", "right": "200"}
+                    ],
+                    "combine_op": "and"
+                  },
+                  "metric": "foo_{{status}}",
+                  "increment": "1"
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+
+--- backend
+  location /transactions/authrep.xml {
+
+    content_by_lua_block {
+      local test_counter = ngx.shared.test_counter or 1
+      if test_counter == 1 then
+        ngx.shared.test_counter = test_counter + 1
+        ngx.exit(200)
+      end
+
+      if test_counter == 2 then
+        local expected = "service_token=token-value&service_id=42&usage%5Bfoo_200%5D=1&usage%5Bhits%5D=1&user_key=value"
+        require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+        ngx.exit(200)
+      end
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request eval
+["GET /?user_key=value", "GET /?user_key=value"]
+--- error_code eval
+[200, 200]
+--- no_error_log
+[error]
+
+=== TEST 4: Rule does not left, metric is not added
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.custom_metrics",
+            "configuration": {
+              "rules": [
+                {
+                  "condition": {
+                    "operations": [
+                      {"op": "==", "left": "{{status}}", "left_type": "liquid", "right": "400"}
+                    ],
+                    "combine_op": "and"
+                  },
+                  "metric": "foo_{{status}}",
+                  "increment": "1"
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+
+--- backend
+  location /transactions/authrep.xml {
+
+    content_by_lua_block {
+      local test_counter = ngx.shared.test_counter or 1
+      if test_counter == 1 then
+        ngx.shared.test_counter = test_counter + 1
+        ngx.exit(200)
+      end
+
+      if test_counter == 2 then
+        local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=1&user_key=value"
+        require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+        ngx.exit(200)
+      end
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request eval
+["GET /?user_key=value", "GET /?user_key=value"]
+--- error_code eval
+[200, 200]
+--- no_error_log
+[error]
+
+
+=== TEST 5: Multiple rules
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.custom_metrics",
+            "configuration": {
+              "rules": [
+                {
+                  "condition": {
+                    "operations": [
+                      {"op": "==", "left": "{{status}}", "left_type": "liquid", "right": "200"}
+                    ],
+                    "combine_op": "and"
+                  },
+                  "metric": "foo",
+                  "increment": "1"
+                },
+                {
+                  "condition": {
+                    "operations": [
+                      {"op": "==", "left": "{{status}}", "left_type": "liquid", "right": "200"}
+                    ],
+                    "combine_op": "and"
+                  },
+                  "metric": "hits_{{status}}",
+                  "increment": "1"
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+
+--- backend
+  location /transactions/authrep.xml {
+
+    content_by_lua_block {
+      local test_counter = ngx.shared.test_counter or 1
+      if test_counter == 1 then
+        ngx.shared.test_counter = test_counter + 1
+        ngx.exit(200)
+      end
+
+      if test_counter == 2 then
+        local expected = "service_token=token-value&service_id=42&usage%5Bfoo%5D=1&usage%5Bhits_200%5D=1&usage%5Bhits%5D=1&user_key=value"
+        require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+        ngx.exit(200)
+      end
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request eval
+["GET /?user_key=value", "GET /?user_key=value"]
+--- error_code eval
+[200, 200]
+--- no_error_log
+[error]
+


### PR DESCRIPTION
This policy adds the avalability to add a new metric on the post_action,
so user can report back things like metric upstream headers, status code
or any other information.

FIX THREESCALE-5098

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>