### PR TITLE
Luarocks: Fix Prometheus version

### DIFF
--- a/gateway/Roverfile.lock
+++ b/gateway/Roverfile.lock
@@ -33,7 +33,7 @@ lyaml 6.2.4-1||production
 markdown 0.33-1||development
 mediator_lua 1.1.2-0||testing
 net-url 0.9-1||testing
-nginx-lua-prometheus 0.20181120-2||production
+nginx-lua-prometheus 0.20181120-3||production
 penlight 1.7.0-1||production,development,testing
 router 2.1-0||production
 say 1.3-1||testing


### PR DESCRIPTION
Fix issues regarding wrong version of Prometheus Lua dependency.

Related to: https://github.com/knyar/nginx-lua-prometheus/pull/84

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>