### PR TITLE
HTTPS Proxy: Fix large body request.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed issues with liquid replaces [THREESCALE-4937](https://issues.jboss.org/browse/THREESCALE-4937) [PR #1185](https://github.com/3scale/APIcast/pull/1185)
+- Fixed issues with HTTPS_PROXY and large bodies [THREESCALE-3863](https://issues.jboss.org/browse/THREESCALE-3863) [PR #1191](https://github.com/3scale/APIcast/pull/1191)
+
 
 ### Added
 

--- a/gateway/src/apicast/http_proxy.lua
+++ b/gateway/src/apicast/http_proxy.lua
@@ -4,6 +4,7 @@ local resty_url = require "resty.url"
 local resty_resolver = require 'resty.resolver'
 local round_robin = require 'resty.balancer.round_robin'
 local http_proxy = require 'resty.http.proxy'
+local file_reader = require("resty.file").file_reader
 
 local _M = { }
 
@@ -96,9 +97,29 @@ local function forward_https_request(proxy_uri, uri)
         -- We cannot use resty.http's .get_client_body_reader().
         -- In POST requests with HTTPS, the result of that call is nil, and it
         -- results in a time-out.
+        --
+        --
+        -- If ngx.req.get_body_data is nil, can be that the body is too big to
+        -- read and need to be cached in a local file. This request will return
+        -- nil, so after this we need to read the temp file.
+        -- https://github.com/openresty/lua-nginx-module#ngxreqget_body_data
         body = ngx.req.get_body_data(),
         proxy_uri = proxy_uri
     }
+
+    if not request.body then
+        local temp_file_path = ngx.req.get_body_file()
+        ngx.log(ngx.INFO, "HTTPS Proxy: Request body is bigger than client_body_buffer_size, read the content from path='", temp_file_path, "'")
+
+        if temp_file_path then
+          local body, err = file_reader(temp_file_path)
+          if err then
+            ngx.log(ngx.ERR, "HTTPS proxy: Failed to read temp body file, err: ", err)
+            ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
+          end
+          request.body = body
+        end
+    end
 
     local httpc, err = http_proxy.new(request)
 

--- a/gateway/src/resty/coroutines.lua
+++ b/gateway/src/resty/coroutines.lua
@@ -1,0 +1,24 @@
+local co_create = coroutine._create
+local co_resume = coroutine._resume
+
+local _M = {}
+
+--- Create coroutine iterator
+-- Like coroutine.wrap but safe to be used as iterator,
+-- because it will return nil as first return value on error.
+function _M.co_wrap_iter(f)
+  local co = co_create(f)
+
+  return function(...)
+    local ok, ret = co_resume(co, ...)
+
+    if ok then
+      return ret
+    else
+      return nil, ret
+    end
+  end
+end
+
+return _M
+

--- a/gateway/src/resty/file.lua
+++ b/gateway/src/resty/file.lua
@@ -1,0 +1,31 @@
+local co_yield = coroutine._yield
+local open = io.open
+
+local co_wrap_iter = require("resty.coroutines").co_wrap_iter
+
+local chunk_size = 2^13 -- 8kb
+
+local _M = {}
+
+-- returns an iterator if the file is correct where can be read in chuinks of
+-- 8kb.
+-- If file cannot be open, it'll return nil function and the error message.
+function _M.file_reader(filename)
+    local handle, err = open(filename)
+    if err then
+      return nil, err
+    end
+
+    return co_wrap_iter(function()
+      while true do
+          local chunk = handle:read(chunk_size)
+          if not chunk then
+            break
+          end
+          co_yield(chunk)
+      end
+      handle:close()
+    end)
+end
+
+return _M

--- a/spec/resty/file_spec.lua
+++ b/spec/resty/file_spec.lua
@@ -1,0 +1,39 @@
+local file_reader = require("resty.file").file_reader
+local random = math.random
+
+local function uuid()
+    local template ='xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
+    return string.gsub(template, '[xy]', function (c)
+        local v = (c == 'x') and random(0, 0xf) or random(8, 0xb)
+        return string.format('%x', v)
+    end)
+end
+
+describe('File utilities', function()
+  local filename = "/tmp/" ..uuid() .. ".txt"
+
+  before_each(function()
+    local file = io.open(filename, 'w')
+    local file_size = (2 ^ 10 * 16) -- 16kb
+    for _=1,file_size do
+      file:write("1")
+    end
+    file:close()
+  end)
+
+  it('file reader is using coroutines', function()
+    local reader, err = file_reader(filename)
+    assert.falsy(err)
+    assert.same(type(reader), "function")
+    assert.truthy(reader()) -- First 8 KB
+    assert.truthy(reader()) -- Second 8 KB
+    assert.falsy(reader()) -- Nothing to read, return nil
+  end)
+
+  it('file reader return error on invalid path', function()
+    local reader, err = file_reader("my_invalid_path.txt")
+    assert.falsy(reader)
+    assert.truthy(err)
+  end)
+
+end)


### PR DESCRIPTION
When request need to be stored in a temp file, the
ngx.req.get_body_data() will return nil. On some uses cases, users
report that large body is not correctly set. So things are failing on
their end.

This commit will check if the file has been created, read the data from
there and set the body correctly.

Fix THREESCALE-3863

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>