### PR TITLE
Policy: IPCheck validate that port is not used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issues with liquid replaces [THREESCALE-4937](https://issues.jboss.org/browse/THREESCALE-4937) [PR #1185](https://github.com/3scale/APIcast/pull/1185)
 - Fixed issues with HTTPS_PROXY and large bodies [THREESCALE-3863](https://issues.jboss.org/browse/THREESCALE-3863) [PR #1191](https://github.com/3scale/APIcast/pull/1191)
 - Fixed issues with path routing and query args [THREESCALE-5149](https://issues.redhat.com/browse/THREESCALE-5149) [PR #1190](https://github.com/3scale/APIcast/pull/1190)
+- Fixed issue with IPCheck policy when forwarder-for value contains port [THREESCALE-5258](https://issues.redhat.com/browse/THREESCALE-5258) [PR #1192](https://github.com/3scale/APIcast/pull/1192)
+
 
 ### Added
 
 - Added upstream Mutual TLS policy [THREESCALE-672](https://issues.jboss.org/browse/THREESCALE-672) [PR #1182](https://github.com/3scale/APIcast/pull/1182)
 - Added Rate-limit headers policy [THREESCALE-3795](https://issues.jboss.org/browse/THREESCALE-3795) [PR #1166](https://github.com/3scale/APIcast/pull/1166)
 - Added Content-caching policy [THREESCALE-2894](https://issues.jboss.org/browse/THREESCALE-2894) [PR #1182](https://github.com/3scale/APIcast/pull/1182)
-
 - Added Nginx request_id variable to context [PR #1184](https://github.com/3scale/APIcast/pull/1184)
 - Added HTTP verb on url_rewriten [PR #1187](https://github.com/3scale/APIcast/pull/1187)  [THREESCALE-5259](https://issues.jboss.org/browse/THREESCALE-5259)
 

--- a/gateway/src/apicast/policy/ip_check/client_ip.lua
+++ b/gateway/src/apicast/policy/ip_check/client_ip.lua
@@ -1,5 +1,6 @@
 local ipairs = ipairs
 local re = require('ngx.re')
+local resty_url = require 'resty.url'
 
 local _M = {}
 
@@ -23,7 +24,13 @@ local function ip_from_x_forwarded_for_header()
     return nil
   end
 
-  return re.split(forwarded_for, ',', 'oj')[1]
+  -- THREESCALE-5258 forwarded_for can contain port. If port is in there IP
+  -- value will not be parsed correctly, parsing as url will get the correct
+  -- host
+  -- `:` split is not valid in case that it's IPv6 notation.
+  local host = re.split(forwarded_for, ',', 'oj')[1]
+  local uri = resty_url.parse("my://".. host)
+  return uri.host
 end
 
 local get_ip_func = {

--- a/spec/policy/ip_check/client_ip_spec.lua
+++ b/spec/policy/ip_check/client_ip_spec.lua
@@ -70,6 +70,51 @@ describe('ClientIP', function()
           assert.is_nil(ip)
         end)
       end)
+
+      describe('and the host contains port', function()
+
+        it("returns valid IPv4 address", function()
+          stub(ngx.req, 'get_headers', function()
+            return { ["X-Forwarded-For"] = '1.2.3.4:1000' }
+          end)
+
+          local ip = client_ip.get_from({ 'X-Forwarded-For' })
+
+          assert.equals('1.2.3.4', ip)
+        end)
+
+        it("with invalid port", function()
+          stub(ngx.req, 'get_headers', function()
+            return { ["X-Forwarded-For"] = '1.2.3.4:foo' }
+          end)
+
+          local ip = client_ip.get_from({ 'X-Forwarded-For' })
+
+          assert.equals('1.2.3.4', ip)
+        end)
+
+        it("with port out of range", function()
+          stub(ngx.req, 'get_headers', function()
+            return { ["X-Forwarded-For"] = '1.2.3.4:99999' }
+          end)
+
+          local ip = client_ip.get_from({ 'X-Forwarded-For' })
+
+          assert.equals('1.2.3.4', ip)
+        end)
+
+        it("returns valid IPv6 address", function()
+
+          stub(ngx.req, 'get_headers', function()
+            return { ["X-Forwarded-For"] = '[2001:4860:4860::8888]:8080' }
+          end)
+
+          local ip = client_ip.get_from({ 'X-Forwarded-For' })
+
+          assert.equals('[2001:4860:4860::8888]', ip)
+        end)
+
+      end)
     end)
 
     describe('when no source is given', function()


### PR DESCRIPTION
This commit fix the issue when port is added into the forwarder-for
header and IPCheck will not match correctly.

Fix THREESCALE-5258

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>