### PR TITLE
Policy: Camel proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added custom_metrics policy [PR #1188](https://github.com/3scale/APIcast/pull/1188) [THREESCALE-5098](https://issues.jboss.org/browse/THREESCALE-5098)
 - New apicast_status Prometheus metric [THREESCALE-5417](https://issues.jboss.org/browse/THREESCALE-5417) [PR #1200](https://github.com/3scale/APIcast/pull/1200)
 
+- Added Camel policy [PR #1193](https://github.com/3scale/APIcast/pull/1193) [THREESCALE-4867](https://issues.jboss.org/browse/THREESCALE-4867)
 
 ## [3.8.0] - 2020-03-24
 

--- a/gateway/src/apicast/policy/camel/Readme.md
+++ b/gateway/src/apicast/policy/camel/Readme.md
@@ -1,0 +1,77 @@
+#  Camel proxy policy
+
+This policy allows users to define a camel proxy where the traffic will be send
+over the defined proxy, the example traffic flow is the following:
+
+```
+   ,-.
+   `-'
+   /|\
+    |            ,-------.          ,---------.          ,----------.
+   / \           |Apicast|          |  CAMEL  |          |APIBackend|
+  User           `---+---'          `----+----'          `----------'
+   |  GET /resource  |                   |                    |
+   | --------------->|                   |                    |
+   |                 |                   |                    |
+   |                 |  Get /resource    |                    |
+   |                 |------------------>|                    |
+   |                 |                   |                    |
+   |                 |                   |  Get /resource/    |
+   |                 |                   | - - - - - - - - - >|
+   |                 |                   |                    |
+   |                 |                   |     response       |
+   |                 |                   |<- - - - - - - - - -|
+   |                 |                   |                    |
+   |                 |     response      |                    |
+   |                 |<------------------|                    |
+   |                 |                   |                    |
+   |                 |                   |                    |
+   | <---------------|                   |                    |
+  User           ,---+---.          ,----+----.          ,----------.
+   ,-.           |Apicast|          |  CAMEL  |          |APIBackend|
+   `-'           `-------'          `---------'          `----------'
+   /|\
+    |
+   / \
+```
+
+
+## Configuration
+
+```
+"policy_chain": [
+    {
+      "name": "apicast.policy.apicast"
+    },
+    {
+      "name": "apicast.policy.camel",
+      "configuration": {
+          "all_proxy": "http://192.168.15.103:8888/",
+          "https_proxy": "https://192.168.15.103:8888/",
+          "http_proxy": "https://192.168.15.103:8888/"
+      }
+    }
+]
+```
+
+- If http_proxy or https_proxy is not defined the all_proxy will be taken. 
+
+## Caveats
+
+- This policy will disable all load-balancing policies and traffic will be
+  always send to the proxy. 
+- In case of HTTP_PROXY, HTTPS_PROXY or ALL_PROXY parameters are defined, this
+  policy will overwrite those values. 
+- Proxy connection does not support authentication, if you need auth, please use
+  headers policy.
+
+
+## Example Use case
+
+This policy was designed to be able to apply more fined grained policies and
+transformation using Apache Camel.
+
+An example project can be found
+[here](https://github.com/zregvart/camel-netty-proxy). This project is an HTTP
+Proxy that transforms to uppercase all the response body given by the API
+backend.

--- a/gateway/src/apicast/policy/camel/apicast-policy.json
+++ b/gateway/src/apicast/policy/camel/apicast-policy.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "Camel Service",
+  "summary": "Adds an Camel proxy to the service.",
+  "description": [
+    "With this policy all the traffic for this service will be routed accross ",
+    "the defined proxy"
+  ],
+  "version": "builtin",
+  "configuration": {
+      "type": "object",
+      "properties": {
+        "all_proxy": {
+          "description": "Defines a HTTP proxy to be used for connecting to services if a protocol-specific proxy is not specified. Authentication is not supported.",
+          "type": "string"
+        },
+        "https_proxy": {
+          "description": "Defines a HTTPS proxy to be used for connecting to HTTPS services. Authentication is not supported",
+          "type": "string"
+        },
+        "http_proxy": {
+          "description": "Defines a HTTP proxy to be used for connecting to HTTP services. Authentication is not supported",
+          "type": "string"
+        }
+      }
+  }
+}

--- a/gateway/src/apicast/policy/camel/camel.lua
+++ b/gateway/src/apicast/policy/camel/camel.lua
@@ -1,0 +1,59 @@
+local policy = require('apicast.policy')
+local _M = policy.new('http_proxy', 'builtin')
+
+local resty_url = require 'resty.url'
+local ipairs = ipairs
+
+local new = _M.new
+
+local proxies = {"http", "https"}
+
+function _M.new(config)
+  local self = new(config)
+  self.proxies = {}
+
+  if config.all_proxy then
+    local err
+    self.all_proxy, err =  resty_url.parse(config.all_proxy)
+    if err then
+      ngx.log(ngx.WARN, "All proxy '", config.all_proxy, "' is not correctly defined, err:", err)
+    end
+  end
+
+  for _, proto in ipairs(proxies) do
+    local val, err =  resty_url.parse(config[string.format("%s_proxy", proto)])
+    if err then
+      ngx.log(ngx.WARN, proto, " proxy is not correctly defined, err: ", err)
+    end
+    self.proxies[proto] = val or self.all_proxy
+  end
+  return self
+end
+
+local function find_proxy(self, scheme)
+  return self.proxies[scheme]
+end
+
+function _M:access(context)
+  local upstream = context.get_upstream()
+  if not upstream then
+    return
+  end
+
+  upstream:set_skip_https_connect_on_proxy()
+end
+
+function _M:export()
+  -- This get_http_proxy function will be called in upstream just in case if a
+  -- proxy is defined.
+  return  {
+    get_http_proxy = function(uri)
+      if not uri.scheme then
+        return nil
+      end
+      return find_proxy(self, uri.scheme)
+    end
+  }
+end
+
+return _M

--- a/gateway/src/apicast/policy/camel/init.lua
+++ b/gateway/src/apicast/policy/camel/init.lua
@@ -1,0 +1,1 @@
+return require("camel")

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -194,6 +194,9 @@ function _M:set_host_header()
     return host, nil
 end
 
+function _M:set_skip_https_connect_on_proxy()
+  self.skip_https_connect = true
+end
 --- Execute the upstream.
 --- @tparam table context any table (policy context, ngx.ctx) to store the upstream for later use by balancer
 function _M:call(context)

--- a/spec/policy/camel/camel_spec.lua
+++ b/spec/policy/camel/camel_spec.lua
@@ -1,0 +1,61 @@
+local camel_policy = require('apicast.policy.camel')
+local resty_url = require 'resty.url'
+
+describe('Camel policy', function()
+  local all_proxy_val = "http://all.com"
+  local http_proxy_val = "http://plain.com"
+  local https_proxy_val = "http://secure.com"
+
+  local http_uri = {scheme="http"}
+  local https_uri = {scheme="https"}
+
+  it("http[s] proxies are defined if all_proxy is in there", function()
+    local proxy = camel_policy.new({
+      all_proxy = all_proxy_val
+    })
+    local callback = proxy:export()
+
+    assert.same(callback.get_http_proxy(http_uri), resty_url.parse(all_proxy_val))
+    assert.same(callback.get_http_proxy(https_uri), resty_url.parse(all_proxy_val))
+  end)
+
+  it("all_proxy does not overwrite http/https proxies", function()
+    local proxy = camel_policy.new({
+      all_proxy = all_proxy_val,
+      http_proxy = http_proxy_val,
+      https_proxy = https_proxy_val
+    })
+    local callback = proxy:export()
+
+    assert.same(callback.get_http_proxy(http_uri), resty_url.parse(http_proxy_val))
+    assert.same(callback.get_http_proxy(https_uri), resty_url.parse(https_proxy_val))
+  end)
+
+  it("empty config return all nil", function()
+    local proxy = camel_policy.new({})
+    local callback = proxy:export()
+
+    assert.is_nil(callback.get_http_proxy(https_uri))
+    assert.is_nil(callback.get_http_proxy(http_uri))
+  end)
+
+  describe("get_http_proxy callback", function()
+    local callback = camel_policy.new({
+        all_proxy = all_proxy_val
+    }):export()
+
+    it("Valid protocol", function()
+
+      local result = callback.get_http_proxy(
+        resty_url.parse("http://google.com"))
+      assert.same(result, resty_url.parse(all_proxy_val))
+    end)
+
+    it("invalid protocol", function()
+      local result = callback:get_http_proxy(
+        {}, {scheme="invalid"})
+      assert.is_nil(result)
+    end)
+
+  end)
+end)

--- a/t/apicast-policy-camel.t
+++ b/t/apicast-policy-camel.t
@@ -1,0 +1,208 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+require("http_proxy.pl");
+
+repeat_each(1);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: API backend connection uses http proxy
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.camel",
+            "configuration": {
+                "http_proxy": "$TEST_NGINX_HTTP_PROXY"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+    access_by_lua_block {
+      local host = ngx.req.get_headers()["Host"]
+      local result = string.match(host, "^test:")
+      local assert = require('luassert')
+      assert.equals(result, "test:")
+      ngx.say("yay, api backend")
+    }
+  }
+--- request
+GET /?user_key=value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- error_log env
+using proxy: $TEST_NGINX_HTTP_PROXY
+
+=== TEST 2: API backend using all_proxy
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.http_proxy",
+            "configuration": {
+                "all_proxy": "$TEST_NGINX_HTTP_PROXY"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+    access_by_lua_block {
+      local host = ngx.req.get_headers()["Host"]
+      local result = string.match(host, "^test:")
+      local assert = require('luassert')
+      assert.equals(result, "test:")
+      ngx.say("yay, api backend")
+    }
+  }
+--- request
+GET /?user_key=value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- error_log env
+using proxy: $TEST_NGINX_HTTP_PROXY
+
+
+=== TEST 3: using HTTPS proxy for backend
+--- init eval
+$Test::Nginx::Util::PROXY_SSL_PORT = Test::APIcast::get_random_port();
+$Test::Nginx::Util::ENDPOINT_SSL_PORT = Test::APIcast::get_random_port();
+--- configuration random_port env eval
+<<EOF
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://localhost:$Test::Nginx::Util::ENDPOINT_SSL_PORT",
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.camel",
+            "configuration": {
+                "https_proxy": "http://127.0.0.1:$Test::Nginx::Util::PROXY_SSL_PORT"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+EOF
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream eval
+<<EOF
+  # Endpoint config
+  listen $Test::Nginx::Util::ENDPOINT_SSL_PORT ssl;
+
+  ssl_certificate $Test::Nginx::Util::ServRoot/html/server.crt;
+  ssl_certificate_key $Test::Nginx::Util::ServRoot/html/server.key;
+
+  server_name _ default_server;
+
+  location /test {
+    access_by_lua_block {
+      assert = require('luassert')
+      assert.equal('https', ngx.var.scheme)
+      assert.equal('$Test::Nginx::Util::ENDPOINT_SSL_PORT', ngx.var.server_port)
+      assert.equal('localhost', ngx.var.ssl_server_name)
+      assert.equal(ngx.var.request_uri, '/test?user_key=test3')
+
+      local host = ngx.req.get_headers()["Host"]
+      assert.equal(host, 'localhost:$Test::Nginx::Util::ENDPOINT_SSL_PORT')
+      ngx.say("yay, endpoint backend")
+
+    }
+  }
+}
+server {
+  # Proxy config
+  listen $Test::Nginx::Util::PROXY_SSL_PORT ssl;
+
+  ssl_certificate $Test::Nginx::Util::ServRoot/html/server.crt;
+  ssl_certificate_key $Test::Nginx::Util::ServRoot/html/server.key;
+
+
+  server_name _ default_server;
+
+  location ~ /.* {
+    proxy_http_version 1.1;
+    proxy_pass https://\$http_host;
+  }
+EOF
+--- request
+GET /test?user_key=test3
+--- more_headers
+User-Agent: Test::APIcast::Blackbox
+ETag: foobar
+--- error_code: 200
+--- user_files fixture=tls.pl eval
+--- error_log eval
+<<EOF
+using proxy: http://127.0.0.1:$Test::Nginx::Util::PROXY_SSL_PORT,
+EOF


### PR DESCRIPTION
Camel netty proxy was used via http-proxy policy, but on TLS
connections, the CONNECT method[0] is not allowed, so the request needs
to be terminated by camel-proxy and send to the upstream API.

With this change, we duplicate the http-proxy and we set the proxy to
terminate the connection so that will work correctly on camel TLS
connections.

[0] https://www.ietf.org/rfc/rfc2817.txt
Fix THREESCALE-4867

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>