### PR TITLE
Policy: content caching, add a new Prometheus metric.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added HTTP verb on url_rewriten [PR #1187](https://github.com/3scale/APIcast/pull/1187)  [THREESCALE-5259](https://issues.jboss.org/browse/THREESCALE-5259) [PR #1202](https://github.com/3scale/APIcast/pull/1202)
 - Added custom_metrics policy [PR #1188](https://github.com/3scale/APIcast/pull/1188) [THREESCALE-5098](https://issues.jboss.org/browse/THREESCALE-5098)
 - New apicast_status Prometheus metric [THREESCALE-5417](https://issues.jboss.org/browse/THREESCALE-5417) [PR #1200](https://github.com/3scale/APIcast/pull/1200)
+- New content_caching Prometheus metric [THREESCALE-5439](https://issues.jboss.org/browse/THREESCALE-5439) [PR #1203](https://github.com/3scale/APIcast/pull/1203)
 
 
 ## [3.8.0] - 2020-03-24

--- a/doc/prometheus-metrics.md
+++ b/doc/prometheus-metrics.md
@@ -1,17 +1,17 @@
 # Prometheus metrics
 
-| Metric                             | Description                                                      | Type      | Labels                                                       | Policy         |
-|------------------------------------|------------------------------------------------------------------|-----------|--------------------------------------------------------------|----------------|
-| apicast_status                     | Number of response status send by APIcast to client              | counter   | status                                                       | Default        |
-| nginx_http_connections             | Number of HTTP connections                                       | gauge     | state(accepted,active,handled,reading,total,waiting,writing) | Default        |
-| nginx_error_log                    | APIcast errors                                                   | counter   | level(debug,info,notice,warn,error,crit,alert,emerg)         | Default        |
-| openresty_shdict_capacity          | Capacity of the dictionaries shared between workers              | gauge     | dict(one for every dictionary)                               | Default        |
-| openresty_shdict_free_space        | Free space of the dictionaries shared between workers            | gauge     | dict(one for every dictionary)                               | Default        |
-| nginx_metric_errors_total          | Number of errors of the Lua library that manages the metrics     | counter   | -                                                            | Default        |
-| total_response_time_seconds        | Time needed to sent a response to the client (in seconds)        | histogram | service_id, service_system_name                              | Default        |
-| upstream_response_time_seconds     | Response times from upstream servers (in seconds)                | histogram | service_id, service_system_name                              | Default        |
-| upstream_status                    | HTTP status from upstream servers                                | counter   | status, service_id, service_system_name                      | Default        |
-| threescale_backend_calls           | Authorize and report requests to the 3scale backend (Apisonator) | counter   | endpoint(authrep, auth, report), status(2xx, 4xx, 5xx)       | APIcast        |
-| batching_policy_auths_cache_hits   | Hits in the auths cache of the 3scale batching policy            | counter   | -                                                            | 3scale Batcher |
-| batching_policy_auths_cache_misses | Misses in the auths cache of the 3scale batching policy          | counter   | -                                                            | 3scale Batcher |
-
+| Metric                             | Description                                                      | Type      | Labels                                                            | Policy          |
+|------------------------------------|------------------------------------------------------------------|-----------|-------------------------------------------------------------------|-----------------|
+| apicast_status                     | Number of response status send by APIcast to client              | counter   | status                                                            | Default         |
+| nginx_http_connections             | Number of HTTP connections                                       | gauge     | state(accepted,active,handled,reading,total,waiting,writing)      | Default         |
+| nginx_error_log                    | APIcast errors                                                   | counter   | level(debug,info,notice,warn,error,crit,alert,emerg)              | Default         |
+| openresty_shdict_capacity          | Capacity of the dictionaries shared between workers              | gauge     | dict(one for every dictionary)                                    | Default         |
+| openresty_shdict_free_space        | Free space of the dictionaries shared between workers            | gauge     | dict(one for every dictionary)                                    | Default         |
+| nginx_metric_errors_total          | Number of errors of the Lua library that manages the metrics     | counter   | -                                                                 | Default         |
+| total_response_time_seconds        | Time needed to sent a response to the client (in seconds)        | histogram | service_id, service_system_name                                   | Default         |
+| upstream_response_time_seconds     | Response times from upstream servers (in seconds)                | histogram | service_id, service_system_name                                   | Default         |
+| upstream_status                    | HTTP status from upstream servers                                | counter   | status, service_id, service_system_name                           | Default         |
+| threescale_backend_calls           | Authorize and report requests to the 3scale backend (Apisonator) | counter   | endpoint(authrep, auth, report), status(2xx, 4xx, 5xx)            | APIcast         |
+| batching_policy_auths_cache_hits   | Hits in the auths cache of the 3scale batching policy            | counter   | -                                                                 | 3scale Batcher  |
+| batching_policy_auths_cache_misses | Misses in the auths cache of the 3scale batching policy          | counter   | -                                                                 | 3scale Batcher  |
+| content_caching                    | Number of requests that go through content caching policy.       | counter   | status(MISS, BYPASS, EXPIRED, STALE, UPDATING, REVALIDATED, HIT)  | Content Caching |

--- a/gateway/src/apicast/policy/content_caching/content_caching.lua
+++ b/gateway/src/apicast/policy/content_caching/content_caching.lua
@@ -6,6 +6,11 @@ local tab_new = require('resty.core.base').new_tab
 
 local Rule = require("rule")
 
+local prometheus = require('apicast.prometheus')
+local metrics_updater = require('apicast.metrics.updater')
+
+local content_cache_metric = prometheus('counter', "content_caching", "Content caching status", {"status"})
+
 local new = _M.new
 
 function _M.new(config)
@@ -45,6 +50,9 @@ function _M:header_filter(context)
   if ngx.var.cache_request ~= "" then
     return
   end
+
+  metrics_updater.inc(content_cache_metric, ngx.var.upstream_cache_status)
+  ngx.log(ngx.INFO, "Request content caching status: ", ngx.var.upstream_cache_status)
 
   if context[self] and context[self].header then
     ngx.header[context[self].header] = ngx.var.upstream_cache_status


### PR DESCRIPTION
When a content caching is enabled, a new metric is exposed to be able to
know the status of content caching.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>