### PR TITLE
Policy: Routing fix URL encoding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issues with HTTPS_PROXY and large bodies [THREESCALE-3863](https://issues.jboss.org/browse/THREESCALE-3863) [PR #1191](https://github.com/3scale/APIcast/pull/1191)
 - Fixed issues with path routing and query args [THREESCALE-5149](https://issues.redhat.com/browse/THREESCALE-5149) [PR #1190](https://github.com/3scale/APIcast/pull/1190)
 - Fixed issue with IPCheck policy when forwarder-for value contains port [THREESCALE-5258](https://issues.redhat.com/browse/THREESCALE-5258) [PR #1192](https://github.com/3scale/APIcast/pull/1192)
+- Fixed issues with URL encode on routing policy [THREESCALE-5454](https://issues.redhat.com/browse/THREESCALE-5454) [PR #1208](https://github.com/3scale/APIcast/pull/1208)
 
 
 ### Added

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -159,9 +159,8 @@ function _M:rewrite_request()
     end
 
     local uri = self.uri
-
     if uri.path then
-        ngx.req.set_uri(prefix_path(uri.path))
+        ngx.req.set_uri(ngx.unescape_uri(prefix_path(uri.path)))
     end
 
     if uri.query then


### PR DESCRIPTION
This commit fixes an issue when a special character uses some encoding.
The value to the upstream API if the routing policy was used, is also
encoded, so something like "/foo/test space" should land in APICast as:

`/foo/test%20space/`

And the path to the Upstream API should contain `test%20space`, but
because `ngx.req.set_uri` mark the URL to be encoded again, the URL that
will be received in the Upstream API will be `/test%2520space/`

This commit keeps the URL encoding correctly across all the flow.

Fix THREESCALE-5454

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>