### PR TITLE
Policy: rate limit headers does not send invalid value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Added upstream Mutual TLS policy [THREESCALE-672](https://issues.jboss.org/browse/THREESCALE-672) [PR #1182](https://github.com/3scale/APIcast/pull/1182)
-- Added Rate-limit headers policy [THREESCALE-3795](https://issues.jboss.org/browse/THREESCALE-3795) [PR #1166](https://github.com/3scale/APIcast/pull/1166) [PR #1197](https://github.com/3scale/APIcast/pull/1197)
+- Added Rate-limit headers policy [THREESCALE-3795](https://issues.jboss.org/browse/THREESCALE-3795) [PR #1166](https://github.com/3scale/APIcast/pull/1166) [PR #1197](https://github.com/3scale/APIcast/pull/1197) [PR #1209](https://github.com/3scale/APIcast/pull/1209)
 - Added Content-caching policy [THREESCALE-2894](https://issues.jboss.org/browse/THREESCALE-2894) [PR #1182](https://github.com/3scale/APIcast/pull/1182)
 - Added Nginx request_id variable to context [PR #1184](https://github.com/3scale/APIcast/pull/1184)
 - Added HTTP verb on url_rewriten [PR #1187](https://github.com/3scale/APIcast/pull/1187)  [THREESCALE-5259](https://issues.jboss.org/browse/THREESCALE-5259) [PR #1202](https://github.com/3scale/APIcast/pull/1202)

--- a/t/apicast-policy-rate_limit_headers.t
+++ b/t/apicast-policy-rate_limit_headers.t
@@ -346,3 +346,60 @@ location / {
 [200, 200]
 --- no_error_log
 [error]
+
+=== TEST 7: No rate-limit information if no limits by app
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "hosts": [
+          "localhost"
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.rate_limit_headers"
+          },
+          {
+            "name": "apicast",
+            "version": "builtin",
+            "configuration": {}
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+--- upstream env
+location / {
+  access_by_lua_block {
+      ngx.say("OK")
+  }
+}
+--- request
+GET /?user_key=123
+--- response_headers
+RateLimit-Limit:
+RateLimit-Remaining:
+RateLimit-Reset: 
+--- response_body env
+OK
+--- error_code: 200
+--- no_error_log
+[error]
+
+


### PR DESCRIPTION
When the backend does not reply with limit headers, APIcast should send
no limit headers at all. This change make sure that the value is not
send at all.

Also, make sure that the value of limit and reset is always positive or
0.

THREESCALE-3795

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>