### PR TITLE
Policy:RateLimit: Fix issues with jsonschema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issues with URL encode on routing policy [THREESCALE-5454](https://issues.redhat.com/browse/THREESCALE-5454) [PR #1208](https://github.com/3scale/APIcast/pull/1208)
 
 - Fixed issue with mapping rules and 3scale batcher policy [THREESCALE-5513](https://issues.redhat.com/browse/THREESCALE-5513) [PR #1210](https://github.com/3scale/APIcast/pull/1210)
+- Fixed issues with invalid number of conditions [THREESCALE-5435](https://issues.redhat.com/browse/THREESCALE-5435) [PR #1212](https://github.com/3scale/APIcast/pull/1212)
+
 
 ### Added
 

--- a/gateway/src/apicast/policy/rate_limit/apicast-policy.json
+++ b/gateway/src/apicast/policy/rate_limit/apicast-policy.json
@@ -113,7 +113,7 @@
             "items": {
               "$ref": "#/definitions/operation"
             },
-            "minItems": 1
+            "minItems": 0
           },
           "combine_op": {
             "type": "string",

--- a/gateway/src/apicast/policy/rate_limit/rate_limit.lua
+++ b/gateway/src/apicast/policy/rate_limit/rate_limit.lua
@@ -98,7 +98,7 @@ local function build_condition(config_condition)
   local cond = config_condition or {}
 
   return Condition.new(
-    build_operations(cond.operations),
+    build_operations(cond.operations or {}),
     cond.combine_op
   )
 end


### PR DESCRIPTION
When the condition is always true, or not valid at all, the number of
operations is not required at all.

Test no needed because is heavily tested without conditions on the
current integration test:

https://github.com/3scale/APIcast/blob/6f46ebde5a0d156a60874f0603c878140a3cf6d2/t/apicast-policy-rate-limit.t#L91
https://github.com/3scale/APIcast/blob/6f46ebde5a0d156a60874f0603c878140a3cf6d2/t/apicast-policy-rate-limit.t#L226
https://github.com/3scale/APIcast/blob/6f46ebde5a0d156a60874f0603c878140a3cf6d2/t/apicast-policy-rate-limit.t#L297

Fixes THREESCALE-5435

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>