### PR TITLE
Config: increase cache limits on demand.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## [Unreleased]
+
+### Added
 - Support Proxy Protocol [PR #1211](https://github.com/3scale/APIcast/pull/1211) [THREESCALE-5366](https://issues.redhat.com/browse/THREESCALE-5366)
 - Enable support to log credentials on logging policy [PR #1217](https://github.com/3scale/APIcast/pull/1217) [THREESCALE-5273](https://issues.redhat.com/browse/THREESCALE-5273)
+- Add a way to support more than 1000 services in a single instance  [PR #1222](https://github.com/3scale/APIcast/pull/1222) [THREESCALE-5308](https://issues.redhat.com/browse/THREESCALE-5308)
+
 
 ### Fixed
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -28,6 +28,15 @@ Specifies the period (in seconds) that the configuration will be stored in the c
 
 This parameter is also used to store OpenID discovery configuration in the local cache, as the same behavior as described above.
 
+### `APICAST_SERVICE_CACHE_SIZE`
+
+**Values:** _a number_
+**Default:** 1000
+
+Specifies the number of services that APICast can store in the internal cache. A
+big number has some kind of performance inpact because Lua lru cache will
+initialize all the entries.
+
 ### `APICAST_CONFIGURATION_LOADER`
 
 **Values:** boot | lazy  

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -34,7 +34,7 @@ This parameter is also used to store OpenID discovery configuration in the local
 **Default:** 1000
 
 Specifies the number of services that APICast can store in the internal cache. A
-big number has some kind of performance inpact because Lua lru cache will
+big number has a performance impact because Lua lru cache will
 initialize all the entries.
 
 ### `APICAST_CONFIGURATION_LOADER`

--- a/gateway/src/apicast/configuration_store.lua
+++ b/gateway/src/apicast/configuration_store.lua
@@ -13,7 +13,7 @@ local _M = {
   path_routing = env.enabled('APICAST_PATH_ROUTING') or env.enabled('APICAST_PATH_ROUTING_ENABLED') or
                  env.enabled('APICAST_PATH_ROUTING_ONLY'),
   path_routing_only = env.enabled('APICAST_PATH_ROUTING_ONLY'),
-  cache_size = 1000
+  cache_size = tonumber(env.value('APICAST_SERVICE_CACHE_SIZE')) or 1000
 }
 
 if env.enabled('APICAST_PATH_ROUTING_ENABLED') then ngx.log(ngx.WARN, 'DEPRECATION NOTICE: Use APICAST_PATH_ROUTING not APICAST_PATH_ROUTING_ENABLED as this will soon be unsupported') end
@@ -34,7 +34,6 @@ function _M.new(cache_size, options)
   else
     path_routing_only = _M.path_routing_only
   end
-
   return setmetatable({
     -- services hashed by id, example: {
     --   ["16"] = service1

--- a/t/configuration-store-cache-limit.t
+++ b/t/configuration-store-cache-limit.t
@@ -1,0 +1,66 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: More than 1000 services
+This test is to validate that APICAST_SERVICE_CACHE_SIZE is working correctly,
+because more than 1000 services can hit the limit of the cache and some
+services can be lost, related THREESCALE-5308
+--- env eval
+(
+  'APICAST_SERVICE_CACHE_SIZE' => "2000",
+)
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.say('yay, api backend');
+    }
+  }
+--- configuration env eval
+my $res = [];
+for(my $i = 0; $i < 1600; $i = $i + 1 ) {
+  my $s = <<EOF;
+{
+      "id": $i,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "hosts": [
+          "test-$i"
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+EOF
+  push @$res, $s;
+}
+my $str = CORE::join(',', @$res);
+<<EOF;
+{"services": [$str]}
+EOF
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /?user_key=value
+--- more_headers
+Host: test-0
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+


### PR DESCRIPTION
By default, 1000 services were enough, currently a lot of new users are hitting
thousands of services in a single APICast instance. This commit adds a option
to have a bigger cache size if the user desired that.

Fix THREESCALE-5308