### PR TITLE
Opentracing: Added new tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support Proxy Protocol [PR #1211](https://github.com/3scale/APIcast/pull/1211) [THREESCALE-5366](https://issues.redhat.com/browse/THREESCALE-5366)
 - Enable support to log credentials on logging policy [PR #1217](https://github.com/3scale/APIcast/pull/1217) [THREESCALE-5273](https://issues.redhat.com/browse/THREESCALE-5273)
 - Add a way to support more than 1000 services in a single instance  [PR #1222](https://github.com/3scale/APIcast/pull/1222) [THREESCALE-5308](https://issues.redhat.com/browse/THREESCALE-5308)
+- Added new original_request_uri tag on Opentracing [PR #1223](https://github.com/3scale/APIcast/pull/1223) [THREESCALE-5669](https://issues.redhat.com/browse/THREESCALE-5669)
 
 
 ### Fixed

--- a/gateway/conf.d/apicast.conf
+++ b/gateway/conf.d/apicast.conf
@@ -159,6 +159,7 @@ location / {
 
   set $post_action_impact '';
   set $original_request_id '';
+  set $original_request_uri '$scheme://$host$request_uri';
 
   # Variables needed by Websocket policy
   set $upstream_connection_header '';

--- a/gateway/http.d/apicast.conf.liquid
+++ b/gateway/http.d/apicast.conf.liquid
@@ -95,6 +95,7 @@ server {
   {% if opentracing_tracer != empty %}
   opentracing_operation_name "apicast";
   opentracing_trace_locations on;
+  opentracing_tag original_request_uri $original_request_uri;
   {% endif %}
 
   {% include "http.d/ssl.conf" %}

--- a/t/opentracing.t
+++ b/t/opentracing.t
@@ -89,3 +89,53 @@ GET /a_path?
 --- udp_query eval
 qr/jaeger.version/
 --- wait: 10
+
+=== TEST 3: original_request_uri tag
+Opentracing custom tag fix for THREESCALE-5669
+-- env eval
+(
+    'OPENTRACING_FORWARD_HEADER' => "foobar"
+)
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "system_name": "foo",
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.upstream",
+            "configuration": {
+              "rules": [
+                {
+                  "regex": "/",
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+    content_by_lua_block {
+      local headers  = ngx.req.get_headers()
+      assert(headers["foobar"] == "value")
+    }
+  }
+--- request
+GET /a_path?
+--- more_headers eval
+"foobar: value"
+--- error_code: 200
+--- no_error_log
+[error]
+--- udp_listen: 6831
+--- udp_reply
+--- udp_query eval
+qr/original_request_uri/
+--- wait: 10


### PR DESCRIPTION
When using opentracing, the http.host label, is the upstream Host. If a
user wants to track down the opentracing config with the original
host/header is not possible at all.

This commit adds a new tag on opentracing called original_request_uri.

Fix THREESCALE-5669

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>