### PR TITLE
Policy: caching fix issues when disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed issues with allow caching mode  and 3scale batcher [PR #1216](https://github.com/3scale/APIcast/pull/1216) [THREESCALE-5753](https://issues.redhat.com/browse/THREESCALE-5753)
+- Fixed issues when Auth Caching is disabled [PR #1225](https://github.com/3scale/APIcast/pull/1225) [THREESCALE-4464](https://issues.redhat.com/browse/THREESCALE-4464)
+
 
 ## [3.9.0] 2020-08-17
 

--- a/gateway/src/apicast/policy/caching/caching.lua
+++ b/gateway/src/apicast/policy/caching/caching.lua
@@ -73,7 +73,8 @@ local function allow_handler(cache, cached_key, response, ttl)
   end
 end
 
-local function disabled_cache_handler()
+local function disabled_cache_handler(cache, cached_key)
+  cache:delete(cached_key)
   ngx.log(ngx.DEBUG, 'Caching is disabled. Skipping cache handler.')
 end
 

--- a/spec/policy/caching/caching_spec.lua
+++ b/spec/policy/caching/caching_spec.lua
@@ -138,6 +138,15 @@ describe('Caching policy', function()
         cache_handler(cache, 'a_key', { status = 200 }, nil)
         assert.is_nil(cache:get('a_key'))
       end)
+
+      it("clears the cache if it's present", function()
+          -- THREESCALE-4464
+          cache:set('a_key', 200)
+
+          cache_handler(cache, 'a_key', { status = 200 }, nil)
+          assert.is_nil(cache:get('a_key'))
+      end)
+
     end)
   end)
 end)


### PR DESCRIPTION
If caching is disabled, the key should be removed just in case some keys
are in the container from older configuration versions.

Fix THREESCALE-4464

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>