### PR TITLE
Caching: JSONSCHEMA disable default value and required a value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add a way to support more than 1000 services in a single instance  [PR #1222](https://github.com/3scale/APIcast/pull/1222) [THREESCALE-5308](https://issues.redhat.com/browse/THREESCALE-5308)
 - Added new original_request_uri tag on Opentracing [PR #1223](https://github.com/3scale/APIcast/pull/1223) [THREESCALE-5669](https://issues.redhat.com/browse/THREESCALE-5669)
 - Added a new metric when the `worker_process` starts [PR #1228](https://github.com/3scale/APIcast/pull/1228) [THREESCALE-5965](https://issues.redhat.com/browse/THREESCALE-5965)
+- Caching policy disable default field [PR #1226](https://github.com/3scale/APIcast/pull/1226) [THREESCALE-1514](https://issues.redhat.com/browse/THREESCALE-1514)
 
 ### Fixed
 

--- a/gateway/src/apicast/policy/caching/apicast-policy.json
+++ b/gateway/src/apicast/policy/caching/apicast-policy.json
@@ -21,6 +21,7 @@
   "version": "builtin",
   "configuration": {
     "type": "object",
+    "required": ["caching_type"],
     "properties": {
       "caching_type": {
         "description": "Caching mode",
@@ -42,8 +43,7 @@
             "enum": ["none"],
             "title": "None: disable caching."
           }
-        ],
-        "default": "none"
+        ]
       }
     }
   }

--- a/spec/policy/caching/caching_spec.lua
+++ b/spec/policy/caching/caching_spec.lua
@@ -17,16 +17,6 @@ describe('Caching policy', function()
     end
   end)
 
-  describe('.new', function()
-    it('disables caching when caching type is not specified', function()
-      caching_policy = require('apicast.policy.caching').new({})
-      cache_handler = caching_policy:export().cache_handler
-
-      cache_handler(cache, 'a_key', { status = 200 }, nil)
-      assert.is_nil(cache:get('a_key'))
-    end)
-  end)
-
   describe('.export', function()
     describe('when configured as strict', function()
       before_each(function()


### PR DESCRIPTION
This change is to be consistent with other policies, where nothing is
set to default, but the value should be required.

Fix THREESCALE-1514:

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>