### PR TITLE
SERVICES_FILTER: Fix issues with oidc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed issues with allow caching mode  and 3scale batcher [PR #1216](https://github.com/3scale/APIcast/pull/1216) [THREESCALE-5753](https://issues.redhat.com/browse/THREESCALE-5753)
 - Fixed issues when Auth Caching is disabled [PR #1225](https://github.com/3scale/APIcast/pull/1225) [THREESCALE-4464](https://issues.redhat.com/browse/THREESCALE-4464)
+- Fixed issues with service filter and OIDC [PR #1229](https://github.com/3scale/APIcast/pull/1229) [THREESCALE-6042](https://issues.redhat.com/browse/THREESCALE-6042)
 
 
 ## [3.9.0] 2020-08-17

--- a/gateway/src/apicast/configuration_loader/oidc.lua
+++ b/gateway/src/apicast/configuration_loader/oidc.lua
@@ -21,8 +21,13 @@ _M.discovery = require('resty.oidc.discovery').new()
 
 local function load_service(service)
     if not service or not service.proxy then return nil end
+    local result = _M.discovery:call(service.proxy.oidc_issuer_endpoint)
 
-    return _M.discovery:call(service.proxy.oidc_issuer_endpoint)
+    if result and service.id then
+      result.service_id = service.id
+    end
+
+    return result
 end
 
 function _M.call(...)

--- a/spec/configuration_loader/oidc_spec.lua
+++ b/spec/configuration_loader/oidc_spec.lua
@@ -52,7 +52,7 @@ describe('OIDC Configuration loader', function()
         }
       local oidc = loader.call(cjson.encode(config))
 
-      assert.same([[{"services":[{"id":21,"proxy":{"oidc_issuer_endpoint":"https:\/\/user:pass@example.com"}}],"oidc":[{"issuer":"https:\/\/example.com","config":{"jwks_uri":"http:\/\/example.com\/jwks","issuer":"https:\/\/example.com"},"keys":{}}]}]], oidc)
+      assert.same([[{"services":[{"id":21,"proxy":{"oidc_issuer_endpoint":"https:\/\/user:pass@example.com"}}],"oidc":[{"service_id":21,"issuer":"https:\/\/example.com","config":{"jwks_uri":"http:\/\/example.com\/jwks","issuer":"https:\/\/example.com"},"keys":{}}]}]], oidc)
     end)
 
     -- This is a regression test. cjson crashed when parsing a config where

--- a/spec/configuration_spec.lua
+++ b/spec/configuration_spec.lua
@@ -179,6 +179,61 @@ describe('Configuration object', function()
 
   end)
 
+  describe('.filter_oidc_config', function()
+    local Service = require 'apicast.configuration.service'
+    local filter_oidc_config = configuration.filter_oidc_config
+
+    local mockservices = {
+      Service.new({id="42", hosts={"test.foo.com", "test.bar.com"}}),
+      Service.new({id="12", hosts={"staging.foo.com"}}),
+      Service.new({id="21", hosts={"prod.foo.com"}}),
+    }
+
+    it('works with nil', function()
+      local res = filter_oidc_config(nil, nil)
+      assert.same(res, {})
+    end)
+
+
+    it('if no id in oidc config returns correctly', function()
+      local res = filter_oidc_config(mockservices, nil)
+      assert.same(res, {})
+    end)
+
+    it("filter multiple services correctly", function()
+      local oidc_config = {
+        {service_id= 42, issuer="foo"},
+        {service_id= 21, issuer="bar"},
+      }
+      local res = filter_oidc_config(mockservices, oidc_config)
+      assert.same(res, oidc_config)
+    end)
+
+    it("OIDC config without id pass the filter", function()
+
+      local oidc_config = {
+        {issuer="foo"},
+        {issuer="bar"},
+      }
+      local res = filter_oidc_config(mockservices, oidc_config)
+      assert.same(res, oidc_config)
+    end)
+
+    it("OIDC config with invalid services are filter out", function()
+      local oidc_config = {
+        {service_id= 42, issuer="foo"},
+        {service_id= 21, issuer="bar"},
+        {service_id= 100, issuer="foobar"},
+      }
+      local res = filter_oidc_config(mockservices, oidc_config)
+      assert.same(res, {
+        {service_id= 42, issuer="foo"},
+        {service_id= 21, issuer="bar"},
+      })
+    end)
+
+  end)
+
   insulate('.services_limit', function()
     local services_limit = configuration.services_limit
 


### PR DESCRIPTION
The oidc-service mapping is not based on a key, so each time that a
service is deleted, the mapping to the given service is broken.

With this change, the OIDC config is stored with the service id, so in
case that some services are removed, it'll keep it correctly mapped.

FIX THREESCALE-6042

Missing unit test

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>