### PR TITLE
Fix issues with Routing policy and camel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 with many services might have experienced issues with this policy because the
 size of those dictionaries was not enough to store everything the policy needs
 to function correctly. [PR #1231](https://github.com/3scale/APIcast/pull/1231)
+- Fixed issue with Camel service over HTTPs when Routing Policy [PR #1230](https://github.com/3scale/APIcast/pull/1230) [THREESCALE-5891](https://issues.redhat.com/browse/THREESCALE-5891)
+
+
 
 ## [3.9.0] 2020-08-17
 

--- a/gateway/src/apicast/policy/camel/camel.lua
+++ b/gateway/src/apicast/policy/camel/camel.lua
@@ -35,6 +35,8 @@ local function find_proxy(self, scheme)
 end
 
 function _M:access(context)
+  context.skip_https_connect_on_proxy = true
+
   local upstream = context.get_upstream()
   if not upstream then
     return

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -214,6 +214,10 @@ function _M:call(context)
         ngx.log(ngx.DEBUG, 'using proxy: ', proxy_uri)
         -- https requests will be terminated, http will be rewritten and sent
         -- to a proxy
+        if context.skip_https_connect_on_proxy then
+          self:set_skip_https_connect_on_proxy();
+        end
+
         http_proxy.request(self, proxy_uri)
     else
         local err = self:rewrite_request()

--- a/t/apicast-policy-camel.t
+++ b/t/apicast-policy-camel.t
@@ -206,3 +206,113 @@ ETag: foobar
 <<EOF
 using proxy: http://127.0.0.1:$Test::Nginx::Util::PROXY_SSL_PORT,
 EOF
+
+
+
+=== TEST 4: using HTTPS proxy without api_backend upstream
+--- init eval
+$Test::Nginx::Util::PROXY_SSL_PORT = Test::APIcast::get_random_port();
+$Test::Nginx::Util::ENDPOINT_SSL_PORT = Test::APIcast::get_random_port();
+--- configuration random_port env eval
+<<EOF
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "https://localhost:$Test::Nginx::Util::ENDPOINT_SSL_PORT",
+                  "condition": {
+                    "operations": [
+                      {
+                        "match": "liquid",
+                        "liquid_value": "test",
+                        "op": "==",
+                        "value": "test"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.camel",
+            "configuration": {
+                "https_proxy": "http://127.0.0.1:$Test::Nginx::Util::PROXY_SSL_PORT"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+EOF
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream eval
+<<EOF
+  # Endpoint config
+  listen $Test::Nginx::Util::ENDPOINT_SSL_PORT ssl;
+
+  ssl_certificate $Test::Nginx::Util::ServRoot/html/server.crt;
+  ssl_certificate_key $Test::Nginx::Util::ServRoot/html/server.key;
+
+  server_name _ default_server;
+
+  location /test {
+    access_by_lua_block {
+      assert = require('luassert')
+      assert.equal('https', ngx.var.scheme)
+      assert.equal('$Test::Nginx::Util::ENDPOINT_SSL_PORT', ngx.var.server_port)
+      assert.equal('localhost', ngx.var.ssl_server_name)
+      assert.equal(ngx.var.request_uri, '/test?user_key=test3')
+
+      local host = ngx.req.get_headers()["Host"]
+      assert.equal(host, 'localhost:$Test::Nginx::Util::ENDPOINT_SSL_PORT')
+      ngx.say("yay, endpoint backend")
+
+    }
+  }
+}
+server {
+  # Proxy config
+  listen $Test::Nginx::Util::PROXY_SSL_PORT ssl;
+
+  ssl_certificate $Test::Nginx::Util::ServRoot/html/server.crt;
+  ssl_certificate_key $Test::Nginx::Util::ServRoot/html/server.key;
+
+
+  server_name _ default_server;
+
+  location ~ /.* {
+    proxy_http_version 1.1;
+    proxy_pass https://\$http_host;
+  }
+EOF
+--- request
+GET /test?user_key=test3
+--- more_headers
+User-Agent: Test::APIcast::Blackbox
+ETag: foobar
+--- error_code: 200
+--- user_files fixture=tls.pl eval
+--- error_log eval
+<<EOF
+using proxy: http://127.0.0.1:$Test::Nginx::Util::PROXY_SSL_PORT,
+EOF


### PR DESCRIPTION
When routing policy is involved(default in APIAP) and Camel is enabled,
the upstream is no longer the context.get_upstream() so the changes made
to the upstream are not longer applied.

Fix THREESCALE-5891

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>