### PR TITLE
Increase size of dictionaries used by the batching policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issues with allow caching mode  and 3scale batcher [PR #1216](https://github.com/3scale/APIcast/pull/1216) [THREESCALE-5753](https://issues.redhat.com/browse/THREESCALE-5753)
 - Fixed issues when Auth Caching is disabled [PR #1225](https://github.com/3scale/APIcast/pull/1225) [THREESCALE-4464](https://issues.redhat.com/browse/THREESCALE-4464)
 - Fixed issues with service filter and OIDC [PR #1229](https://github.com/3scale/APIcast/pull/1229) [THREESCALE-6042](https://issues.redhat.com/browse/THREESCALE-6042)
-
+- Increased size of dictionaries used by the Batching policy to 20 MB. Users
+with many services might have experienced issues with this policy because the
+size of those dictionaries was not enough to store everything the policy needs
+to function correctly. [PR #1231](https://github.com/3scale/APIcast/pull/1231)
 
 ## [3.9.0] 2020-08-17
 

--- a/gateway/conf/nginx.conf.liquid
+++ b/gateway/conf/nginx.conf.liquid
@@ -89,8 +89,8 @@ http {
   # This shared dictionaries are only used in the 3scale batcher policy.
   # This is not ideal, but they'll need to be here until we allow policies to
   # modify this template.
-  lua_shared_dict cached_auths 1m;
-  lua_shared_dict batched_reports 1m;
+  lua_shared_dict cached_auths 20m;
+  lua_shared_dict batched_reports 20m;
   lua_shared_dict batched_reports_locks 1m;
 
   {% for file in "sites.d/*.conf" | filesystem %}

--- a/t/prometheus-metrics.t
+++ b/t/prometheus-metrics.t
@@ -33,9 +33,9 @@ nginx_metric_errors_total 0
 # HELP openresty_shdict_capacity OpenResty shared dictionary capacity
 # TYPE openresty_shdict_capacity gauge
 openresty_shdict_capacity{dict="api_keys"} 10485760
-openresty_shdict_capacity{dict="batched_reports"} 1048576
+openresty_shdict_capacity{dict="batched_reports"} 20971520
 openresty_shdict_capacity{dict="batched_reports_locks"} 1048576
-openresty_shdict_capacity{dict="cached_auths"} 1048576
+openresty_shdict_capacity{dict="cached_auths"} 20971520
 openresty_shdict_capacity{dict="configuration"} 10485760
 openresty_shdict_capacity{dict="init"} 16384
 openresty_shdict_capacity{dict="limiter"} 1048576
@@ -45,9 +45,9 @@ openresty_shdict_capacity{dict="rate_limit_headers"} 20971520
 # HELP openresty_shdict_free_space OpenResty shared dictionary free space
 # TYPE openresty_shdict_free_space gauge
 openresty_shdict_free_space{dict="api_keys"} 10412032
-openresty_shdict_free_space{dict="batched_reports"} 1032192
+openresty_shdict_free_space{dict="batched_reports"} 20840448
 openresty_shdict_free_space{dict="batched_reports_locks"} 1032192
-openresty_shdict_free_space{dict="cached_auths"} 1032192
+openresty_shdict_free_space{dict="cached_auths"} 20840448
 openresty_shdict_free_space{dict="configuration"} 10412032
 openresty_shdict_free_space{dict="init"} 4096
 openresty_shdict_free_space{dict="limiter"} 1032192


### PR DESCRIPTION
I'm running some benchmarks with a large number of products, services, metrics, etc. and 1MB for the dictionaries used by the batching policy is not enough. I've seen the free space go to 0 using Prometheus.

For the particular use case that I'm trying ~12MB seems to be the minimum space required. I've defined 20 to have some margin.