### PR TITLE
3scale-batcher: Fix issues with non alphanumeric metrics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add response/request content size limits [PR #1227](https://github.com/3scale/APIcast/pull/1227) [THREESCALE-5244](https://issues.redhat.com/browse/THREESCALE-5244)
 
 
+
 ### Fixed
 
 - Fixed issues with allow caching mode  and 3scale batcher [PR #1216](https://github.com/3scale/APIcast/pull/1216) [THREESCALE-5753](https://issues.redhat.com/browse/THREESCALE-5753)
@@ -28,6 +29,7 @@ size of those dictionaries was not enough to store everything the policy needs
 to function correctly. [PR #1231](https://github.com/3scale/APIcast/pull/1231)
 - Fixed issue with Camel service over HTTPs when Routing Policy [PR #1230](https://github.com/3scale/APIcast/pull/1230) [THREESCALE-5891](https://issues.redhat.com/browse/THREESCALE-5891)
 - Fixed doc issue on SERVICES_FILTER parameter [PR #1233](https://github.com/3scale/APIcast/pull/1233) [THREESCALE-5421](https://issues.redhat.com/browse/THREESCALE-5421)
+- Non-alphanumeric metric name in 3scale-batcher policy [PR #1234](https://github.com/3scale/APIcast/pull/1234) [THREESCALE-4913](https://issues.redhat.com/browse/THREESCALE-4913)
 
 
 

--- a/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
@@ -39,10 +39,10 @@ local function metrics_part_in_key(usage)
 end
 
 local regexes_report_key = {
-  [[service_id:(?<service_id>[\w-]+),user_key:(?<user_key>[\w-]+),metric:(?<metric>[\w-]+)]],
-  [[service_id:(?<service_id>[\w-]+),access_token:(?<access_token>[\w-]+),metric:(?<metric>[\w-]+)]],
-  [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\w-]+),app_key:(?<app_key>[\w-]+),metric:(?<metric>[\w-]+)]],
-  [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\w-]+),metric:(?<metric>[\w-]+)]],
+  [[service_id:(?<service_id>[\w-]+),user_key:(?<user_key>[\w-]+),metric:(?<metric>[\S-]+)]],
+  [[service_id:(?<service_id>[\w-]+),access_token:(?<access_token>[\w-]+),metric:(?<metric>[\S-]+)]],
+  [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\w-]+),app_key:(?<app_key>[\w-]+),metric:(?<metric>[\S-]+)]],
+  [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\w-]+),metric:(?<metric>[\S-]+)]],
 }
 
 function _M.key_for_cached_auth(transaction)

--- a/spec/policy/3scale_batcher/keys_helper_spec.lua
+++ b/spec/policy/3scale_batcher/keys_helper_spec.lua
@@ -36,6 +36,21 @@ describe('Keys Helper', function()
       assert.same({ service_id = 's1', app_id = 'ai', app_key = 'ak', metric = 'm1' }, report)
     end)
 
+    it('returns a valid metric in case of special chars', function()
+      local key = 'service_id:s1,app_id:ai,app_key:ak,metric:m/1'
+      local report = keys_helper.report_from_key_batched_report(key)
+      assert.same({ service_id = 's1', app_id = 'ai', app_key = 'ak', metric = 'm/1' }, report)
+
+      key = 'service_id:s1,app_id:ai,app_key:ak,metric:m_1'
+      report = keys_helper.report_from_key_batched_report(key)
+      assert.same({ service_id = 's1', app_id = 'ai', app_key = 'ak', metric = 'm_1' }, report)
+
+
+      key = 'service_id:s1,app_id:ai,app_key:ak,metric:m%1'
+      report = keys_helper.report_from_key_batched_report(key)
+      assert.same({ service_id = 's1', app_id = 'ai', app_key = 'ak', metric = 'm%1' }, report)
+    end)
+
     it('returns a report given a key of a batched report with user key', function()
       local key = 'service_id:s1,user_key:uk,metric:m1'
 


### PR DESCRIPTION
When the metric has a non-alphanumeric name, it'll be not reported
correctly by APIcast.

Fix THREESCALE-4913

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>