### PR TITLE
Resolver: using Fully qualified names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ to function correctly. [PR #1231](https://github.com/3scale/APIcast/pull/1231)
 - Fixed issue with Camel service over HTTPs when Routing Policy [PR #1230](https://github.com/3scale/APIcast/pull/1230) [THREESCALE-5891](https://issues.redhat.com/browse/THREESCALE-5891)
 - Fixed doc issue on SERVICES_FILTER parameter [PR #1233](https://github.com/3scale/APIcast/pull/1233) [THREESCALE-5421](https://issues.redhat.com/browse/THREESCALE-5421)
 - Non-alphanumeric metric name in 3scale-batcher policy [PR #1234](https://github.com/3scale/APIcast/pull/1234) [THREESCALE-4913](https://issues.redhat.com/browse/THREESCALE-4913)
-
+- Fixed issues when using fully qualified DNS query [PR #1235](https://github.com/3scale/APIcast/pull/1235) [THREESCALE-4752](https://issues.redhat.com/browse/THREESCALE-4752)
 
 
 ## [3.9.0] 2020-08-17

--- a/gateway/src/resty/resolver.lua
+++ b/gateway/src/resty/resolver.lua
@@ -3,6 +3,7 @@ local next = next
 local open = io.open
 local gmatch = string.gmatch
 local match = string.match
+local sub = string.sub
 local format = string.format
 local find = string.find
 local insert = table.insert
@@ -280,28 +281,44 @@ local function valid_answers(answers)
 end
 
 local function search_dns(self, qname, stale)
+
   local search = self.search
   local dns = self.dns
   local options = self.options
   local cache = self.cache
 
-  local answers, err
-
-  for i=1, #search do
-    local query = qname .. '.' .. search[i]
-    ngx.log(ngx.DEBUG, 'resolver query: ', qname, ' search: ', search[i], ' query: ', query)
-
+  local function get_answer(query)
+    local answers, err
     answers, err = cache:get(query, stale)
-    if valid_answers(answers) then break end
+    if valid_answers(answers) then
+      return answers, err
+    end
 
     answers, err = dns:query(query, options)
     if valid_answers(answers) then
       cache:save(answers)
-      break
+      return answers, err
+    end
+    return nil, err
+  end
+
+  if sub(qname, -1) == "." then
+    local query = sub(qname, 1 ,-2)
+    ngx.log(ngx.DEBUG, 'resolver query: ', qname, ' query: ', query)
+    return get_answer(query)
+  end
+
+  local answer, err
+  for i=1, #search do
+    local query = qname .. '.' .. search[i]
+    ngx.log(ngx.DEBUG, 'resolver query: ', qname, ' search: ', search[i], ' query: ', query)
+    answer, err = get_answer(query)
+    if answer then
+      return answer, err
     end
   end
 
-  return answers, err
+  return nil, err
 end
 
 local function resolve_upstream(qname)

--- a/spec/resty/resolver_spec.lua
+++ b/spec/resty/resolver_spec.lua
@@ -126,7 +126,31 @@ describe('resty.resolver', function()
   end)
 
   describe(':lookup', function()
-    pending('does query when cached cname missing address')
+    local  resolver
+
+    before_each(function()
+      local dns = {
+        query = spy.new(function(_, name)
+          return {
+            { name = name , address = '127.0.0.1' }
+          }
+        end)
+      }
+      resolver = resty_resolver.new(dns, { cache = resolver_cache.new(), search = {"foo.com"}})
+    end)
+
+    it("works when fully qualified name in private base_url", function()
+      local answer, err = resolver:lookup('test.service.ns.cluster.local.')
+      assert.same("test.service.ns.cluster.local", answer[1].name)
+      assert.same(err, nil)
+    end)
+
+    it("search domain is appended correctly", function()
+      local answer, err = resolver:lookup('test.service.ns.cluster.local')
+      assert.same("test.service.ns.cluster.local.foo.com", answer[1].name)
+      assert.same(err, nil)
+    end)
+
   end)
 
   describe('.parse_resolver', function()


### PR DESCRIPTION
When adding a dot to the end of the domain, the search string from
resolv.conf should not be added, because the domain is absolute.

Adding this, will save a few DNS request to the DNS server because no
cluster.local, etc.. will be added to the Qname.

More info in relation to this:
https://superuser.com/a/1468139

Fix THREESCALE-4752

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>