### PR TITLE
OIDC: Fix issues with filtering services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ to function correctly. [PR #1231](https://github.com/3scale/APIcast/pull/1231)
 - Fixed doc issue on SERVICES_FILTER parameter [PR #1233](https://github.com/3scale/APIcast/pull/1233) [THREESCALE-5421](https://issues.redhat.com/browse/THREESCALE-5421)
 - Non-alphanumeric metric name in 3scale-batcher policy [PR #1234](https://github.com/3scale/APIcast/pull/1234) [THREESCALE-4913](https://issues.redhat.com/browse/THREESCALE-4913)
 - Fixed issues when using fully qualified DNS query [PR #1235](https://github.com/3scale/APIcast/pull/1235) [THREESCALE-4752](https://issues.redhat.com/browse/THREESCALE-4752)
+- Fixed issues with OIDC validation [PR #1239](https://github.com/3scale/APIcast/pull/1239) [THREESCALE-6313](https://issues.redhat.com/browse/THREESCALE-6313)
+
 
 
 ## [3.9.0] 2020-08-17

--- a/gateway/src/apicast/configuration.lua
+++ b/gateway/src/apicast/configuration.lua
@@ -191,6 +191,8 @@ function _M.filter_oidc_config(services, oidc)
       if not oidc_config.service_id or services_ids[tostring(oidc_config.service_id)] then
         table.insert(oidc_final_config, oidc_config)
       end
+    else
+      table.insert(oidc_final_config, {})
     end
   end
   return oidc_final_config

--- a/spec/configuration_spec.lua
+++ b/spec/configuration_spec.lua
@@ -232,6 +232,21 @@ describe('Configuration object', function()
       })
     end)
 
+    it("Services without oidc_config data", function()
+      local oidc_config = {
+        false,
+        {service_id= 42, issuer="foo"},
+        {service_id= 21, issuer="bar"},
+
+      }
+      local res = filter_oidc_config(mockservices, oidc_config)
+      assert.same(res, {
+        {},
+        {service_id= 42, issuer="foo"},
+        {service_id= 21, issuer="bar"},
+      })
+    end)
+
   end)
 
   insulate('.services_limit', function()


### PR DESCRIPTION
When the OIDC config is false, an empty object is not added in the array, so
the services does not match, and OIDC validation failed.

FIX: THREESCALE-6313

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>