### PR TITLE
CLI: increase body size on template render.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ to function correctly. [PR #1231](https://github.com/3scale/APIcast/pull/1231)
 - Non-alphanumeric metric name in 3scale-batcher policy [PR #1234](https://github.com/3scale/APIcast/pull/1234) [THREESCALE-4913](https://issues.redhat.com/browse/THREESCALE-4913)
 - Fixed issues when using fully qualified DNS query [PR #1235](https://github.com/3scale/APIcast/pull/1235) [THREESCALE-4752](https://issues.redhat.com/browse/THREESCALE-4752)
 - Fixed issues with OIDC validation [PR #1239](https://github.com/3scale/APIcast/pull/1239) [THREESCALE-6313](https://issues.redhat.com/browse/THREESCALE-6313)
+- Fixed issues with Liquid body size [PR #1240](https://github.com/3scale/APIcast/pull/1240) [THREESCALE-6315](https://issues.redhat.com/browse/THREESCALE-6315)
+
 
 
 

--- a/gateway/src/apicast/cli/command/start.lua
+++ b/gateway/src/apicast/cli/command/start.lua
@@ -167,7 +167,6 @@ function mt:__call(options)
     update_env(env)
     -- also use env from the config file
     update_env(context.env or {})
-
     local nginx = nginx_config(context, template_path)
 
     local log_level = get_log_level(self, options)

--- a/gateway/src/apicast/cli/template.lua
+++ b/gateway/src/apicast/cli/template.lua
@@ -94,7 +94,10 @@ function _M:interpret(str)
     local context = self.context
     local filesystem = self.filesystem
     local filter_set = FilterSet:new()
-    local resource_limit = ResourceLimit:new(nil, 1000, nil)
+    -- The 1000000 limit, is to increase the body limits. This was triggered by
+    -- a issue THREESCALE-6315 where a lot of ENV variables are render in the
+    -- nginx.conf file.
+    local resource_limit = ResourceLimit:new(1000000, 1000, nil)
 
     local filesystem_cache = {}
 


### PR DESCRIPTION
A user reported that when a lot of services in K8s environment started
with apicast name, APICast cannot started because of the body size of
the template.

Because the body limit is set to nil, but liquid template set to 100000
[0] and started to fail in there.

The main reason to print all ENV variables on the nginx.conf, is because
the following code [1]

[0] https://github.com/3scale/liquid-lua/blob/a7f4119e96054f08df1fb8dce2be3469eb7ffb5f/lib/liquid.lua#L2675-L2686
[1] https://github.com/3scale/APIcast/blob/fba67b02200a4df231546145296927dea816c33f/gateway/http.d/init.conf#L46-L58

Fix THREESCALE-6315

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>