### PR TITLE
APICAST_SERVICES_FILTER_BY_URL fix when remote_v2 is in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ to function correctly. [PR #1231](https://github.com/3scale/APIcast/pull/1231)
 - Fixed issues when using fully qualified DNS query [PR #1235](https://github.com/3scale/APIcast/pull/1235) [THREESCALE-4752](https://issues.redhat.com/browse/THREESCALE-4752)
 - Fixed issues with OIDC validation [PR #1239](https://github.com/3scale/APIcast/pull/1239) [THREESCALE-6313](https://issues.redhat.com/browse/THREESCALE-6313)
 - Fixed issues with Liquid body size [PR #1240](https://github.com/3scale/APIcast/pull/1240) [THREESCALE-6315](https://issues.redhat.com/browse/THREESCALE-6315)
-
+- Fixed filter services with APICAST_SERVICES_FILTER_BY_URL when using remote v2 config [PR #1243](https://github.com/3scale/APIcast/pull/1243) [THREESCALE-6139](https://issues.redhat.com/browse/THREESCALE-6139)
 
 
 


### PR DESCRIPTION
When remote_v2 config is in use, the APICAST_SERVICES_FILTER_BY_URL
parameter was not in use. The main reason was because  the IDs are
filtered out, but the host is not available on api/services.json.

This is a issue when multiple services are in place, and all of them
request info to openid connect, where things are getting super slow, but
in this case, the request to
admin/api/services/${serice id}/proxy/configs/staging/latest.json need to be done
to be able to filter it out.

FIX THREESCALE-6139

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>