### PR TITLE
Policies: export get_uri method on context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed issues with URI when using Routing Policy [PR #1245](https://github.com/3scale/APIcast/pull/1245) [THREESCALE-6410](https://issues.redhat.com/browse/THREESCALE-6410)
+
 ### Added
 
 - Add HTTP codes policy [PR #1236](https://github.com/3scale/APIcast/pull/1236) [THREESCALE-6255](https://issues.redhat.com/browse/THREESCALE-6255)
@@ -53,7 +55,10 @@ to function correctly. [PR #1231](https://github.com/3scale/APIcast/pull/1231)
 - Non-alphanumeric metric name in 3scale-batcher policy [PR #1234](https://github.com/3scale/APIcast/pull/1234) [THREESCALE-4913](https://issues.redhat.com/browse/THREESCALE-4913)
 
 ## [3.9.1] 2020-10-13
-
+- Fixed issues when using fully qualified DNS query [PR #1235](https://github.com/3scale/APIcast/pull/1235) [THREESCALE-4752](https://issues.redhat.com/browse/THREESCALE-4752)
+- Fixed issues with OIDC validation [PR #1239](https://github.com/3scale/APIcast/pull/1239) [THREESCALE-6313](https://issues.redhat.com/browse/THREESCALE-6313)
+- Fixed issues with Liquid body size [PR #1240](https://github.com/3scale/APIcast/pull/1240) [THREESCALE-6315](https://issues.redhat.com/browse/THREESCALE-6315)
+- Fixed filter services with APICAST_SERVICES_FILTER_BY_URL when using remote v2 config [PR #1243](https://github.com/3scale/APIcast/pull/1243) [THREESCALE-6139](https://issues.redhat.com/browse/THREESCALE-6139)
 - Added a new metric when the `worker_process` starts [PR #1228](https://github.com/3scale/APIcast/pull/1228) [THREESCALE-5965](https://issues.redhat.com/browse/THREESCALE-5965)
 - Fixed issues when using fully qualified DNS query [PR #1235](https://github.com/3scale/APIcast/pull/1235) [THREESCALE-4752](https://issues.redhat.com/browse/THREESCALE-4752)
 

--- a/gateway/src/apicast/policy/jwt_claim_check/jwt_claim_check.lua
+++ b/gateway/src/apicast/policy/jwt_claim_check/jwt_claim_check.lua
@@ -57,7 +57,7 @@ end
 -- the methods, the methods that are not  defined in the rule will be allowed.
 local function is_rule_denied_request(rule, context)
 
-  local uri = ngx.var.uri
+  local uri = context:get_uri()
   local request_method =  ngx.req.get_method()
 
   local resource = rule.resource:render(context)

--- a/gateway/src/apicast/policy/load_configuration/load_configuration.lua
+++ b/gateway/src/apicast/policy/load_configuration/load_configuration.lua
@@ -14,10 +14,16 @@ function _M.new(...)
     return policy
 end
 
-function _M:export()
-    return {
-        configuration = self.configuration
-    }
+function _M:export(context)
+  return  {
+    get_uri = function(self)
+      if self.route_upstream then
+        return self.route_upstream.uri.path or "/"
+      end
+      return ngx.var.uri
+    end,
+    configuration = self.configuration
+  }
 end
 
 function _M.init()

--- a/spec/policy/jwt_claim_check/jwt_claim_check_spec.lua
+++ b/spec/policy/jwt_claim_check/jwt_claim_check_spec.lua
@@ -12,7 +12,10 @@ describe('JWT claim check policy', function()
       ooo = { 1,2},
       roles = { "one", "two"}
 
-    }
+    },
+    get_uri = function()
+      return ngx.var.uri
+    end
   }
 
   before_each(function()

--- a/spec/policy/load_configuration/load_configuration_spec.lua
+++ b/spec/policy/load_configuration/load_configuration_spec.lua
@@ -8,8 +8,7 @@ describe('load_configuration', function()
   describe('.export', function()
     it('returns a table with the configuration of the policy', function()
       local load_config_policy = require('apicast.policy.load_configuration').new()
-      assert.same({ configuration = load_config_policy.configuration },
-                  load_config_policy:export())
+      assert.same(load_config_policy.configuration , load_config_policy:export().configuration)
     end)
   end)
 

--- a/t/apicast-policy-jwt-claim-check.t
+++ b/t/apicast-policy-jwt-claim-check.t
@@ -445,3 +445,122 @@ GET /confidential
 yay, api backend
 --- no_error_log
 [error]
+
+
+=== TEST 7: JWT claim with routing policy uri change
+When using the routing policy, the set_uri is in use, and moved to /, so the
+the URI is not longer valid at all, and JWT is not expected to work correctly.
+--- backend
+  location /transactions/oauth_authrep.xml {
+    content_by_lua_block {
+      ngx.exit(200)
+    }
+  }
+
+--- configuration
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": { "id_token_signing_alg_values_supported": [ "RS256" ] },
+      "keys": { "somekid": { "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----" } }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT",
+                  "replace_path": "{{original_request.path }}-test",
+                  "condition": {
+                    "operations": [
+                      {
+                        "match": "liquid",
+                        "liquid_value": "/confidential",
+                        "op": "==",
+                        "value": "/confidential"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.jwt_claim_check",
+            "configuration": {
+              "rules" : [
+                {
+                  "operations": [
+                    {"op": "==", "jwt_claim": "{{foo}}", "jwt_claim_type": "liquid", "value": "test_foo", "value_type": "liquid"}
+                  ],
+                  "combine_op": "and",
+                  "methods": ["GET"],
+                  "resource": "/confidential"
+                },
+                {
+                  "operations": [
+                    {"op": "==", "jwt_claim": "{{foo}}", "jwt_claim_type": "liquid", "value": "INVALID", "value_type": "liquid"}
+                  ],
+                  "combine_op": "and",
+                  "methods": ["GET"],
+                  "resource": "/test.*"
+                }
+              ]
+            }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /confidential {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+
+  location /test {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+
+--- request eval
+["GET /confidential", "GET /test"]
+--- more_headers eval
+[
+::authorization_bearer_jwt('audience', {
+  foo => "test_foo",
+  bar => "foo",
+  roles => [ 'director', 'manager' ]
+}, 'somekid'),
+::authorization_bearer_jwt('audience', {
+  foo => "test_foo",
+  bar => "foo",
+  roles => [ 'director', 'manager' ]
+}, 'somekid')
+]
+--- error_code eval
+[200, 403]
+--- response_body eval
+["yay, api backend\n","Request blocked due to JWT claim policy\n"]
+--- no_error_log
+[error]


### PR DESCRIPTION
When using routing policy in APIAP, the path is always set to /. Becuase
routing policy is always the first, the jwt_claim_check started to fail,
because ngx.var.uri is always /.

This created a shared method, get_uri, and if routing policy was in use,
it'll use the new path.

FIX THREESCALE-6410

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>