### PR TITLE
Add Access-Control-Max-Age to cors policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add Access-Control-Max-Age [PR #1247](https://github.com/3scale/APIcast/pull/1247) [THREESCALE-6556](https://issues.redhat.com/browse/THREESCALE-6556)
 - Add HTTP codes policy [PR #1236](https://github.com/3scale/APIcast/pull/1236) [THREESCALE-6255](https://issues.redhat.com/browse/THREESCALE-6255)
 
 
@@ -41,6 +42,8 @@ Beta1 is stable and moved to final release.
 - Added new original_request_uri tag on Opentracing [PR #1223](https://github.com/3scale/APIcast/pull/1223) [THREESCALE-5669](https://issues.redhat.com/browse/THREESCALE-5669)
 - Caching policy disable default field [PR #1226](https://github.com/3scale/APIcast/pull/1226) [THREESCALE-1514](https://issues.redhat.com/browse/THREESCALE-1514)
 - Add response/request content size limits [PR #1227](https://github.com/3scale/APIcast/pull/1227) [THREESCALE-5244](https://issues.redhat.com/browse/THREESCALE-5244)
+- Add HTTP codes policy [PR #1236](https://github.com/3scale/APIcast/pull/1236) [THREESCALE-6255](https://issues.redhat.com/browse/THREESCALE-6255)
+
 
 ### Fixed
 - Fixed issues with allow caching mode  and 3scale batcher [PR #1216](https://github.com/3scale/APIcast/pull/1216) [THREESCALE-5753](https://issues.redhat.com/browse/THREESCALE-5753)

--- a/gateway/src/apicast/policy/cors/apicast-policy.json
+++ b/gateway/src/apicast/policy/cors/apicast-policy.json
@@ -52,6 +52,10 @@
       "allow_credentials": {
         "description": "Whether the request can be made using credentials",
         "type": "boolean"
+      },
+      "max_age": {
+        "description": "The ttl of the preflight response (default: 600)",
+        "type": "integer"
       }
     }
   }

--- a/gateway/src/apicast/policy/cors/cors.lua
+++ b/gateway/src/apicast/policy/cors/cors.lua
@@ -50,6 +50,12 @@ local function set_access_control_allow_credentials(allow_credentials)
   ngx.header['Access-Control-Allow-Credentials'] = value
 end
 
+local function set_access_control_max_age(max_age)
+  local value = max_age
+  if value == nil then value = 600 end
+  ngx.header['Access-Control-Max-Age'] = value
+end
+
 local function set_cors_headers(config)
   local origin = ngx.var.http_origin
   if not origin then return end
@@ -58,6 +64,7 @@ local function set_cors_headers(config)
   set_access_control_allow_methods(config.allow_methods)
   set_access_control_allow_origin(config.allow_origin, origin)
   set_access_control_allow_credentials(config.allow_credentials)
+  set_access_control_max_age(config.max_age)
 end
 
 local function cors_preflight_response()

--- a/spec/policy/cors/cors_spec.lua
+++ b/spec/policy/cors/cors_spec.lua
@@ -17,7 +17,7 @@ describe('CORS policy', function()
         }
       end)
 
-      it('exists with status code 204', function()
+      it('exits with status code 204', function()
         local cors = CORSPolicy.new()
         cors:rewrite()
         assert.spy(ngx_exit_spy).was_called_with(204)
@@ -55,6 +55,7 @@ describe('CORS policy', function()
           allow_headers = { 'Content-Type' },
           allow_methods = { 'GET', 'POST' },
           allow_origin = '*',
+          max_age = 200;
           allow_credentials = true
         }
         local cors = CORSPolicy.new(policy_config)
@@ -69,6 +70,8 @@ describe('CORS policy', function()
                       ngx.header['Access-Control-Allow-Origin'])
         assert.equals(policy_config.allow_credentials,
                       ngx.header['Access-Control-Allow-Credentials'])
+        assert.equals(policy_config.max_age,
+                      ngx.header['Access-Control-Max-Age'])
       end)
     end)
 
@@ -99,6 +102,8 @@ describe('CORS policy', function()
                     ngx.header['Access-Control-Allow-Methods'])
         assert.equals(req_http_origin,
                       ngx.header['Access-Control-Allow-Origin'])
+        assert.equals(600,
+                      ngx.header['Access-Control-Max-Age'])
         assert.is_true(ngx.header['Access-Control-Allow-Credentials'])
       end)
     end)

--- a/t/apicast-policy-cors.t
+++ b/t/apicast-policy-cors.t
@@ -39,6 +39,7 @@ Access-Control-Request-Method: GET
 --- response_headers
 Access-Control-Allow-Methods: GET
 Access-Control-Allow-Origin: localhost
+Access-Control-Max-Age: 600
 --- no_error_log
 [error]
 
@@ -96,6 +97,7 @@ Access-Control-Allow-Headers: Content-Type
 Access-Control-Allow-Methods: GET
 Access-Control-Allow-Origin: http://example.com
 Access-Control-Allow-Credentials: true
+Access-Control-Max-Age: 600
 --- error_code: 200
 --- no_error_log
 [error]
@@ -117,6 +119,7 @@ the CORS headers in the response.
             "configuration": { "allow_headers": [ "X-Custom-Header-1", "X-Custom-Header-2" ],
                                "allow_methods": [ "POST", "GET", "OPTIONS" ],
                                "allow_origin" : "*",
+                               "max_age" : 200,
                                "allow_credentials": false } },
           { "name": "apicast.policy.apicast" }
         ],
@@ -152,6 +155,7 @@ Access-Control-Allow-Headers: X-Custom-Header-1, X-Custom-Header-2
 Access-Control-Allow-Methods: POST, GET, OPTIONS
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Credentials: false
+Access-Control-Max-Age: 200
 --- error_code: 200
 --- no_error_log
 [error]


### PR DESCRIPTION
As per the [issue 1246](https://github.com/3scale/APIcast/issues/1246) this PR add Access-Control-Max-Age parameter to the CORS Policy