### PR TITLE
Add APICAST_ACCESS_LOG_BUFFER option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add Access-Control-Max-Age [PR #1247](https://github.com/3scale/APIcast/pull/1247) [THREESCALE-6556](https://issues.redhat.com/browse/THREESCALE-6556)
 - Add HTTP codes policy [PR #1236](https://github.com/3scale/APIcast/pull/1236) [THREESCALE-6255](https://issues.redhat.com/browse/THREESCALE-6255)
-
+- Buffer access log on chunks [PR #1248](https://github.com/3scale/APIcast/pull/1248) [THREESCALE-6563](https://issues.redhat.com/browse/THREESCALE-6563)
 
 ## [3.10.0] 2021-01-04
 
@@ -43,6 +43,7 @@ Beta1 is stable and moved to final release.
 - Caching policy disable default field [PR #1226](https://github.com/3scale/APIcast/pull/1226) [THREESCALE-1514](https://issues.redhat.com/browse/THREESCALE-1514)
 - Add response/request content size limits [PR #1227](https://github.com/3scale/APIcast/pull/1227) [THREESCALE-5244](https://issues.redhat.com/browse/THREESCALE-5244)
 - Add HTTP codes policy [PR #1236](https://github.com/3scale/APIcast/pull/1236) [THREESCALE-6255](https://issues.redhat.com/browse/THREESCALE-6255)
+
 
 
 ### Fixed

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -105,6 +105,15 @@ Specifies the log level for the OpenResty logs.
 Defines the file that will store the access logs.
 
 
+### APICAST_ACCESS_LOG_BUFFER
+
+**Values:** integer
+**Default**: nil
+
+Allows access log writes to be writes in chunks on bytes, so less system calls
+that improves the performance of the whole gateway.
+
+
 ### `APICAST_OIDC_LOG_LEVEL`
 
 **Values:** debug | info | notice | warn | error | crit | alert | emerg  

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -110,8 +110,8 @@ Defines the file that will store the access logs.
 **Values:** integer
 **Default**: nil
 
-Allows access log writes to be writes in chunks on bytes, so less system calls
-that improves the performance of the whole gateway.
+Allows access log writes to be included in chunks of bytes, resulting on fewer system calls
+that improve the performance of the whole gateway.
 
 
 ### `APICAST_OIDC_LOG_LEVEL`

--- a/gateway/config/production.lua
+++ b/gateway/config/production.lua
@@ -5,4 +5,5 @@ return {
     configuration_cache = os.getenv('APICAST_CONFIGURATION_CACHE') or 5*60,
     timer_resolution = '100ms',
     port = { metrics = 9421 },
+    log_buffer_size = os.getenv("APICAST_ACCESS_LOG_BUFFER") or nil
 }

--- a/gateway/http.d/apicast.conf.liquid
+++ b/gateway/http.d/apicast.conf.liquid
@@ -48,11 +48,12 @@ server {
 }
 
 server {
+  {% capture log_buffer %} {%if log_buffer_size %}buffer={{ log_buffer_size }} {% endif %} {% endcapture %}
 
   set $access_logs_enabled '1';
-  access_log {{ access_log_file | default: "/dev/stdout" }} time if=$access_logs_enabled;
+  access_log {{ access_log_file | default: "/dev/stdout" }} time if=$access_logs_enabled {{ log_buffer }};
   set $extended_access_logs_enabled '0';
-  access_log {{ access_log_file | default: "/dev/stdout" }} extended if=$extended_access_logs_enabled;
+  access_log {{ access_log_file | default: "/dev/stdout" }} extended if=$extended_access_logs_enabled {{ log_buffer }};
 
   {%- assign http_port = port.apicast | default: 8080 %}
   {%- assign https_port = env.APICAST_HTTPS_PORT %}

--- a/t/apicast-policy-logging.t
+++ b/t/apicast-policy-logging.t
@@ -587,7 +587,7 @@ OK
 [error]
 
 === TEST 14: APICAST_ACCESS_LOG_BUFFER env parameter
-When buffer is enabled, log will be bump in chunks
+When buffer is enabled, log will be bumped in chunks
 --- env eval
 ('APICAST_ACCESS_LOG_BUFFER' => '1k')
 --- configuration


### PR DESCRIPTION
This commit add a new way to write access log, based on chunks, so
access log writes only happens when a buffer is full and this improves the
performance by reducing the number of system calls.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>