### PR TITLE
CORS: Enable multiple Origins value based on regexp.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Buffer access log on chunks [PR #1248](https://github.com/3scale/APIcast/pull/1248) [THREESCALE-6563](https://issues.redhat.com/browse/THREESCALE-6563)
 - Added sendfile_max_chunk to the worker [PR #1250](https://github.com/3scale/APIcast/pull/1250) [THREESCALE-6570](https://issues.redhat.com/browse/THREESCALE-6570)
 - Increased api-keys shared memory size [PR #1250](https://github.com/3scale/APIcast/pull/1250) [THREESCALE-6570](https://issues.redhat.com/browse/THREESCALE-6570)
+- Add support to multiple Origin based on regexp [PR #1251](https://github.com/3scale/APIcast/pull/1251) [THREESCALE-6569](https://issues.redhat.com/browse/THREESCALE-6569)
+
 
 
 ## [3.10.0] 2021-01-04

--- a/gateway/src/apicast/policy/cors/apicast-policy.json
+++ b/gateway/src/apicast/policy/cors/apicast-policy.json
@@ -46,7 +46,7 @@
         }
       },
       "allow_origin": {
-        "description": "Origin allowed for CORS requests. The field expects only one origin (e.g. https://example.com) or '*'. If left blank, the value of the 'Origin' request header will be used.",
+        "description": "Origin allowed for CORS requests. The field expects only one origin (e.g. 'https://example.com') or '*'. If left blank, the value of the 'Origin' request header will be used. In order to allow more than one origin it is possible to use a regular expression, if it matches with Origin header value, the value will be set to the Origin Value. In case it does not match, the header will not set at all. Example: '(api|web).test.com' wil match both 'api.test.com' and 'web.test.com'.",
         "type": "string"
       },
       "allow_credentials": {

--- a/gateway/src/apicast/policy/cors/cors.lua
+++ b/gateway/src/apicast/policy/cors/cors.lua
@@ -18,6 +18,9 @@ local _M = policy.new('CORS Policy', 'builtin')
 
 local new = _M.new
 
+local url_helper = require('resty.url_helper')
+local re_match = ngx.re.match
+
 --- Initialize a CORS policy
 -- @tparam[opt] table config
 -- @field[opt] allow_headers Table with the allowed headers (e.g. Content-Type)
@@ -25,8 +28,19 @@ local new = _M.new
 -- @field[opt] allow_origin Allowed origins (e.g. 'http://example.com', '*')
 -- @field[opt] allow_credentials Boolean
 function _M.new(config)
-  local self = new(config)
-  self.config = config or {}
+  local  cfg = config or {}
+  local self = new(cfg)
+  self.allow_origin_is_regexp = false
+
+  local _, err = url_helper.parse_url(cfg.allow_origin or "")
+  if err then
+    if cfg.allow_origin ~= "*" and cfg.allow_origin then
+      self.allow_origin_is_regexp = true
+    end
+
+  end
+
+  self.config = cfg
   return self
 end
 
@@ -40,8 +54,22 @@ local function set_access_control_allow_methods(allow_methods)
   ngx.header['Access-Control-Allow-Methods'] = value
 end
 
-local function set_access_control_allow_origin(allow_origin, default)
-  ngx.header['Access-Control-Allow-Origin'] = allow_origin or default
+local function set_access_control_allow_origin(self, allow_origin, default)
+  if not self.allow_origin_is_regexp then
+    ngx.header['Access-Control-Allow-Origin'] = allow_origin or default
+    return
+  end
+
+  local m = re_match(default, allow_origin)
+  if m then
+    ngx.header['Access-Control-Allow-Origin'] = default
+    return
+  end
+
+  -- There is a reason to not set the default Origin here, because the user
+  -- only want to send the origin if match, so no reason to add the default.
+  -- Furthermore can be a secrity issue.
+  ngx.log(ngx.DEBUG, "Default Origin header did not match, skip Access-Control-Allow-Origin header")
 end
 
 local function set_access_control_allow_credentials(allow_credentials)
@@ -56,13 +84,13 @@ local function set_access_control_max_age(max_age)
   ngx.header['Access-Control-Max-Age'] = value
 end
 
-local function set_cors_headers(config)
+local function set_cors_headers(self, config)
   local origin = ngx.var.http_origin
   if not origin then return end
 
   set_access_control_allow_headers(config.allow_headers)
   set_access_control_allow_methods(config.allow_methods)
-  set_access_control_allow_origin(config.allow_origin, origin)
+  set_access_control_allow_origin(self, config.allow_origin, origin)
   set_access_control_allow_credentials(config.allow_credentials)
   set_access_control_max_age(config.max_age)
 end
@@ -86,7 +114,7 @@ function _M.rewrite(_)
 end
 
 function _M:header_filter()
-  set_cors_headers(self.config)
+  set_cors_headers(self, self.config)
 end
 
 return _M


### PR DESCRIPTION
This will check if the allow_origins is a valid regexp, and if it is,
will match with the Origin header value, it'll set the
Access-Control-Allow-Origin header to the Origin value.

Examples:
```
Config             | Origin Request Header Value  | Access-Control-Allow-Origin header
(api|web).test.com | http://web.test.com          | http://web.test.com
(api|web).test.com | http://api.test.com          | http://api.test.com
(api|web).test.com | http://staging.test.com      | Not header set
http://test.com    | http://api.test.com          | http://test.com
*                  | http://api.test.com          | *
blank              | http://api.test.com          | http://api.test.com
```

Fix: THREESCALE-6569

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>