### PR TITLE
adds method matching check to rewrite url captures policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add methods to transformations in rewrite url captures policy [PR #1253](https://github.com/3scale/APIcast/pull/1253) [THREESCALE-6270](https://issues.redhat.com/browse/THREESCALE-6270)
 - Add Access-Control-Max-Age [PR #1247](https://github.com/3scale/APIcast/pull/1247) [THREESCALE-6556](https://issues.redhat.com/browse/THREESCALE-6556)
 - Add HTTP codes policy [PR #1236](https://github.com/3scale/APIcast/pull/1236) [THREESCALE-6255](https://issues.redhat.com/browse/THREESCALE-6255)
 - Buffer access log on chunks [PR #1248](https://github.com/3scale/APIcast/pull/1248) [THREESCALE-6563](https://issues.redhat.com/browse/THREESCALE-6563)

--- a/gateway/src/apicast/policy/rewrite_url_captures/apicast-policy.json
+++ b/gateway/src/apicast/policy/rewrite_url_captures/apicast-policy.json
@@ -11,6 +11,59 @@
      "'/123/456' will be transformed into '/sales/v2/123?account=456'"],
   "version": "builtin",
   "configuration": {
+    "definitions": {
+      "methods": {
+        "description": "Array of HTTP methods this rule must be applied to. If left blank it will be applied to all HTTP methods",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "oneOf": [
+            {
+              "enum": [
+                "GET"
+              ],
+              "title": "GET"
+            },
+            {
+              "enum": [
+                "POST"
+              ],
+              "title": "POST"
+            },
+            {
+              "enum": [
+                "PUT"
+              ],
+              "title": "PUT"
+            },
+            {
+              "enum": [
+                "PATCH"
+              ],
+              "title": "PATCH"
+            },
+            {
+              "enum": [
+                "DELETE"
+              ],
+              "title": "DELETE"
+            },
+            {
+              "enum": [
+                "HEAD"
+              ],
+              "title": "HEAD"
+            },
+            {
+              "enum": [
+                "OPTIONS"
+              ],
+              "title": "OPTIONS"
+            }
+          ]
+        }
+      }
+    },
     "type": "object",
     "properties": {
       "transformations": {
@@ -25,6 +78,9 @@
             "template": {
               "type": "string",
               "description": "Template in which the matched args are replaced"
+            },
+            "methods": {
+              "$ref": "#/definitions/methods"
             }
           }
         }

--- a/gateway/src/apicast/policy/rewrite_url_captures/named_args_matcher.lua
+++ b/gateway/src/apicast/policy/rewrite_url_captures/named_args_matcher.lua
@@ -114,11 +114,11 @@ end
 -- Returns true if no Method is provided in the config for backwardscompatibility
 local function is_match_methods(methods)
 
-  local request_method = ngx.req.get_method()
-
   if methods == nil or next(methods) == nil  then
     return true
   end
+
+  local request_method = ngx.req.get_method()
 
   for _,v in pairs(methods) do
     if v == request_method then

--- a/gateway/src/apicast/policy/rewrite_url_captures/rewrite_url_captures.lua
+++ b/gateway/src/apicast/policy/rewrite_url_captures/rewrite_url_captures.lua
@@ -27,7 +27,8 @@ function _M.new(config)
   for _, transformation in ipairs(config.transformations or {}) do
     local matcher = NamedArgsMatcher.new(
       transformation.match_rule,
-      transformation.template
+      transformation.template,
+      transformation.methods
     )
 
     insert(self.matchers, matcher)

--- a/spec/policy/rewrite_url_captures/rewrite_url_captures_spec.lua
+++ b/spec/policy/rewrite_url_captures/rewrite_url_captures_spec.lua
@@ -11,19 +11,27 @@ describe('Capture args policy', function()
     before_each(function()
       query_params = { set = stub.new() }
       stub(QueryParams, 'new').returns(query_params)
-
+      stub(ngx.req, 'get_method', function() return 'GET' end)
       set_uri_stub = stub(ngx.req, 'set_uri')
 
       ngx.var = { uri = '/abc/def' }
 
       matching_transformation = {
         match_rule = '/{var_1}/{var_2}',
-        template = '/{var_2}?my_arg={var_1}'
+        template = '/{var_2}?my_arg={var_1}',
+        methods = {'GET'}
       }
 
       non_matching_transformation = {
         match_rule = '/i_dont_match/{var_1}/{var_2}',
-        template = '/{var_2}?my_arg={var_1}'
+        template = '/{var_2}?my_arg={var_1}',
+        methods = {'GET'}
+      }
+
+      matching_transformation_no_method = {
+        match_rule = '/{var1}/{var2}',
+        template = '/{var2}?my_arg={var1}',
+        methods = {}
       }
     end)
 
@@ -33,7 +41,44 @@ describe('Capture args policy', function()
           non_matching_transformation,
           matching_transformation
         }
+        local rewrite_url_captures = RewriteUrlCapturesPolicy.new(
+          { transformations = transformations }
+        )
 
+        rewrite_url_captures:rewrite()
+
+        assert.stub(set_uri_stub).was_called_with('/def')
+        assert.stub(query_params.set).was_called_with(
+          query_params, 'my_arg', 'abc')
+      end)
+    end)
+
+    describe('when there is a match but method does not match', function()
+      it('does not modifiy the path nor the params', function()
+        local transformations = {
+          non_matching_transformation,
+          matching_transformation
+        }
+        ngx.req.get_method:revert()
+        stub(ngx.req, 'get_method', function() return 'PUT' end)
+        local rewrite_url_captures = RewriteUrlCapturesPolicy.new(
+          { transformations = transformations }
+        )
+
+        rewrite_url_captures:rewrite()
+
+        assert.stub(set_uri_stub).was_not_called()
+        assert.stub(query_params.set).was_not_called()
+      end)
+    end)
+
+    describe('when there is a match but no method is defined', function()
+      it('modifies the path and the params', function()
+        local transformations = {
+          non_matching_transformation,
+          matching_transformation,
+          matching_transformation_no_method
+        }
         local rewrite_url_captures = RewriteUrlCapturesPolicy.new(
           { transformations = transformations }
         )
@@ -52,7 +97,8 @@ describe('Capture args policy', function()
           match_rule = '/{var_1}/{var_2}',
 
           -- Swap var_1 and var_2 in the original one.
-          template = '/{var_1}?my_arg={var_2}'
+          template = '/{var_1}?my_arg={var_2}',
+          methods = {'POST'}
         }
 
         local transformations = {

--- a/t/apicast-policy-rewrite-url-captures.t
+++ b/t/apicast-policy-rewrite-url-captures.t
@@ -233,3 +233,51 @@ yay, api backend
 --- error_code: 200
 --- no_error_log
 [error]
+
+=== TEST 5: one transformation with method that doesn't match
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "rewrite_url_captures",
+            "configuration": {
+              "transformations": [
+                {
+                  "match_rule": "/{var_1}/{var_2}",
+                  "template": "/{var_2}?my_arg={var_1}",
+                  "methods": ["PUT", "OPTIONS"]
+                }
+              ]
+            }
+          },
+          {
+            "name": "upstream",
+            "configuration": {
+              "rules": [
+                {
+                  "regex": "/",
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /abc/def {
+     content_by_lua_block {
+       ngx.exit(404)
+     }
+  }
+--- request
+GET /abc/def?user_key=xyz
+--- error_code: 404
+--- no_error_log
+[error]


### PR DESCRIPTION
Adds a list of methods to the transformation. Checks the request method against the method configured in the policy just as it is done in the URL rewrite policy.

Fixes: THREESCALE-6270