### PR TITLE
Add /etc/hosts support (e.g. for k8s hostAliases)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added sendfile_max_chunk to the worker [PR #1250](https://github.com/3scale/APIcast/pull/1250) [THREESCALE-6570](https://issues.redhat.com/browse/THREESCALE-6570)
 - Increased api-keys shared memory size [PR #1250](https://github.com/3scale/APIcast/pull/1250) [THREESCALE-6570](https://issues.redhat.com/browse/THREESCALE-6570)
 - Add support to multiple Origin based on regexp [PR #1251](https://github.com/3scale/APIcast/pull/1251) [THREESCALE-6569](https://issues.redhat.com/browse/THREESCALE-6569)
+- Added Support for /etc/hosts [PR #1258](https://github.com/3scale/APIcast/pull/1258)
 
 
 


### PR DESCRIPTION
WHY:

If you are trying to set alternative resolutions for ip's via /etc/hosts, they are ignored because the resolver.lua does not respect the /etc/hosts file. 

Thus if you are using k8s hostAliases annotation to rewrite an external domain to an internal ip, it will not resolve those.

WHAT:

This patch adds a hosts_map generated from /etc/hosts at startup and will answer the dns lookup's to those directly without querying the nameservers at all.