### PR TITLE
Caching: Fix race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed Status code overwrite policy jsonschema [PR #1296](https://github.com/3scale/APIcast/pull/1296) [THREESCALE-6415](https://issues.redhat.com/browse/THREESCALE-6415)
 - Fixed URL encoding on set-path [PR #1297](https://github.com/3scale/APIcast/pull/1297) [THREESCALE-5117](https://issues.redhat.com/browse/THREESCALE-5117)
 - Fixed trailing slash on routing policy [PR #1298](https://github.com/3scale/APIcast/pull/1298) [THREESCALE-7146](https://issues.redhat.com/browse/THREESCALE-7146)
+- Fixed race condition on caching mode [PR #1259](https://github.com/3scale/APIcast/pull/1259) [THREESCALE-4464](https://issues.redhat.com/browse/THREESCALE-4464)
 
 
 ### Added

--- a/gateway/src/apicast/policy/caching/caching.lua
+++ b/gateway/src/apicast/policy/caching/caching.lua
@@ -101,17 +101,26 @@ local function handler(config)
   return res
 end
 
+local function is_disabled(config)
+  return config.caching_type and config.caching_type == "none"
+end
+
 --- Initialize a Caching policy.
 -- @tparam[opt] table config
 -- @field caching_type Caching type (strict, resilient, allow, none)
 function _M.new(config)
   local self = new(config)
   self.cache_handler = handler(config or {})
+  self.is_disabled = is_disabled(config or {})
   return self
 end
 
+
 function _M:export()
-  return { cache_handler = self.cache_handler }
+  return {
+    cache_handler = self.cache_handler,
+    cache_is_disabled = self.is_disabled
+  }
 end
 
 return _M

--- a/gateway/src/apicast/proxy.lua
+++ b/gateway/src/apicast/proxy.lua
@@ -129,7 +129,7 @@ function _M:authorize(context, service, usage, credentials, ttl)
   local cache = self.cache
   local is_known = cache:get(cached_key)
 
-  if is_known == 200 then
+  if is_known == 200 and context.cache_is_disabled ~= true then
     ngx.log(ngx.DEBUG, 'apicast cache hit key: ', cached_key)
     ngx.var.cached_key = cached_key
   else


### PR DESCRIPTION
When caching is disabled with none, the cache key can be in there, and a
race condition can be happend with this.

To test this:

1) Strict caching mode
2) Made a request, 200 OK cache.set("$KEY", 200)
3) Update config to none
4) apicast/proxy:authorize -> cache.get($KEY) is 200
5) request go to the API
6) Authrep, cache for $KEY is deleted.

Next request will return 403.

Fixed behaviour:

1) Strict caching mode
2) Made a request, 200 OK cache.set("$KEY", 200)
3) Update config to none
4) apicast/proxy:authorize -> cache.get($KEY) is 200
5) cache_is_disabled = true -> execute backend call.
5) request go to the API, and fails
6) Authrep, cache for $KEY is deleted.

Fix THREESCALE-4464

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>