### PR TITLE
THREESCALE-6723 fix hostname_rewrite incompatible with routing policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed hostname_rewrite incompatibility with Routing Policy [PR #1263](https://github.com/3scale/APIcast/pull/1263) [THREESCALE-6723](https://issues.redhat.com/browse/THREESCALE-6723)
 - Fixed issues with URI when using Routing Policy [PR #1245](https://github.com/3scale/APIcast/pull/1245) [THREESCALE-6410](https://issues.redhat.com/browse/THREESCALE-6410)
 - Fixed typo on TLS jsonschema [PR #1260](https://github.com/3scale/APIcast/pull/1260) [THREESCALE-6390](https://issues.redhat.com/browse/THREESCALE-6390)
 

--- a/gateway/src/apicast/policy/routing/upstream_selector.lua
+++ b/gateway/src/apicast/policy/routing/upstream_selector.lua
@@ -21,6 +21,8 @@ end
 function _M.select(_, rules, context)
   if not rules then return nil end
 
+  local service = context.service or ngx.ctx.service or {}
+
   for _, rule in ipairs(rules) do
     local cond_is_true = rule.condition:evaluate(context)
 
@@ -29,8 +31,9 @@ function _M.select(_, rules, context)
 
       local upstream = Upstream.new(rule.url)
 
-      if rule.host_header and rule.host_header ~= '' then
-        upstream:use_host_header(rule.host_header)
+      local host_header = rule.host_header or service and service.hostname_rewrite
+      if host_header and host_header ~= '' then
+        upstream:use_host_header(host_header)
       end
 
       if rule.owner_id then

--- a/spec/policy/routing/upstream_selector_spec.lua
+++ b/spec/policy/routing/upstream_selector_spec.lua
@@ -191,5 +191,38 @@ describe('UpstreamSelector', function()
         assert.spy(apicast_upstream.append_path).was.called_with(upstream, "bar")
       end)
     end)
+
+    describe('when hostname_rewrite is set ', function()
+      describe('and a rule that matches has a value in host_header', function()
+        it('sets the value of host_header for the host header', function()
+          ctx = { service = { hostname_rewrite = "hostname_rewrite_value" } }
+          local rule = {
+            url = 'http://example.com',
+            condition = true_condition,
+            host_header = 'some_host.com'
+          }
+
+          local upstream_selector = UpstreamSelector.new()
+          local upstream = upstream_selector:select({ rule }, ctx)
+
+          assert.equals(rule.host_header, upstream.host)
+        end)
+      end)
+      describe('and a rule that matches does not have a value in host_header', function()
+        it('sets the value of hostname_rewrite for the host header', function()
+          local hostname_rewrite_value = "hostname_rewrite_value"
+          ctx = { service = { hostname_rewrite = hostname_rewrite_value } }
+          local rule = {
+            url = 'http://example.com',
+            condition = true_condition
+          }
+
+          local upstream_selector = UpstreamSelector.new()
+          local upstream = upstream_selector:select({ rule }, ctx)
+
+          assert.equals(hostname_rewrite_value, upstream.host)
+        end)
+      end)
+    end)
   end)
 end)


### PR DESCRIPTION
This makes hostname_rewrite work even when the routing policy is in the policy chain.