### PR TITLE
http-ng: fix HOST header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed issues with URI when using Routing Policy [PR #1245](https://github.com/3scale/APIcast/pull/1245) [THREESCALE-6410](https://issues.redhat.com/browse/THREESCALE-6410)
 - Fixed typo on TLS jsonschema [PR #1260](https://github.com/3scale/APIcast/pull/1260) [THREESCALE-6390](https://issues.redhat.com/browse/THREESCALE-6390)
+- Fixed host header format on http_ng resty [PR #1264](https://github.com/3scale/APIcast/pull/1264) [THREESCALE-2235](https://issues.redhat.com/browse/THREESCALE-2235)
 
 
 ### Added

--- a/gateway/src/resty/http_ng/request.lua
+++ b/gateway/src/resty/http_ng/request.lua
@@ -2,6 +2,9 @@ local find = string.find
 local sub = string.sub
 local assert = assert
 local setmetatable = setmetatable
+local resty_url = require 'resty.url'
+local format = string.format
+
 
 ------------
 -- @module middleware
@@ -20,13 +23,20 @@ local request = { }
 
 request.headers = require 'resty.http_ng.headers'
 
+local function host_header(uri)
+    local port = uri.port
+    local default_port = resty_url.default_port(uri.scheme)
+
+    if port and port ~= default_port then
+        return format('%s:%s', uri.host, port)
+    else
+        return uri.host
+    end
+end
+
 local function extract_host(url)
-  local _, last = find(url, '://', 0, true)
-  local len = find(url, '/', last + 1, true)
-
-  if len then len = len - 1 end
-
-  return sub(url, last + 1, len)
+  local uri = resty_url.parse(url)
+  return host_header(uri or {})
 end
 
 function request.extract_headers(req)

--- a/spec/resty/http_ng/request_spec.lua
+++ b/spec/resty/http_ng/request_spec.lua
@@ -29,6 +29,23 @@ describe('request', function()
     assert.equal('example.com',req.headers.Host)
   end)
 
+  it('correct host heder format', function()
+    results = {
+      ['http://foo.com'] = "foo.com",
+      ['http://foo.com:80'] = "foo.com",
+      ['http://foo.com:80/test'] = "foo.com",
+      ['http://foo.com:8080/test'] = "foo.com:8080",
+      ['https://foo.com/'] = "foo.com",
+      ['https://foo.com:8043/'] = "foo.com:8043",
+      ['https://foo.com:8043/test'] = "foo.com:8043",
+    }
+    for key, val in pairs(results) do
+      local req = request.new{url = key, method = 'GET' }
+      assert.equal(val, req.headers.Host)
+    end
+
+  end)
+
   it('has version', function()
     local req = request.new{url = 'http://example.com/path', method = 'GET' }
 


### PR DESCRIPTION
This strips the default port and use the correct host header value when
using http-ng

```
URL                          Host Header
--------------------------------------------------------------
http://foo.com               foo.com
http://foo.com:80            foo.com
http://foo.com:80/test       foo.com
http://foo.com:8080/test     foo.com:8080
https://foo.com/             foo.com
https://foo.com:8043/        foo.com:8043
https://foo.com:8043/test    foo.com:8043
```

Fix THREESCALE-2235
Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>