### PR TITLE
BPFTrace: Add initial trace scripts

### DIFF
--- a/docker-compose-devel-volmount-default.yml
+++ b/docker-compose-devel-volmount-default.yml
@@ -1,7 +1,10 @@
 version: '2.2'
 services:
   development:
+    privileged: true
+    pid: "host"
     volumes:
       - .:/home/centos/
       - .docker/cpanm:/home/centos/.cpanm
-
+      - /sys/kernel/debug:/sys/kernel/debug
+      - /lib/modules:/lib/module

--- a/script/traces/Readme.md
+++ b/script/traces/Readme.md
@@ -1,0 +1,23 @@
+# Trace scripts
+
+A few trace scripts to run bpftrace tool in the container and be able to debug
+how Nginx behave
+
+## Install
+
+```shell
+docker exec -ti --user root --privileged apicast_build_0_development_1 dnf install -y bpftrace
+```
+
+Recommended to install debuginfo packages to get better ustack
+
+```
+docker exec -ti --user root --privileged apicast_build_0_development_1 dnf install -y openresty-debuginfo
+```
+
+
+## Run
+
+```shell
+docker exec -ti --user root --privileged apicast_build_0_development_1 bpftrace leaked.bt -p ${OPENRESTY_WORKER_PID}
+```

--- a/script/traces/leaked.st
+++ b/script/traces/leaked.st
@@ -1,0 +1,16 @@
+BEGIN {
+  printf("Probe started\n");
+}
+
+uretprobe:/usr/local/openresty/nginx/sbin/nginx:ngx_create_pool {
+  @pools[retval] = ustack ;
+}
+
+uprobe:/usr/local/openresty/nginx/sbin/nginx:ngx_destroy_pool {
+  delete(@pools[arg0]);
+}
+
+interval:s:60 {
+  printf("--------------\n");
+  print(@pools);
+}


### PR DESCRIPTION
BPFtrace is a great tool to debug how APICast behave, this commit add
a few scripts that will help debugging weird behaviours.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>