### PR TITLE
Policy: Payload limits fix on content-length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed typo on TLS jsonschema [PR #1260](https://github.com/3scale/APIcast/pull/1260) [THREESCALE-6390](https://issues.redhat.com/browse/THREESCALE-6390)
 - Fixed host header format on http_ng resty [PR #1264](https://github.com/3scale/APIcast/pull/1264) [THREESCALE-2235](https://issues.redhat.com/browse/THREESCALE-2235)
 - Fixed issues on OIDC jwk discovery [PR #1268](https://github.com/3scale/APIcast/pull/1268) [THREESCALE-6913](https://issues.redhat.com/browse/THREESCALE-6913)
+- Fixed Payload limit content-length response header [PR #1266](https://github.com/3scale/APIcast/pull/1266) [THREESCALE-6736](https://issues.redhat.com/browse/THREESCALE-6736)
 
 
 ### Added

--- a/t/apicast-policy-payload_limits.t
+++ b/t/apicast-policy-payload_limits.t
@@ -236,6 +236,8 @@ yay, api backend
 --- request
 POST /test
 --- error_code: 413
+--- response_headers
+Content-Length: 17
 --- response_body eval
 "Payload Too Large"
 --- no_error_log


### PR DESCRIPTION
When content length was bigger than the limit, the content length
value was not changed at all, and clients keep reading until got the
full length.

Fix https://issues.redhat.com/browse/THREESCALE-6736

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>