### PR TITLE
OIDC: Fix discovery content-type issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issues with URI when using Routing Policy [PR #1245](https://github.com/3scale/APIcast/pull/1245) [THREESCALE-6410](https://issues.redhat.com/browse/THREESCALE-6410)
 - Fixed typo on TLS jsonschema [PR #1260](https://github.com/3scale/APIcast/pull/1260) [THREESCALE-6390](https://issues.redhat.com/browse/THREESCALE-6390)
 - Fixed host header format on http_ng resty [PR #1264](https://github.com/3scale/APIcast/pull/1264) [THREESCALE-2235](https://issues.redhat.com/browse/THREESCALE-2235)
+- Fixed issues on OIDC jwk discovery [PR #1268](https://github.com/3scale/APIcast/pull/1268) [THREESCALE-6913](https://issues.redhat.com/browse/THREESCALE-6913)
 
 
 ### Added


### PR DESCRIPTION
When JWK response was not application/json content_type, the keys cannot
be parsed and OIDC flow failed.

With this fix, if the application is returning `jwk-set+json`, something
valid that was not parsed as we should.[0]

[0] https://tools.ietf.org/html/rfc7517#section-8.5.1

Fix: THREESCALE-6913

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>