### PR TITLE
Policy: Add GC policy for shared dicts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added sendfile_max_chunk to the worker [PR #1250](https://github.com/3scale/APIcast/pull/1250) [THREESCALE-6570](https://issues.redhat.com/browse/THREESCALE-6570)
 - Increased api-keys shared memory size [PR #1250](https://github.com/3scale/APIcast/pull/1250) [THREESCALE-6570](https://issues.redhat.com/browse/THREESCALE-6570)
 - Add support to multiple Origin based on regexp [PR #1251](https://github.com/3scale/APIcast/pull/1251) [THREESCALE-6569](https://issues.redhat.com/browse/THREESCALE-6569)
-
+- Garbage collector policy for shared dicts [PR #1269](https://github.com/3scale/APIcast/pull/1269) [THREESCALE-6718](https://issues.redhat.com/browse/THREESCALE-6718)
 
 
 ## [3.10.0] 2021-01-04

--- a/gateway/src/apicast/policy/gc/gc.lua
+++ b/gateway/src/apicast/policy/gc/gc.lua
@@ -1,0 +1,44 @@
+local _M = require('apicast.policy').new('GC', 'builtin')
+
+
+-- This policy allows APICast to remove data that it's staled from shared
+-- dictionaries.  By default, Openresty only deletes this when trying to
+-- write a new entry in the shared dict.  When no new requests in this
+-- instance, will keep allocated the memory forever.
+
+-- The main reason for this change was a user using blue-green deployment,
+-- where the proxy is not receiving more traffic. However, the shared
+-- dictionaries are full, so the data is still allocated and cannot be used
+-- by other processes.
+
+
+local mt = {
+  __index = _M
+}
+
+--- When is not set, we set the cleanup each 300 seconds
+local default_delay_cleanup = 300
+
+--- This is called when APIcast boots the master process.
+function _M.new(delay)
+  local self = setmetatable({}, mt)
+  self.delay = tonumber(delay) or default_delay_cleanup
+  return self
+end
+
+-- Need to happens by worker, cannot run something like this on master process,
+-- so need to run on each worker.
+-- @TODO: This is so sad in Openresty, we need to find a way to detect a leader
+-- in some way.
+function _M:init_worker()
+  local handler = function()
+    for name,dict in pairs(ngx.shared) do
+      local flushed = dict:flush_expired()
+      ngx.log(ngx.DEBUG, "flushed ", flushed , " expired entries on shared dict '", name,"'")
+    end
+  end
+  ngx.log(ngx.INFO, "GC cleanup process called every ", self.delay, "seconds")
+  ngx.timer.every(self.delay, handler)
+end
+
+return _M

--- a/gateway/src/apicast/policy/gc/init.lua
+++ b/gateway/src/apicast/policy/gc/init.lua
@@ -1,0 +1,1 @@
+return require('gc')

--- a/gateway/src/apicast/policy_chain.lua
+++ b/gateway/src/apicast/policy_chain.lua
@@ -70,7 +70,8 @@ local DEFAULT_POLICIES = {
     'apicast.policy.load_configuration',
     'apicast.policy.find_service',
     'apicast.policy.local_chain',
-    'apicast.policy.nginx_metrics'
+    'apicast.policy.nginx_metrics',
+    'apicast.policy.gc'
 }
 
 --- Return new policy chain with default policies.

--- a/spec/policy/gc/gc_spec.lua
+++ b/spec/policy/gc/gc_spec.lua
@@ -1,0 +1,29 @@
+
+local GC = require('apicast.policy.gc')
+
+local shdict_mt = {
+  __index = {
+    flush_expired = function() return 1 end,
+  }
+}
+local function shdict()
+  return setmetatable({ }, shdict_mt)
+end
+
+describe('GC policy', function()
+
+  it("Delete shared dict entries on timeout", function()
+
+    local gc = GC.new(1)
+    gc:init_worker()
+
+    --- just to make sure that every is used and no mistake in the future
+    for var=0,1 do
+      ngx.shared.gc_test = shdict()
+      spy.on(ngx.shared.gc_test, "flush_expired")
+      ngx.sleep(1)
+      assert.spy(ngx.shared.gc_test.flush_expired).was.called()
+    end
+  end)
+
+end)


### PR DESCRIPTION
This policy allows APICast to remove data that it's staled from shared
dictionaries.  By default, Openresty only deletes this when trying to
write a new entry in the shared dict.  When no new requests in this
instance, will keep allocated the memory forever.

The main reason for this change was a user using blue-green deployment,
where the proxy is not receiving more traffic. However, the shared
dictionaries are full, so the data is still allocated and cannot be used
by other processes.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>