### PR TITLE
Usage: fix issues on encoding 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Increased api-keys shared memory size [PR #1250](https://github.com/3scale/APIcast/pull/1250) [THREESCALE-6570](https://issues.redhat.com/browse/THREESCALE-6570)
 - Add support to multiple Origin based on regexp [PR #1251](https://github.com/3scale/APIcast/pull/1251) [THREESCALE-6569](https://issues.redhat.com/browse/THREESCALE-6569)
 - Bump Openresty version to 1.19.3 [PR #1272](https://github.com/3scale/APIcast/pull/1272) [THREESCALE-6963](https://issues.redhat.com/browse/THREESCALE-6963)
+- Change how ngx.encode_args is made on usage [PR #1277](https://github.com/3scale/APIcast/pull/1277) [THREESCALE-7122](https://issues.redhat.com/browse/THREESCALE-7122)
 
 
 

--- a/gateway/src/apicast/usage.lua
+++ b/gateway/src/apicast/usage.lua
@@ -7,7 +7,11 @@ local ipairs = ipairs
 local insert = table.insert
 local remove = table.remove
 local encode_args = ngx.encode_args
-
+local tconcat = table.concat
+local tinsert = table.insert
+local format = string.format
+local tablex = require('pl.tablex')
+local ngx_escape_uri = ngx.escape_uri
 local _M = {}
 
 local mt = { __index = _M }
@@ -104,7 +108,11 @@ end
 
 --- Return a string with the encoded format() output
 function _M:encoded_format()
-    return encode_args(self:format())
+    local res = {}
+    for key,val in tablex.sort(self:format()) do
+      tinsert(res, format("%s=%s", ngx_escape_uri(key), ngx_escape_uri(val)))
+    end
+    return tconcat(res, "&")
 end
 
 --- Return  the max delta in the usage, by default returns 0

--- a/spec/usage_spec.lua
+++ b/spec/usage_spec.lua
@@ -169,10 +169,39 @@ describe('usage', function()
     end)
   end)
 
-  it("encode_format", function()
-    local usage = Usage.new()
-    usage:add('hits', 0)
-    assert.are.same(usage:encoded_format(), "usage%5Bhits%5D=0")
+  describe("encode format", function()
+    it("works with a single metric", function()
+      local usage = Usage.new()
+      usage:add('hits', 0)
+      assert.are.same(usage:encoded_format(), "usage%5Bhits%5D=0")
+    end)
+
+    it("with multiple metrics return the same", function()
+      local usage = Usage.new()
+      usage:add('a', 1)
+      usage:add('c', 3)
+      usage:add('b', 2)
+      assert.are.same(usage:encoded_format(), "usage%5Ba%5D=1&usage%5Bb%5D=2&usage%5Bc%5D=3")
+      -- Multiple cases just in case
+      local usage = Usage.new()
+      usage:add('c', 3)
+      usage:add('a', 1)
+      usage:add('b', 2)
+      assert.are.same(usage:encoded_format(), "usage%5Ba%5D=1&usage%5Bb%5D=2&usage%5Bc%5D=3")
+
+    end)
+
+    it("integer metrics", function()
+      local usage = Usage.new()
+      usage:add(1, 10)
+      assert.are.same(usage:encoded_format(), "usage%5B1%5D=10")
+    end)
+
+    it("no metrics", function()
+      local usage = Usage.new()
+      assert.are.same(usage:encoded_format(), "")
+    end)
+
   end)
 
   describe("get_max_delta", function()


### PR DESCRIPTION
Usage keys are based on ngx.encode_args, BUT due to the Luajit update
the data is not always the same, so the following usage metatable:

```
{
  metric_a=1,
  metric_b=1,
}
```

can be `metric_a=1&metric_b=1` or `metric_b=1&metric_a=1`, so the cached
key is not the same, and auth call will happen a few more times when it
shouldn't.

The way that I followed is the same as Openresty, and the escape_uri
should always be a string due to the usage method.

Fix THREESCALE-7122