### PR TITLE
Policy: Content Caching disable totally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issues on OIDC jwk discovery [PR #1268](https://github.com/3scale/APIcast/pull/1268) [THREESCALE-6913](https://issues.redhat.com/browse/THREESCALE-6913)
 - Fixed Payload limit content-length response header [PR #1266](https://github.com/3scale/APIcast/pull/1266) [THREESCALE-6736](https://issues.redhat.com/browse/THREESCALE-6736)
 - Fixed IPcheck policy issues with invalid IP [PR #1273](https://github.com/3scale/APIcast/pull/1273) [THREESCALE-7075](https://issues.redhat.com/browse/THREESCALE-7075)
-
+- Disabled content-caching globally if no policy at all [PR #1278](https://github.com/3scale/APIcast/pull/1278) [THREESCALE-7016](https://issues.redhat.com/browse/THREESCALE-7016)
 
 
 ### Added
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bump Openresty version to 1.19.3 [PR #1272](https://github.com/3scale/APIcast/pull/1272) [THREESCALE-6963](https://issues.redhat.com/browse/THREESCALE-6963)
 - Change how ngx.encode_args is made on usage [PR #1277](https://github.com/3scale/APIcast/pull/1277) [THREESCALE-7122](https://issues.redhat.com/browse/THREESCALE-7122)
 - Upstream pool key when is using HTTPs  connection [PR #1274](https://github.com/3scale/APIcast/pull/1274) [THREESCALE-6849](https://issues.redhat.com/browse/THREESCALE-6849)
+
 
 
 

--- a/gateway/conf.d/apicast.conf
+++ b/gateway/conf.d/apicast.conf
@@ -77,7 +77,7 @@ location @upstream {
   }
 
   #{% capture proxy_cache_valid %}
-  #{#} proxy_cache apicast_cache;
+  #{#} proxy_cache $cache_zone;
   #{#} proxy_cache_key $scheme$request_method$proxy_host$request_uri$service_id;
   #{#} proxy_no_cache $cache_request;
   #{#} proxy_cache_valid {{ env.APICAST_CACHE_STATUS_CODES | default: '200 302'}} {{ env.APICAST_CACHE_MAX_TIME | default: '1m' }};
@@ -166,6 +166,7 @@ location / {
 
   # Variable to enable/disable content cache
   set $cache_request 'true';
+  set $cache_zone 'off';
 
   set $original_request_id $request_id;
   set $upstream_keepalive_key "";

--- a/gateway/src/apicast/policy/content_caching/content_caching.lua
+++ b/gateway/src/apicast/policy/content_caching/content_caching.lua
@@ -11,6 +11,8 @@ local metrics_updater = require('apicast.metrics.updater')
 
 local content_cache_metric = prometheus('counter', "content_caching", "Content caching status", {"status"})
 
+local cache_zone = "apicast_cache"
+
 local new = _M.new
 
 function _M.new(config)
@@ -30,7 +32,9 @@ function _M.new(config)
 end
 
 function _M:access(context)
+  ngx.var.cache_zone = cache_zone
   ngx.var.cache_request = "true"
+
   for _, rule in ipairs(self.rules or {}) do
     local cond_is_true = rule.condition:evaluate(context)
     if cond_is_true and rule.cache then


### PR DESCRIPTION
When using content_cache and proxy_no_cache, some directives are still
in place, and was causing issues to a few users regarding HEAD request,
etc..

This commit disabled the proxy_cache globally based on cache_zone
variable.

FIX THREESCALE-7016

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>