### PR TITLE
Policy: Nginx header filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Change how ngx.encode_args is made on usage [PR #1277](https://github.com/3scale/APIcast/pull/1277) [THREESCALE-7122](https://issues.redhat.com/browse/THREESCALE-7122)
 - Upstream pool key when is using HTTPs  connection [PR #1274](https://github.com/3scale/APIcast/pull/1274) [THREESCALE-6849](https://issues.redhat.com/browse/THREESCALE-6849)
 - Fix a warning message on invalid upstream [PR #1285](https://github.com/3scale/APIcast/pull/1285) [THREESCALE-5225](https://issues.redhat.com/browse/THREESCALE-5225)
-- Upstream MTLS server verify  [PR #1280](https://github.com/3scale/APIcast/pull/1280) [THREESCALE-7099](https://issues.redhat.com/browse/THREESCALE-7099)
+- Upstream MTLS server verify [PR #1280](https://github.com/3scale/APIcast/pull/1280) [THREESCALE-7099](https://issues.redhat.com/browse/THREESCALE-7099)
+- Add Nginx filter policy [PR #1279](https://github.com/3scale/APIcast/pull/1279) [THREESCALE-6704](https://issues.redhat.com/browse/THREESCALE-6704)
 
 
 

--- a/gateway/src/apicast/policy/nginx_filters/Readme.md
+++ b/gateway/src/apicast/policy/nginx_filters/Readme.md
@@ -1,0 +1,45 @@
+# Nginx Filters policy
+
+## Description
+
+Nginx, by default, checks/validates some request headers. This policy allows the
+user to skips these checks and sends them to the upstream servers. 
+
+The primary use case is like If-Match headers, where Nginx filters by default,
+but some users want these headers on the upstream server because Nginx is not
+responsible for this header. 
+
+There is an option to delete it or to append it to the upstream server. 
+
+## Warning
+
+If one header is also managed by the multiple headers policy, this can cause
+conflicts.
+
+
+## Examples
+
+Send If-Match header to the upstream server, and avoid Nginx 412 response:
+
+```
+{ "name": "apicast.policy.nginx_filters",
+  "configuration": {
+    "headers": [
+      {"name": "If-Match", "append": true}
+    ]
+  }
+}
+```
+
+
+Delete If-Match header and avoid the Nginx 412 response:
+
+```
+{ "name": "apicast.policy.nginx_filters",
+  "configuration": {
+    "headers": [
+      {"name": "If-Match", "append": false}
+    ]
+  }
+}
+```

--- a/gateway/src/apicast/policy/nginx_filters/apicast-policy.json
+++ b/gateway/src/apicast/policy/nginx_filters/apicast-policy.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
+  "name": "Nginx Filter",
+  "summary": "Skip nginx filters on certain headers",
+  "description": [
+    "Nginx, by default, checks/validates some request headers. This policy allows the user to skips these checks and sends them to the upstream servers. "
+  ],
+  "version": "builtin",
+  "order": {
+    "before": [
+      {
+        "name": "apicast",
+        "version": "builtin"
+      }
+    ]
+  },
+  "configuration": {
+    "type": "object",
+    "properties": {
+      "headers": {
+        "type": "array",
+        "title": "Headers to filter",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "Header Name"
+            },
+            "append": {
+              "type": "boolean",
+              "title": "Append header to upstream"
+            }
+          },
+          "required": [
+            "name",
+            "append"
+          ]
+        }
+      }
+    },
+    "required": [
+      "headers"
+    ]
+  }
+}

--- a/gateway/src/apicast/policy/nginx_filters/init.lua
+++ b/gateway/src/apicast/policy/nginx_filters/init.lua
@@ -1,0 +1,1 @@
+return require("nginx_filters")

--- a/gateway/src/apicast/policy/nginx_filters/nginx_filters.lua
+++ b/gateway/src/apicast/policy/nginx_filters/nginx_filters.lua
@@ -1,0 +1,45 @@
+local _M  = require('apicast.policy').new('Nginx Filter Policy', 'builtin')
+local new = _M.new
+local get_headers = ngx.req.get_headers
+
+function _M.new(config)
+  local self = new(config)
+  self.headers = {}
+  self.validate = false
+  for _,val in pairs(config.headers or {}) do
+    self.headers[val.name] = val.append
+    self.validate = true
+  end
+  return self
+end
+
+function _M:rewrite(context)
+  if not self.validate then
+    return
+  end
+
+  local headers = get_headers()
+  context.nginx_filters_headers = {}
+
+  for header_name,append in pairs(self.headers) do
+      local original_header = headers[header_name]
+      if original_header then
+        ngx.req.clear_header(header_name)
+        if append then
+          context.nginx_filters_headers[header_name] = original_header
+        end
+      end
+  end
+end
+
+function _M:access(context)
+  if not self.validate then
+    return
+  end
+
+  for header_name, val in pairs(context.nginx_filters_headers) do
+    ngx.req.set_header(header_name, val)
+  end
+end
+
+return _M

--- a/t/apicast-policy-nginx_filters.t
+++ b/t/apicast-policy-nginx_filters.t
@@ -1,0 +1,149 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+check_accum_error_log();
+run_tests();
+
+repeat_each(1);
+
+__DATA__
+
+=== TEST 1: Check If-Match is returning 412
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/", "url": "http://echo" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- request
+GET /
+--- more_headers
+If-Match: anything
+--- error_code: 412
+--- no_error_log
+[error]
+
+=== TEST 2: Check If-Match header is deleted and processed
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.say("OK")
+    }
+  }
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" },
+          { "name": "apicast.policy.nginx_filters",
+            "configuration": {
+              "headers": [
+                {"name": "If-Match", "append": false}
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+
+--- upstream
+  location / {
+     content_by_lua_block {
+       local assert = require('luassert')
+       assert.same(ngx.req.get_headers()["If-Match"], nil)
+       assert.same(ngx.req.get_headers()["Test"], "one")
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /?user_key=foo
+--- more_headers
+If-Match: anything
+Test: one
+--- error_code: 200
+--- response_body
+yay, api backend
+--- no_error_log
+[error]
+
+=== TEST 3: Check If-Match header is sent to the upstream API
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.say("OK")
+    }
+  }
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" },
+          { "name": "apicast.policy.nginx_filters",
+            "configuration": {
+              "headers": [
+                {"name": "If-Match", "append": true}
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location / {
+    rewrite_by_lua_block {
+      local assert = require('luassert')
+      assert.same(ngx.req.get_headers()["If-Match"], "anything")
+      assert.same(ngx.req.get_headers()["Test"], "one")
+      ngx.req.clear_header("If-Match")
+      ngx.say("yay, api backend")
+      ngx.exit(200)
+    }
+  }
+--- request
+GET /?user_key=foo
+--- more_headers
+If-Match: anything
+Test: one
+--- error_code: 200
+--- response_body
+yay, api backend
+--- no_error_log
+[error]
+


### PR DESCRIPTION
Nginx, by default, checks/validates some request headers. This policy
allows the user to skips these checks and sends them to the upstream
servers.

FIX THREESCALE-6704

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>