### PR TITLE
Logs: Fix host on access logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Disabled content-caching globally if no policy at all [PR #1278](https://github.com/3scale/APIcast/pull/1278) [THREESCALE-7016](https://issues.redhat.com/browse/THREESCALE-7016)
 - Fixed warning messages [PR #1282](https://github.com/3scale/APIcast/pull/1282) [THREESCALE-5816](https://issues.redhat.com/browse/THREESCALE-5816)
 - Fixed lua socket error on ssl_certificate [PR #1283](https://github.com/3scale/APIcast/pull/1283) [THREESCALE-7230](https://issues.redhat.com/browse/THREESCALE-7230)
+- Fixed Acess log header [PR #1284](https://github.com/3scale/APIcast/pull/1284) [THREESCALE-6193](https://issues.redhat.com/browse/THREESCALE-6193)
 
 ### Added
 

--- a/gateway/conf.d/apicast.conf
+++ b/gateway/conf.d/apicast.conf
@@ -157,7 +157,7 @@ location / {
   set $ctx_ref -1;
 
   set $post_action_impact '';
-  set $original_request_id '';
+  set $original_request_id $request_id;
   set $original_request_uri '$scheme://$host$request_uri';
 
   # Variables needed by Websocket policy
@@ -168,7 +168,8 @@ location / {
   set $cache_request 'true';
   set $cache_zone 'off';
 
-  set $original_request_id $request_id;
+  set $target_host $host;
+
   set $upstream_keepalive_key "";
 
   # {% if http_keepalive_timeout != empty %}

--- a/gateway/http.d/apicast.conf.liquid
+++ b/gateway/http.d/apicast.conf.liquid
@@ -1,4 +1,4 @@
-log_format time '[$time_local] $host:$server_port $remote_addr:$remote_port "$request" $status $body_bytes_sent ($request_time) $post_action_impact';
+log_format time '[$time_local] $target_host:$server_port $remote_addr:$remote_port "$request" $status $body_bytes_sent ($request_time) $post_action_impact';
 
 map $status $extended_access_log {
     default '';

--- a/t/apicast-log.t
+++ b/t/apicast-log.t
@@ -1,6 +1,10 @@
 use lib 't';
 use Test::APIcast::Blackbox 'no_plan';
 
+# Test::Nginx does not allow to grep access logs, so we redirect them to
+# stderr to be able to use "grep_error_log" by setting APICAST_ACCESS_LOG_FILE
+$ENV{APICAST_ACCESS_LOG_FILE} = "$Test::Nginx::Util::ErrLogFile";
+
 repeat_each(2);
 
 run_tests();
@@ -87,5 +91,43 @@ yay, api backend: test:$TEST_NGINX_SERVER_PORT
 --- error_code: 200
 --- no_error_log
 requestID=
+--- no_error_log
+[error]
+
+=== TEST 3: Access log has the correct host.
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(200)
+    }
+  }
+--- upstream
+  location / {
+     echo 'yay, api backend: $http_host';
+  }
+--- request
+GET /?user_key=value
+--- response_body env
+yay, api backend: test:$TEST_NGINX_SERVER_PORT
+--- error_code: 200
+--- error_log eval
+qr/\+0000\] localhost\:\d+ 127\.0\.0\.1\:\d+/
 --- no_error_log
 [error]


### PR DESCRIPTION
When using ngx.var.host the access_logs are not logging the target host.
With this change, by default we log the host that was hit in the
upstream.

Fix THREESCALE-6193

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>