### PR TITLE
Logs: disable invalid warning when no api_backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bump Openresty version to 1.19.3 [PR #1272](https://github.com/3scale/APIcast/pull/1272) [THREESCALE-6963](https://issues.redhat.com/browse/THREESCALE-6963)
 - Change how ngx.encode_args is made on usage [PR #1277](https://github.com/3scale/APIcast/pull/1277) [THREESCALE-7122](https://issues.redhat.com/browse/THREESCALE-7122)
 - Upstream pool key when is using HTTPs  connection [PR #1274](https://github.com/3scale/APIcast/pull/1274) [THREESCALE-6849](https://issues.redhat.com/browse/THREESCALE-6849)
+- Fix a warning message on invalid upstream [PR #1285](https://github.com/3scale/APIcast/pull/1285) [THREESCALE-5225](https://issues.redhat.com/browse/THREESCALE-5225)
 - Upstream MTLS server verify  [PR #1280](https://github.com/3scale/APIcast/pull/1280) [THREESCALE-7099](https://issues.redhat.com/browse/THREESCALE-7099)
 
 

--- a/gateway/src/apicast/proxy.lua
+++ b/gateway/src/apicast/proxy.lua
@@ -172,6 +172,13 @@ function _M.get_upstream(service, context)
   if not service then
     return errors.service_not_found()
   end
+
+  -- Due to API as a product, the api_backend is no longer needed because this
+  -- can be handled by routing policy
+  if not service.api_backend then
+    return nil, nil
+  end
+
   local upstream, err = Upstream.new(service.api_backend)
   if not upstream then
     return nil, err

--- a/spec/proxy_spec.lua
+++ b/spec/proxy_spec.lua
@@ -57,6 +57,19 @@ describe('Proxy', function()
       assert.same(80, get_upstream({ api_backend = 'http://example.com' }):port())
       assert.same(8080, get_upstream({ api_backend = 'http://example.com:8080' }):port())
     end)
+
+    it("on invalid api_backend return error", function()
+      local upstream, err = get_upstream({ api_backend = 'test.com' })
+      assert.falsy(upstream)
+      assert.same(err, "invalid upstream")
+    end)
+
+    it("on no api_backend return nil and no error", function()
+      local upstream, err = get_upstream({})
+      assert.falsy(upstream)
+      assert.falsy(err)
+    end)
+
   end)
 
   describe('.authorize', function()


### PR DESCRIPTION
Since API as a product, api_backend is no longer a required parameter of
the config. Due to the change, a warning message was in place on each
request due to invalid upstream.

With this change, in case of no api_backend, a nil object is returned
and no error message at all.

Fix THREESCALE-5225

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>