### PR TITLE
Policy: add on_failed policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix a warning message on invalid upstream [PR #1285](https://github.com/3scale/APIcast/pull/1285) [THREESCALE-5225](https://issues.redhat.com/browse/THREESCALE-5225)
 - Upstream MTLS server verify [PR #1280](https://github.com/3scale/APIcast/pull/1280) [THREESCALE-7099](https://issues.redhat.com/browse/THREESCALE-7099)
 - Add Nginx filter policy [PR #1279](https://github.com/3scale/APIcast/pull/1279) [THREESCALE-6704](https://issues.redhat.com/browse/THREESCALE-6704)
-
-
+- Added on_failed policy [PR#1286](https://github.com/3scale/APIcast/pull/1286) [THREESCALE-6705](https://issues.redhat.com/browse/THREESCALE-6705)
 
 
 ## [3.10.0] 2021-01-04

--- a/gateway/src/apicast/configuration.lua
+++ b/gateway/src/apicast/configuration.lua
@@ -65,19 +65,14 @@ end
 local function build_policy_chain(policies)
   if not value(policies) then return nil, 'no policy chain' end
 
-  local chain = tab_new(#policies, 0)
-
+  local built_chain = policy_chain.new()
   for i=1, #policies do
-      local policy, err = policy_chain.load_policy(policies[i].name, policies[i].version, policies[i].configuration)
-
-      if policy then
-        insert(chain, policy)
-      elseif err then
-        ngx.log(ngx.WARN, 'failed to load policy: ', policies[i].name, ' version: ', policies[i].version, ' err: ', err)
-      end
+    local ok, err = built_chain:add_policy(policies[i].name, policies[i].version, policies[i].configuration)
+    if err then
+      ngx.log(ngx.WARN, 'failed to load policy: ', policies[i].name, ' version: ', policies[i].version, ' err: ', err)
+    end
   end
 
-  local built_chain = policy_chain.new(chain)
   built_chain:check_order()
   return built_chain
 end

--- a/gateway/src/apicast/policy/on_failed/Readme.md
+++ b/gateway/src/apicast/policy/on_failed/Readme.md
@@ -1,0 +1,4 @@
+# Policy on_failed
+
+When any policy fails, this policy block the request and send back a given
+status code to the user.

--- a/gateway/src/apicast/policy/on_failed/apicast-policy.json
+++ b/gateway/src/apicast/policy/on_failed/apicast-policy.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
+  "name": "On fail",
+  "summary": "Block request if any policy fails",
+  "description": "When a policy fails, this policy allows to set an error message back to the user and stop processing the request to the upstream API.",
+  "version": "builtin",
+  "order": {
+    "before": [
+      {
+        "name": "apicast",
+        "version": "builtin"
+      }
+    ]
+  },
+  "configuration": {
+    "type": "object",
+    "properties": {
+      "error_status_code": {
+        "description": "Status code that will send to the user if any policy fails",
+        "type": "integer",
+        "minimum": 100,
+        "exclusiveMaximum": 700
+      }
+    }
+  }
+}

--- a/gateway/src/apicast/policy/on_failed/init.lua
+++ b/gateway/src/apicast/policy/on_failed/init.lua
@@ -1,0 +1,1 @@
+return require("on_failed")

--- a/gateway/src/apicast/policy/on_failed/on_failed.lua
+++ b/gateway/src/apicast/policy/on_failed/on_failed.lua
@@ -1,0 +1,20 @@
+local _M  = require('apicast.policy').new('On failed', 'builtin')
+local new = _M.new
+
+
+function _M.new(config)
+  local self = new(config)
+  self.error_status_code = config.error_status_code or ngx.HTTP_SERVICE_UNAVAILABLE
+  return self
+end
+
+function _M:export()
+  return {
+    policy_error_callback = function(policy_name, error_message)
+      ngx.log(ngx.DEBUG, "Stop request because policy: '", policy_name, "' failed, error='", error_message, "'")
+      ngx.exit(self.error_status_code)
+    end
+  }
+end
+
+return _M

--- a/t/apicast-policy-on_failed.t
+++ b/t/apicast-policy-on_failed.t
@@ -1,0 +1,111 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+use Cwd qw(abs_path);
+
+BEGIN {
+    $ENV{TEST_NGINX_APICAST_POLICY_LOAD_PATH} = 't/fixtures/policies';
+}
+
+env_to_apicast(
+    'APICAST_POLICY_LOAD_PATH' => abs_path($ENV{TEST_NGINX_APICAST_POLICY_LOAD_PATH}),
+);
+
+repeat_each();
+run_tests();
+
+__DATA__
+
+=== TEST 1: policy with invalid configuration return 503
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          { "name": "example_policy", "version": "1.0.0", "configuration": { } },
+          { "name": "apicast.policy.on_failed", "configuration": {} },
+          { "name": "apicast.policy.echo" }
+        ]
+      }
+    }
+  ]
+}
+--- request
+GET /test
+--- error_code: 503
+--- error_log
+Stop request because policy: 'example_policy' failed, error=
+
+
+=== TEST 2: policy with access phase issues return 503
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "example_policy",
+            "version": "1.0.0",
+            "configuration": {
+              "message": "foo",
+              "fail_access": true
+            }
+          },
+          {
+            "name": "apicast.policy.on_failed",
+            "configuration": {}
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- request
+GET /test
+--- error_code: 503
+--- error_log
+Stop request because policy: 'example_policy' failed, error=
+
+
+=== TEST 3: policy with access phase issues return provided status code
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "example_policy",
+            "version": "1.0.0",
+            "configuration": {
+              "message": "foo",
+              "fail_access": true
+            }
+          },
+          {
+            "name": "apicast.policy.on_failed",
+            "configuration": {
+              "error_status_code": 401
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- request
+GET /test
+--- error_code: 401
+--- error_log
+Stop request because policy: 'example_policy' failed, error='

--- a/t/fixtures/policies/example_policy/1.0.0/example_policy.lua
+++ b/t/fixtures/policies/example_policy/1.0.0/example_policy.lua
@@ -11,7 +11,15 @@ function _M.new(configuration)
     policy.message = configuration.message
   end
 
+  policy.fail_access = configuration.fail_access
+
   return policy
+end
+
+function _M:access()
+  if self.fail_access then
+    self.fail()
+  end
 end
 
 function _M:content()


### PR DESCRIPTION
Some users complained that if a policy fails, the request didn't
terminate. This problem is strategic for some users because it can raise
a security flaw if a policy is not executed correctly(jwt_claim_check
policy as an example)

This pull request adds some "pcalls" on policy_chain, where the error is
checked and, if the context has a callback function defined, is called.

Fix THREESCALE-6705

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>