### PR TITLE
CIRCLECI: push containers with latest tag when build master git branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,12 @@ jobs:
       - run: make test-runtime-image gateway-logs --keep-going
       - login-docker:
           command: |
-            IMAGE_NAME="apicast:${CIRCLE_TAG:-${CIRCLE_BRANCH}}"
+            IMAGE_TAG="${CIRCLE_TAG:-${CIRCLE_BRANCH}}"
+            if [ "${IMAGE_TAG}" == "master" ]
+            then
+              IMAGE_TAG="latest"
+            fi
+            IMAGE_NAME="apicast:${IMAGE_TAG}"
             docker tag apicast-runtime-image ${IMAGE_NAME}
             make push
       - cleanup-docker
@@ -174,7 +179,12 @@ jobs:
 
       - login-docker:
           command: |
-            IMAGE_NAME="apicast:${CIRCLE_TAG:-${CIRCLE_BRANCH}}-builder"
+            IMAGE_TAG="${CIRCLE_TAG:-${CIRCLE_BRANCH}}"
+            if [ "${IMAGE_TAG}" == "master-builder" ]
+            then
+              IMAGE_TAG="latest-builder"
+            fi
+            IMAGE_NAME="apicast:${IMAGE_TAG}"
             docker tag apicast-builder-image ${IMAGE_NAME}
             make push
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Upstream MTLS server verify [PR #1280](https://github.com/3scale/APIcast/pull/1280) [THREESCALE-7099](https://issues.redhat.com/browse/THREESCALE-7099)
 - Add Nginx filter policy [PR #1279](https://github.com/3scale/APIcast/pull/1279) [THREESCALE-6704](https://issues.redhat.com/browse/THREESCALE-6704)
 - Added on_failed policy [PR#1286](https://github.com/3scale/APIcast/pull/1286) [THREESCALE-6705](https://issues.redhat.com/browse/THREESCALE-6705)
+- Master branch containers builds are now latest tag on quay.io [PR#1289](https://github.com/3scale/APIcast/pull/1289) [THREESCALE-7251](https://issues.redhat.com/browse/THREESCALE-7251)
 
 
 ## [3.10.0] 2021-01-04


### PR DESCRIPTION
When using master branch, the quay.io images are reference as master.
The operator team wants to have the name as latest, so all components
can have the same naming.

FIX https://issues.redhat.com/browse/THREESCALE-7251

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>