### PR TITLE
TEST: Fix Uptream MTLs policy integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,12 +109,12 @@ executors:
     environment:
       S2I_VERSION: "1.1.12-2a783420"
       DOCKER_COMPOSE_VERSION: "1.16.1"
-      OPENRESTY_VERSION: "1.19.3.5-20-centos8"
+      OPENRESTY_VERSION: "1.19.3.6-20-centos8"
 
   openresty:
     working_directory: /opt/app-root/apicast
     docker:
-    - image: quay.io/3scale/s2i-openresty-centos7:1.19.3.5-20-centos8
+    - image: quay.io/3scale/s2i-openresty-centos7:1.19.3.6-20-centos8
     - image: redis:3.2.8-alpine
     environment:
       TEST_NGINX_BINARY: openresty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed Acess log header [PR #1284](https://github.com/3scale/APIcast/pull/1284) [THREESCALE-6193](https://issues.redhat.com/browse/THREESCALE-6193)
 - Fixed Payload limit jsonschema [PR #1293](https://github.com/3scale/APIcast/pull/1293) [THREESCALE-6965](https://issues.redhat.com/browse/THREESCALE-6965)
 - Fixed Status code overwrite policy jsonschema [PR #1294](https://github.com/3scale/APIcast/pull/1294) [THREESCALE-7238](https://issues.redhat.com/browse/THREESCALE-7238)
+- Fixed TLS host validation [PR #1295](https://github.com/3scale/APIcast/pull/1295) [THREESCALE-768](https://issues.redhat.com/browse/THREESCALE-768)
 
 ### Added
 


### PR DESCRIPTION
When using invalid host, the ngx_ssl_host was not used, so the verify
was working when it shouldn't.

This PR is part of THREESCALE-768

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>