### PR TITLE
FIX: routing policy catch-all condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed Payload limit jsonschema [PR #1293](https://github.com/3scale/APIcast/pull/1293) [THREESCALE-6965](https://issues.redhat.com/browse/THREESCALE-6965)
 - Fixed Status code overwrite policy jsonschema [PR #1294](https://github.com/3scale/APIcast/pull/1294) [THREESCALE-7238](https://issues.redhat.com/browse/THREESCALE-7238)
 - Fixed TLS host validation [PR #1295](https://github.com/3scale/APIcast/pull/1295) [THREESCALE-768](https://issues.redhat.com/browse/THREESCALE-768)
+- Fixed Status code overwrite policy jsonschema [PR #1296](https://github.com/3scale/APIcast/pull/1296) [THREESCALE-6415](https://issues.redhat.com/browse/THREESCALE-6415)
 
 ### Added
 

--- a/gateway/src/apicast/policy/routing/rule.lua
+++ b/gateway/src/apicast/policy/routing/rule.lua
@@ -44,6 +44,9 @@ local function init_operation(config_operation)
 end
 
 local function init_condition(config_condition)
+  if not config_condition.operations then
+    config_condition.operations = {}
+  end
   local operations = tab_new(#config_condition.operations, 0)
 
   for _, operation in ipairs(config_condition.operations) do

--- a/t/apicast-policy-routing.t
+++ b/t/apicast-policy-routing.t
@@ -2305,3 +2305,114 @@ yay, api backend
 --- error_code: 200
 --- no_error_log
 [error]
+
+
+=== TEST 34: Match all conditions working as expected
+Context: https://issues.redhat.com/browse/THREESCALE-6415
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT/",
+                  "condition": {
+                    "operations": [
+                      {
+                        "match": "path",
+                        "op": "==",
+                        "value": "/a_path"
+                      }
+                    ]
+                  }
+                },
+
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT/",
+                  "condition": {}
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location ~ / {
+     content_by_lua_block {
+       ngx.say(ngx.var.uri)
+     }
+  }
+--- request eval
+["GET /a_path", "GET /"]
+--- response_body eval
+["/a_path\n", "/\n"]
+--- error_code eval
+[200, 200]
+--- no_error_log
+[error]
+
+
+=== TEST 35: Match all conditions working as expected
+Context: https://issues.redhat.com/browse/THREESCALE-6415
+operations is an empty array instead of nil
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "proxy": {
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT/",
+                  "condition": {
+                    "operations": [
+                      {
+                        "match": "path",
+                        "op": "==",
+                        "value": "/a_path"
+                      }
+                    ]
+                  }
+                },
+
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT/",
+                  "condition": {
+                    "operations": []
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location ~ / {
+     content_by_lua_block {
+       ngx.say(ngx.var.uri)
+     }
+  }
+--- request eval
+["GET /a_path", "GET /"]
+--- response_body eval
+["/a_path\n", "/\n"]
+--- error_code eval
+[200, 200]
+--- no_error_log
+[error]


### PR DESCRIPTION
When operations is empty was working as expected, but when it was nil,
raises an excpetion and routing policy was not working as expected.

FIX https://issues.redhat.com/browse/THREESCALE-6415

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>