### PR TITLE
Routing: Fix encoding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed Status code overwrite policy jsonschema [PR #1294](https://github.com/3scale/APIcast/pull/1294) [THREESCALE-7238](https://issues.redhat.com/browse/THREESCALE-7238)
 - Fixed TLS host validation [PR #1295](https://github.com/3scale/APIcast/pull/1295) [THREESCALE-768](https://issues.redhat.com/browse/THREESCALE-768)
 - Fixed Status code overwrite policy jsonschema [PR #1296](https://github.com/3scale/APIcast/pull/1296) [THREESCALE-6415](https://issues.redhat.com/browse/THREESCALE-6415)
+- Fixed URL encoding on set-path [PR #1297](https://github.com/3scale/APIcast/pull/1297) [THREESCALE-5117](https://issues.redhat.com/browse/THREESCALE-5117)
+
 
 ### Added
 

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -160,7 +160,7 @@ function _M:rewrite_request()
 
     local uri = self.uri
     if uri.path then
-        ngx.req.set_uri(ngx.unescape_uri(prefix_path(uri.path)))
+        ngx.req.set_uri(prefix_path(uri.path))
     end
 
     if uri.query then


### PR DESCRIPTION
When using encoding, some characters got encoded a few times, so the
upstream request was not correct.

Is impossible to get it 100% perfect, because some chars (`?/#`) are
hard to get it right when using ngx.var.uri, but we need to use
ngx.var.uri.

After discussing it with support/product, this is the best way to handle
it.

Reported by sillumin@redhat.com
Fix: https://issues.redhat.com/browse/THREESCALE-5117

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>