### PR TITLE
Upstream: Do not append a trailing / on the end.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed TLS host validation [PR #1295](https://github.com/3scale/APIcast/pull/1295) [THREESCALE-768](https://issues.redhat.com/browse/THREESCALE-768)
 - Fixed Status code overwrite policy jsonschema [PR #1296](https://github.com/3scale/APIcast/pull/1296) [THREESCALE-6415](https://issues.redhat.com/browse/THREESCALE-6415)
 - Fixed URL encoding on set-path [PR #1297](https://github.com/3scale/APIcast/pull/1297) [THREESCALE-5117](https://issues.redhat.com/browse/THREESCALE-5117)
+- Fixed trailing slash on routing policy [PR #1298](https://github.com/3scale/APIcast/pull/1298) [THREESCALE-7146](https://issues.redhat.com/browse/THREESCALE-7146)
 
 
 ### Added

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -135,7 +135,10 @@ function _M:append_path(path)
     if not self.uri.path then
       self.uri.path = "/"
     end
-    self.uri.path = resty_url.join(self.uri.path, tmp_path)
+
+    if tmp_path ~= "" then
+      self.uri.path = resty_url.join(self.uri.path, tmp_path)
+    end
 
     -- If query is already present, do not need to add more.
     if tmp_query and tmp_query ~= "" then

--- a/spec/upstream_spec.lua
+++ b/spec/upstream_spec.lua
@@ -80,6 +80,12 @@ describe('Upstream', function()
             assert.same(up.uri.path, "/test/")
         end)
 
+        it('trailing slash is not appended', function()
+            local up = Upstream.new('http://host:8090/test')
+            up:append_path("")
+            assert.same(up.uri.path, "/test")
+        end)
+
     end)
 
     local function stub_ngx_request()

--- a/t/apicast-policy-maintenance-mode.t
+++ b/t/apicast-policy-maintenance-mode.t
@@ -188,7 +188,6 @@ Content-Type: application/json
 
 
 === TEST 5: Maintenance mode is applied with routing policy + matching upstream condition
-
 --- configuration
 {
   "services": [
@@ -204,7 +203,7 @@ Content-Type: application/json
             "configuration": {
               "rules": [
                 {
-                    "url": "http://test:$TEST_NGINX_SERVER_PORT/b1",
+                    "url": "http://test:$TEST_NGINX_SERVER_PORT/b1/",
                     "condition": {
                         "operations": [
                             {
@@ -219,7 +218,7 @@ Content-Type: application/json
               ]
             }
           },
-          { 
+          {
             "name": "apicast.policy.maintenance_mode",
             "configuration": {
                 "condition": {


### PR DESCRIPTION
If the tmp_path is empty on upstream:append_path, we should add the
trailing slash, as resty_url:join is doing.

Fix https://issues.redhat.com/browse/THREESCALE-7146
Reported-by: sillumin@redhat.com

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>