### PR TITLE
Fix: Add bigger timeout on integration test

### DIFF
--- a/t/apicast-policy-payload_limits.t
+++ b/t/apicast-policy-payload_limits.t
@@ -183,6 +183,7 @@ yay, api backend
 
 
 === TEST 4: Response limit set to 100 rejects the request
+--- timeout: 5s
 --- backend
   location /transactions/authrep.xml {
     content_by_lua_block {
@@ -245,6 +246,7 @@ Content-Length: 17
 
 
 === TEST 5: Request body size smaller than the limit
+--- timeout: 5s
 --- backend
   location /transactions/authrep.xml {
     content_by_lua_block {


### PR DESCRIPTION
Some test were failing, and maybe is because busy CI worker node and
things are slower, increasing timeout to avoid this kind of issues.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>