### PR TITLE
Policy: Nginx filters fix jsonschema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed URL encoding on set-path [PR #1297](https://github.com/3scale/APIcast/pull/1297) [THREESCALE-5117](https://issues.redhat.com/browse/THREESCALE-5117)
 - Fixed trailing slash on routing policy [PR #1298](https://github.com/3scale/APIcast/pull/1298) [THREESCALE-7146](https://issues.redhat.com/browse/THREESCALE-7146)
 - Fixed race condition on caching mode [PR #1259](https://github.com/3scale/APIcast/pull/1259) [THREESCALE-4464](https://issues.redhat.com/browse/THREESCALE-4464)
+- Fixed Nginx filter issues on jsonschema [PR #1302](https://github.com/3scale/APIcast/pull/1302) [THREESCALE-7349](https://issues.redhat.com/browse/THREESCALE-7349)
 
 
 ### Added

--- a/gateway/src/apicast/policy/nginx_filters/apicast-policy.json
+++ b/gateway/src/apicast/policy/nginx_filters/apicast-policy.json
@@ -20,6 +20,7 @@
       "headers": {
         "type": "array",
         "title": "Headers to filter",
+        "minItems": 1,
         "items": {
           "type": "object",
           "properties": {


### PR DESCRIPTION
Add a minimum number of items in the policy to avoid empty list.

Fix https://issues.redhat.com/browse/THREESCALE-7349

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>