### PR TITLE
CircleCI: Fix typo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
 
       - login-docker:
           command: |
-            IMAGE_TAG="${CIRCLE_TAG:-${CIRCLE_BRANCH}}"
+            IMAGE_TAG="${CIRCLE_TAG:-${CIRCLE_BRANCH}}-builder"
             if [ "${IMAGE_TAG}" == "master-builder" ]
             then
               IMAGE_TAG="latest-builder"


### PR DESCRIPTION
When moving to the `latest` tag, `-builder` suffix was not added to the
image tag, some images got overwritten incorrectly.

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>