### PR TITLE
OIDC: Fix issues with subset of services.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed trailing slash on routing policy [PR #1298](https://github.com/3scale/APIcast/pull/1298) [THREESCALE-7146](https://issues.redhat.com/browse/THREESCALE-7146)
 - Fixed race condition on caching mode [PR #1259](https://github.com/3scale/APIcast/pull/1259) [THREESCALE-4464](https://issues.redhat.com/browse/THREESCALE-4464)
 - Fixed Nginx filter issues on jsonschema [PR #1302](https://github.com/3scale/APIcast/pull/1302) [THREESCALE-7349](https://issues.redhat.com/browse/THREESCALE-7349)
+- Fixed issues with OIDC filters [PR #1304](https://github.com/3scale/APIcast/pull/1304) [THREESCALE-6042](https://issues.redhat.com/browse/THREESCALE-6042)
 
 
 ### Added

--- a/gateway/src/apicast/configuration_loader/oidc.lua
+++ b/gateway/src/apicast/configuration_loader/oidc.lua
@@ -40,7 +40,8 @@ function _M.call(...)
         for i,service in ipairs(config.services or empty) do
             -- Assign false instead of nil to avoid sparse arrays. cjson raises
             -- an error by default when converting sparse arrays.
-            oidc[i] = oidc[i] or load_service(service) or false
+            oidc[i] = oidc[i] or load_service(service) or { service_id = service.id}
+            -- oidc[i] = oidc[i] or load_service(service) or false
         end
 
         config.oidc = oidc

--- a/t/apicast-subset-of-services.t
+++ b/t/apicast-subset-of-services.t
@@ -201,6 +201,17 @@ use JSON qw(to_json);
 to_json({
   services => [
   {
+    id => 12,
+    backend_version => '1',
+    proxy => {
+        api_backend => "http://test:$TEST_NGINX_SERVER_PORT/",
+        hosts => ["null.com"],
+        proxy_rules => [
+          { pattern => '/', http_method => 'GET', metric_system_name => 'hits', delta => 1  }
+        ]
+    }
+  },
+  {
     id => 24,
     backend_version => 'oauth',
     backend_authentication_type => 'provider_key',
@@ -231,8 +242,10 @@ to_json({
     }
   }
   ],
-  oidc => [{
-    service_id => 24, 
+  oidc => [
+  {service_id => 12},
+  {
+    service_id => 24,
     issuer => 'https://example.com/auth/realms/apicast_zero',
     config => { id_token_signing_alg_values_supported => [ 'RS256' ] },
     keys => { somekid => { pem => $::public_key } },

--- a/t/configuration-loading-when-needed.t
+++ b/t/configuration-loading-when-needed.t
@@ -49,6 +49,6 @@ content_by_lua_block {
 
 --- error_code: 200
 --- expected_json
-{"services":[{"id":42,"backend_version":1}],"oidc":[false]}
+{"services":[{"id":42,"backend_version":1}],"oidc":[{"service_id": 42}]}
 --- no_error_log
 [error]

--- a/t/management.t
+++ b/t/management.t
@@ -173,7 +173,7 @@ include $TEST_NGINX_MANAGEMENT_CONFIG;
 --- request
 POST /boot
 --- expected_json
-{"status":"ok","config":{"oidc":[false],"services":[{"id":42}]}}
+{"status":"ok","config":{"oidc":[{"service_id": 42}],"services":[{"id":42}]}}
 --- error_code: 200
 --- udp_listen random_port env chomp
 $TEST_NGINX_RANDOM_PORT
@@ -198,8 +198,8 @@ include $TEST_NGINX_MANAGEMENT_CONFIG;
 --- request eval
 ['POST /boot', 'POST /boot']
 --- expected_json eval
-['{"status":"ok","config":{"services":[{"id":42}],"oidc":[false]}}',
-'{"status":"ok","config":{"services":[{"id":42}],"oidc":[false]}}']
+['{"status":"ok","config":{"services":[{"id":42}],"oidc":[{"service_id": 42}]}}',
+'{"status":"ok","config":{"services":[{"id":42}],"oidc":[{"service_id": 42}]}}']
 --- error_code eval
 [200, 200]
 --- udp_listen random_port env chomp


### PR DESCRIPTION
By default, APICast stores all services in an array of Service Objects, also,
another array with the OIDC objects, something like this:

```
{
  "services": [
    {
      "id": 1,
      "issuer": "http://foo.com",
      "auth_type": "oidc",
      ...
    },
    {
      "id": 2,
      "auth_type": "provider_key"
      ...
    },
    {
      "id": 3,
      "issuer": "http://bar.com",
      "auth_type": "oidc",
      ...
    }
  ],
  "oidc": [
    {
      "issuer": "http://foo.com",
      ...
    },
    false,
    {
      "issuer": "http://bar.com",
      ...
    }
  ]
}
```

The mapping, on APICast config is like this:

```
service[0] using oidc[0]
service[1] using oidc[1]
service[2] using oidc[2]
```

When we filter using `APICAST_SERVICE_LIST`, it filters based on the array, so
it'll transform to this:

export APICAST_SERVICE_LIST=3

```
{
  "services": [
    {
      "id": 3,
      "issuer": "http://bar.com",
      "auth_type": "oidc",
      ...
    }
  ],
  "oidc": [
    false,
    {
      "issuer": "http://bar.com",
      ...
    }
  ]
}
```

So, OIDC will fail, because the first entry of the OIDC array is false, because
false is added on filtering.

This PR added a new entry on oidc object, that it's service_id, so filtering can
be done without issues, config will be like this:

```
{
  "services": [
    {
      "id": 1,
      "issuer": "http://foo.com",
      "auth_type": "oidc",
      ...
    },
    {
      "id": 2,
      "auth_type": "provider_key"
      ...
    },
    {
      "id": 3,
      "issuer": "http://bar.com",
      "auth_type": "oidc",
      ...
    }
  ],
  "oidc": [
    {
      "issuer": "http://foo.com",
      "service_id": 1,
      ...
    },
    {
      "service_id": 2,
    },
    {
      "issuer": "http://bar.com",
      "service_id": 3,
      ...
    }
  ]
}
```

On non-oidc services, the oidc will be not hitted at all. On invalid fetch,
It'll be not fail, because the issuer is not in there, so it'll not work as
expected.

OIDC config links:

Service OIDC setup:
https://github.com/3scale/APIcast/blob/c184ff3e904f3d75857032a3da0004f8d74eba00/gateway/src/apicast/configuration/service.lua#L221-L231

OIDC error on invalid oicd setup:
https://github.com/3scale/APIcast/blob/c184ff3e904f3d75857032a3da0004f8d74eba00/gateway/src/apicast/oauth/oidc.lua#L55

Warning message:

https://github.com/3scale/APIcast/blob/c184ff3e904f3d75857032a3da0004f8d74eba00/gateway/src/apicast/proxy.lua#L199-L205

Filtering part:
https://github.com/3scale/APIcast/blob/c184ff3e904f3d75857032a3da0004f8d74eba00/gateway/src/apicast/configuration.lua#L173-L297

Fix: THREESCALE-6042
Reported-by: Kevin Price <kevprice@redhat.com>
Reported-by: Samuele Illuminati <sillumin@redhat.com>
Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>