### PR TITLE
OIDC: fix issue on remote v2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed trailing slash on routing policy [PR #1298](https://github.com/3scale/APIcast/pull/1298) [THREESCALE-7146](https://issues.redhat.com/browse/THREESCALE-7146)
 - Fixed race condition on caching mode [PR #1259](https://github.com/3scale/APIcast/pull/1259) [THREESCALE-4464](https://issues.redhat.com/browse/THREESCALE-4464)
 - Fixed Nginx filter issues on jsonschema [PR #1302](https://github.com/3scale/APIcast/pull/1302) [THREESCALE-7349](https://issues.redhat.com/browse/THREESCALE-7349)
-- Fixed issues with OIDC filters [PR #1304](https://github.com/3scale/APIcast/pull/1304) [THREESCALE-6042](https://issues.redhat.com/browse/THREESCALE-6042)
+- Fixed issues with OIDC filters [PR #1304](https://github.com/3scale/APIcast/pull/1304) [PR #1306](https://github.com/3scale/APIcast/pull/1306) [THREESCALE-6042](https://issues.redhat.com/browse/THREESCALE-6042)
 
 
 ### Added

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -549,7 +549,10 @@ UwIDAQAB
       assert.truthy(config)
       assert.equals('string', type(config))
 
-      assert.equals(1, #(cjson.decode(config).services))
+      result_config = cjson.decode(config)
+      assert.equals(1, #result_config.services)
+      assert.equals(1, #result_config.oidc)
+      assert.same('2', result_config.oidc[1].service_id)
     end)
 
     it('returns nil and an error if the config is not a valid', function()
@@ -561,6 +564,63 @@ UwIDAQAB
 
       assert.is_nil(config)
       assert.equals('Expected object key string but found invalid token at character 3', err)
+    end)
+
+    it('returns configuration with oidc config complete', function()
+
+      env.set('THREESCALE_DEPLOYMENT_ENV', 'production')
+      test_backend.expect{ url = 'http://example.com/something/with/path/production.json?host=foobar.example.com' }.
+        respond_with{ status = 200, body = cjson.encode({ proxy_configs = {
+          {
+            proxy_config = {
+              version = 42,
+              environment = 'staging',
+              content = { 
+                id = 2, 
+                backend_version = 1,
+                proxy = { oidc_issuer_endpoint = 'http://user:pass@idp.example.com/auth/realms/foo/' }
+              }
+            }
+          }
+        }})}
+
+      test_backend.expect{ url = "http://idp.example.com/auth/realms/foo/.well-known/openid-configuration" }.
+      respond_with{
+        status = 200,
+        headers = { content_type = 'application/json' },
+        body = [[
+            {
+              "issuer": "https://idp.example.com/auth/realms/foo",
+              "jwks_uri": "https://idp.example.com/auth/realms/foo/jwks",
+              "id_token_signing_alg_values_supported": [ "RS256" ]
+            }
+          ]]
+      }
+
+      test_backend.expect{ url = "https://idp.example.com/auth/realms/foo/jwks" }.
+      respond_with{
+        status = 200,
+        headers = { content_type = 'application/json' },
+        body =  [[
+            { "keys": [{
+                "kid": "3g-I9PWt6NrznPLcbE4zZrakXar27FDKEpqRPlD2i2Y",
+                "kty": "RSA",
+                "n": "iqXwBiZgN2q1dCKU1P_vzyiGacdQhfqgxQST7GFlWU_PUljV9uHrLOadWadpxRAuskNpXWsrKoU_hDxtSpUIRJj6hL5YTlrvv-IbFwPNtD8LnOfKL043_ZdSOe3aT4R4NrBxUomndILUESlhqddylVMCGXQ81OB73muc9ovR68Ajzn8KzpU_qegh8iHwk-SQvJxIIvgNJCJTC6BWnwS9Bw2ns0fQOZZRjWFRVh8BjkVdqa4vCAb6zw8hpR1y9uSNG-fqUAPHy5IYQaD8k8QX0obxJ0fld61fH-Wr3ENpn9YZWYBcKvnwLm2bvxqmNVBzW4rhGEZb9mf-KrSagD5GUw",
+                "e": "AQAB"
+            }] }
+        ]]
+      }
+
+      local config = assert(loader:index('foobar.example.com'))
+
+      assert.truthy(config)
+      assert.equals('string', type(config))
+
+      result_config = cjson.decode(config)
+      assert.equals(1, #result_config.services)
+      assert.equals(1, #result_config.oidc)
+      assert.same('2', result_config.oidc[1].service_id)
+      assert.same('https://idp.example.com/auth/realms/foo', result_config.oidc[1].config.issuer)
     end)
   end)
 end)


### PR DESCRIPTION
This is a second patch, and it's related to PR #1304.

When using remotev2 loader, the config.oidc is created in there, and
there is also a caching mechanism for OIDC[0], so we need to append the
service_id and send a valid table in case of non OIDC setup.

Because this oidc is cached, we also do a deepcopy, to avoid to use
always the same reference, so the config.oidc[i].service_id is always
different and we didn't get a invalid filtering.

This is only failing when using APICAST_SERVICE_LIST

[0] Commit: 720cd99f5dcbd2e11e3b3f07d5ee5888865740d7
Related to: THREESCALE-6042

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>