### PR TITLE
Policy: upstream MTLS fix on verify.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed Nginx filter issues on jsonschema [PR #1302](https://github.com/3scale/APIcast/pull/1302) [THREESCALE-7349](https://issues.redhat.com/browse/THREESCALE-7349)
 - Fixed issues with OIDC filters [PR #1304](https://github.com/3scale/APIcast/pull/1304) [PR #1306](https://github.com/3scale/APIcast/pull/1306) [THREESCALE-6042](https://issues.redhat.com/browse/THREESCALE-6042)
 
+- Fixed issues with OIDC filters [PR #1304](https://github.com/3scale/APIcast/pull/1304) [THREESCALE-6042](https://issues.redhat.com/browse/THREESCALE-6042)
+- Fixed issues with Upstream MTLS certs [PR #1307](https://github.com/3scale/APIcast/pull/1307) [THREESCALE-7508](https://issues.redhat.com/browse/THREESCALE-7508)
 
 ### Added
 

--- a/gateway/src/apicast/policy/upstream_mtls/upstream_mtls.lua
+++ b/gateway/src/apicast/policy/upstream_mtls/upstream_mtls.lua
@@ -170,17 +170,17 @@ function _M:balancer(context)
     return
   end
 
+  local val = C.ngx_http_apicast_ffi_set_ssl_verify(r, ffi.new("int", 1), ffi.new("int", 1))
+  if val ~= ngx.OK then
+    ngx.log(ngx.WARN, "Cannot verify SSL upstream connection")
+  end
+
   if not self.ca_store then
     ngx.log(ngx.WARN, "Set verify without including CA certificates")
     return
   end
 
   self.set_ca_cert(r, self.ca_store)
-
-  local val = C.ngx_http_apicast_ffi_set_ssl_verify(r, ffi.new("int", 1), ffi.new("int", 1))
-  if val ~= ngx.OK then
-    ngx.log(ngx.WARN, "Cannot verify SSL upstream connection")
-  end
 end
 
 return _M

--- a/t/apicast-policy-upstream_mtls.t
+++ b/t/apicast-policy-upstream_mtls.t
@@ -353,15 +353,9 @@ EOF
 EOF
 --- request
 GET /?user_key=value
---- response_body
-ssl_client_s_dn: CN=localhost,OU=APIcast,O=3scale
-ssl_client_i_dn: CN=localhost,OU=APIcast,O=3scale
---- error_code: 200
+--- error_code: 502
 --- no_error_log
 [error]
---- error_log
-Set verify without including CA certificates
-
 
 
 === TEST 5: MTLS policy with correct certificate, verify works as expected


### PR DESCRIPTION
Before, if not CA cert was set, we don't set the verify at all, but this
is a bad behaviour because:

- CA certs can be the global ones.
- Verify is true, so should fail.

Now, if not CA proxy will return a 502 back to the user.

Fix THREESCALE-7508

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>