### PR TITLE
Mapping rules integration and verification with threescalers library

### DIFF
--- a/.busted
+++ b/.busted
@@ -21,4 +21,8 @@ end
 return {
   _all = all,
   default = default,
+  threescalers = {
+    table.unpack(default),
+    ROOT = { "spec/threescalers" },
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ tmp/benchmark/
 /vendor/cache
 /.docker
 /tmp/
+libthreescalers.so
+/.profile
+/.bashrc
+/.rustup/
+/.cargo/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "threescalers"]
+	path = threescalers/threescalers
+	url = https://github.com/3scale-rs/threescalers
+	branch = capi

--- a/README.threescalers.md
+++ b/README.threescalers.md
@@ -1,0 +1,6 @@
+# Running the mapping rules tests from the threescalers crate
+
+- Ensure you have checked out the submodules for this repository.
+- Run `make development`.
+- Once in the development container, run: `make threescalers-test`
+

--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -1,7 +1,7 @@
 version: '2.2'
 services:
   development:
-    image: ${IMAGE:-quay.io/3scale/s2i-openresty-centos7:master}
+    build: threescalers
     depends_on:
       - redis
     working_dir: /home/centos/

--- a/gateway/src/apicast/mapping_rule.lua
+++ b/gateway/src/apicast/mapping_rule.lua
@@ -50,6 +50,10 @@ end
 local regex_variable = '\\{[-\\w_]+\\}'
 
 local function matches_querystring_params(params, args)
+  if args == nil then
+    args = {}
+  end
+
   local match = true
 
   for i=1, #params do

--- a/gateway/src/threescalers/encoding.lua
+++ b/gateway/src/threescalers/encoding.lua
@@ -1,0 +1,42 @@
+local ffi_cow = require("threescalers.ffi_cow")
+local ffi = require("ffi")
+ffi.cdef[[
+const struct FFICow *encoding_encode(const char *s, size_t len);
+int encoding_encode_buffer(const char *src, size_t srclen, char *dst, size_t *dstlen_ptr);
+]]
+
+local threescalers = ffi.load("threescalers")
+
+local _M = {}
+
+local mt = { __index = _M }
+
+function _M.encode(s)
+  local fc = threescalers.encoding_encode(s, #s)
+  if fc == nil then
+    return nil, 'threescalers.encoding_encode failed'
+  end
+
+  local fc = ffi_cow.new(fc)
+
+  local ptr, len = fc:to_ptr_len()
+  return ffi.string(ptr, len)
+end
+
+function _M.encode_buffer(s, bufsize)
+  if bufsize == nil then
+    bufsize = #s * 3
+  end
+
+  local buf = ffi.new("uint8_t[?]", bufsize)
+  local buflen = ffi.new("unsigned long[1]", bufsize)
+
+  local res = threescalers.encoding_encode_buffer(s, #s, buf, buflen)
+  if res < 0 then
+    return nil, buflen[0]
+  end
+
+  return ffi.string(buf, buflen[0]), nil
+end
+
+return _M

--- a/gateway/src/threescalers/ffi_cow.lua
+++ b/gateway/src/threescalers/ffi_cow.lua
@@ -1,0 +1,82 @@
+local ffi = require("ffi")
+ffi.cdef[[
+typedef struct FFIStr {
+  size_t len;
+  const char *ptr;
+} FFIStr;
+
+typedef struct FFIString {
+  size_t len;
+  size_t cap;
+  const char *ptr;
+} FFIString;
+
+enum FFICow_Tag {
+  Borrowed,
+  Owned,
+};
+typedef uint8_t FFICow_Tag;
+
+typedef struct FFICow {
+  FFICow_Tag tag;
+  union {
+    struct {
+      struct FFIStr borrowed;
+    };
+    struct {
+      struct FFIString owned;
+    };
+  };
+} FFICow;
+
+size_t fficow_len(const struct FFICow *c);
+size_t fficow_ptr_len(const struct FFICow *c, const char **ptr);
+void fficow_free(const struct FFICow *c);
+]]
+
+local threescalers = ffi.load("threescalers")
+
+local _M = {}
+
+local ffi_cow_mt = {
+  __index = _M,
+  __new = function(ct, value)
+    if value == nil then
+      error('failed to create FFICow', 2)
+    end
+
+    return ffi.new(ct, value)
+  end,
+  __gc = function(self)
+    threescalers.fficow_free(self.cdata)
+  end
+}
+
+local FFICow = ffi.metatype('struct { const struct FFICow *cdata; }', ffi_cow_mt)
+
+function _M.new(value)
+  return FFICow(value)
+end
+
+function _M:free()
+  threescalers.fficow_free(self.cdata)
+end
+
+function _M:len()
+  return threescalers.fficow_len(self.cdata)
+end
+
+function _M:to_ptr_len()
+  local self = self.cdata;
+  --local ptr = ffi.new("const char *[1]")
+  --local len = threescalers.fficow_ptr_len(self, ptr)
+  --return ptr[0], len
+
+  if self.tag == 0 then
+    return self.borrowed.ptr, self.borrowed.len
+  else
+    return self.owned.ptr, self.owned.len
+  end
+end
+
+return _M

--- a/gateway/src/threescalers/metadata.lua
+++ b/gateway/src/threescalers/metadata.lua
@@ -1,0 +1,21 @@
+local ffi = require("ffi")
+ffi.cdef[[
+const char *user_agent(void);
+const char *version(void);
+]]
+
+local threescalers = ffi.load("threescalers")
+
+local _M = {}
+
+local mt = { __index = _M }
+
+function _M.version()
+  return ffi.string(threescalers.version())
+end
+
+function _M.user_agent()
+  return ffi.string(threescalers.user_agent())
+end
+
+return _M

--- a/gateway/src/threescalers/rest_rule.lua
+++ b/gateway/src/threescalers/rest_rule.lua
@@ -1,0 +1,108 @@
+local ffi_cow = require('threescalers.ffi_cow')
+
+local ffi = require('ffi')
+ffi.cdef[[
+typedef struct RestRule RestRule;
+
+const struct RestRule *rest_rule_new(const char *method, const char *path_n_qs);
+const struct RestRule *rest_rule_with_path_n_qs(const char *method,
+                                                const char *path,
+                                                const char *qs);
+void rest_rule_free(const struct RestRule *rule);
+
+int rest_rule_matches(const struct RestRule *rule, const char *method, const char *path_qs);
+int rest_rule_matches_path_n_qs(const struct RestRule *rule,
+                                const char *method,
+                                const char *path,
+                                const char *qs);
+int rest_rule_matches_request_line(const struct RestRule *rule, const char *http_request_line);
+
+const struct FFICow *rest_rule_method(const struct RestRule *rule);
+
+const struct FFICow *rest_rule_debug(const struct RestRule *rule);
+]]
+
+local threescalers = ffi.load("threescalers")
+
+local _M = {}
+local _mt = {
+  __index = _M,
+  __new = function(ct, method, ...)
+    local argn = select('#', ...)
+    local rule
+    if argn == 1 then
+      rule = threescalers.rest_rule_new(method, ...)
+    elseif argn == 2 then
+      rule = threescalers.rest_rule_with_path_n_qs(method, ...)
+    else
+      error('failed to pass the right parameters to RestRule.new', 2)
+    end
+
+    if rule == nil then
+      error('failed to create threescalers mapping rule', 2)
+    end
+
+    return ffi.new(ct, rule)
+  end,
+  __gc = function(self)
+    threescalers.rest_rule_free(self.cdata)
+  end,
+}
+
+local RestRule = ffi.metatype('struct { const struct RestRule *cdata; }', _mt)
+
+function _M.new(method, path_n_qs)
+  return RestRule(method, path_n_qs)
+end
+
+function _M.with_path_n_qs(method, path, qs)
+  return RestRule(method, path, qs)
+end
+
+function _M:matches(method, path_n_qs)
+  local match = threescalers.rest_rule_matches(self.cdata, method, path_n_qs)
+  if match > 0 then
+    return true
+  else
+    return false
+  end
+end
+
+function _M:matches_path_n_qs(method, path, qs)
+  local match = threescalers.rest_rule_matches_path_n_qs(self.cdata, method, path, qs)
+  if match > 0 then
+    return true
+  else
+    return false
+  end
+end
+
+function _M:matches_request_line(request_line)
+  local match = threescalers.rest_rule_matches_request_line(self.cdata, request_line)
+  if match > 0 then
+    return true
+  else
+    return false
+  end
+end
+
+function _M:method()
+  local method = threescalers.rest_rule_method(self.cdata)
+  if method == nil then
+    return nil, 'no method associated to rest rule'
+  end
+  return ffi_cow.new(method)
+end
+
+function _M:debug()
+  local debug = threescalers.rest_rule_debug(self.cdata)
+  if debug == nil then
+    return nil, 'debug implementation associated to rest rule failed'
+  end
+
+  local fc = ffi_cow.new(debug)
+  local ptr, len = fc:to_ptr_len()
+  return ffi.string(ptr, len)
+end
+
+return _M

--- a/spec/mapping_rule_spec.lua
+++ b/spec/mapping_rule_spec.lua
@@ -165,4 +165,419 @@ describe('mapping_rule', function()
     end)
   end)
 
+  -- NOTE: these tests from rest_rules also test the way in which path and query string are parsed,
+  -- but the current interface needs query string parameters passed in separately, so some tests
+  -- are missing important assertions.
+  describe('rest_rules specs', function()
+    it("matches a simple case", function()
+      --local mapping_rule = rest_rule.new('GET', '/?required=1')
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = 'GET',
+        pattern = '/',
+        querystring_parameters = { required = '1' },
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', '/test', { optional='1', required='1', other='1' }))
+    end)
+
+    it("matches simple cases", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/',
+        querystring_parameters = { },
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', '/'))
+      assert.is_true(mapping_rule:matches('GET', '//'))
+      assert.is_true(mapping_rule:matches('GET', '/?'))
+      assert.is_true(mapping_rule:matches('GET', '/', nil))
+      assert.is_true(mapping_rule:matches('GET', '/', { a }))
+      assert.is_true(mapping_rule:matches('GET', '/', { a=nil }))
+      assert.is_true(mapping_rule:matches('GET', '/', { a='1' }))
+      assert.is_true(mapping_rule:matches('GET', '/', { a='1', b='2' }))
+      assert.is_true(mapping_rule:matches('GET', '/some/path'))
+      assert.is_true(mapping_rule:matches('GET', '/some/path/'))
+      assert.is_true(mapping_rule:matches('GET', '/some/path/', { a='1', b='2' }))
+    end)
+
+    it("matches edge cases", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/auto',
+        querystring_parameters = { maybe_empty = nil, w = 'hello', color = '{color}'},
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_false(mapping_rule:matches('GET', '/'))
+      assert.is_false(mapping_rule:matches('GET', '/auto'))
+      assert.is_false(mapping_rule:matches('GET', '/auto', {}))
+
+      assert.is_true(mapping_rule:matches('GET', '/auto', { w='hello', color='red', maybe_empty=nil }))
+      assert.is_true(mapping_rule:matches('GET', '/auto-matic', { w='hello', maybe_empty=nil, color='green' }))
+      assert.is_true(mapping_rule:matches('GET', '/auto', { maybe_empty='its-full-now', color='blue', w='hello' }))
+      assert.is_true(mapping_rule:matches('GET', '/auto-matic', { color='black', w='hello', maybe_empty=nil }))
+
+      assert.is_false(mapping_rule:matches('GET', '/auto-matic', { w='hello', color=nil, maybe_empty=nil }))
+    end)
+
+    it("matches parameter values", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc',
+        querystring_parameters = { fmt = '{fmt}', lang = '{code}', s = '1', t = '$9' },
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc", { fmt='html', lang='ca', s='1', t='$9' }))
+
+      assert.is_false(mapping_rule:matches('GET', "/abc", { fmt='html', langs='ca', s='1', t='$9' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc", { fmt='html', lang=nil, s='1', t='$9' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc", { fmt='html', lang='', s='1', t='$9' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc", { fmt='html', lang='ca', s='2', t='$9' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc", { fmt='html', lang='ca', s='1' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc", { fmt='html', s='1', t='$9' }))
+    end)
+
+    it("matches parameter values when unknown parameters are present", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc',
+        querystring_parameters = { t = '9' },
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc", { t='9', other='1' }))
+      assert.is_true(mapping_rule:matches('GET', "/abc", { other='1', t='9' }))
+    end)
+
+    it("matches parameter values as prefixes", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc',
+        querystring_parameters = { lang = '1' },
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc", { lang='1' }))
+      assert.is_true(mapping_rule:matches('GET', "/abc", { lang='123' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc", { lang='01' }))
+    end)
+
+    it("matches partial parameter values", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc',
+        querystring_parameters = { lang = '{code}t' },
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc", { lang='cat' }))
+      assert.is_true(mapping_rule:matches('GET', "/abc", { lang='catalunya' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc", { lang='ca' }))
+    end)
+
+    it("matches partial literal parameter values", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc',
+        querystring_parameters = { lang = '{code}t$' },
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc", { lang='cat$' }))
+      assert.is_true(mapping_rule:matches('GET', "/abc", { lang='cat$alunya' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc", { lang='cat' }))
+    end)
+
+    -- Pending because we need a way to specify the table below.
+    -- Perhaps viable using a dynamic mechanism or a different interface.
+    pending("matches parameter keys", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc',
+	-- CAN'T SPECIFY A TABLE WITH: { '{wildcard}' = '25' }
+        -- querystring_parameters = { '{somekey}' = '25' },
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc", { fmt='html', choice='25' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc", { fmt='html', choice='2525' }))
+      -- CAN'T SPECIFY A TABLE WITH: { '{wildcard}' = '25' }
+      -- assert.is_true(mapping_rule:matches('GET', "/abc", { '25'='25' }))
+      -- assert.is_false(mapping_rule:matches('GET', "/abc", { '25'='125' }))
+    end)
+
+    -- Pending because we need a way to specify the table below.
+    -- Perhaps viable using a dynamic mechanism or a different interface.
+    pending("matches partial parameter keys", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc',
+	-- CAN'T SPECIFY A TABLE WITH: { '{wildcard}' = '25' }
+        -- querystring_parameters = { 'la{partial}g' = 'ca' },
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc", { fmt='html', lang='ca' }))
+      assert.is_true(mapping_rule:matches('GET', "/abc", { fmt='html', lannnnnng='ca' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc", { lag='ca' }))
+      assert.is_true(mapping_rule:matches('GET', "/abc", { la1g='ca' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc", { langs='ca' }))
+    end)
+
+    -- Pending because we need a way to specify the table below.
+    -- Perhaps viable using a dynamic mechanism or a different interface.
+    pending("matches partial literal parameter keys", function()
+      local mapping_rule = rest_rule.new('get', '/abc?la{partial}g$=ca')
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc',
+	-- CAN'T SPECIFY A TABLE WITH: { '{wildcard}' = '25' }
+        -- querystring_parameters = { 'la{partial}g$' = '25' },
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_false(mapping_rule:matches('GET', "/abc", { fmt='html', lang='ca' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc", { fmt='html', lannnnnng='ca' }))
+      -- CAN'T SPECIFY A TABLE WITH: { '{wildcard}' = '25' }
+      -- assert.is_true(mapping_rule:matches('GET', "/abc", { fmt='html', lannnnnng$='ca' }))
+      -- assert.is_false(mapping_rule:matches('GET', "/abc", { lag$='ca' }))
+      -- assert.is_true(mapping_rule:matches('GET', "/abc", { la1g$='ca' }))
+      -- assert.is_false(mapping_rule:matches('GET', "/abc", { lang$s='ca' }))
+    end)
+
+    it("matches combined cases", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc/v{version}/id\\$$',
+        querystring_parameters = { fmt = '{fmt}', lang = '{code}x', s = '1', t = '$9' },
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/v1/id$", { fmt='html', lang='cax', s='1', t='$9' }))
+      assert.is_true(mapping_rule:matches('GET', "///abc/v1//id$", { fmt='html', lang='cax', s='1', t='$9' }))
+      assert.is_false(mapping_rule:matches('GET', "///abc/v1//id$///", { fmt='html', lang='cax', s='1', t='$9' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/v2/id$", { fmt='html', lang='cax', s='1', t='$9' }))
+      assert.is_true(mapping_rule:matches('GET', "/abc/v1./id$", { fmt='html', lang='cax', other='70', s='1', z='2', t='$9' }))
+      assert.is_true(mapping_rule:matches('GET', "/abc//v2/id$", { misc='1', t='$9', fmt='html', z='2', s='1', lang='enx' }))
+      assert.is_true(mapping_rule:matches('GET', "/abc/v2/id$", { misc='1', t='$998', fmt='html', z='2', s='1', lang='cax' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v2/id$", { misc='1', t='$998', fmt='html', z='2', s='1', lang='ca' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1.1/id$", { missing_required_params='1' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/id$", { fmt='html', lang='cax', other='70', s='2', z='1', t='$9' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/id$", { fmt='json', lang='cax', other='70', z='2' }))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/id", { fmt='json', lang='cax', other='70', s='1', z='2', t='$9' }))
+    end)
+
+    pending("matches (ignores) inner wildcards", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc/_{wild{card}}_/',
+        querystring_parameters = {},
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+    end)
+
+    pending("matches (ignores) escaped inner wildcards", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc/_{wild\\{card\\}}_/',
+        querystring_parameters = {},
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+    end)
+
+    it("matches (ignores) inner left unbalanced wildcards", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc/_{wild{card}_/',
+        querystring_parameters = {},
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+    end)
+
+    it("matches (ignores) outer right unbalanced wildcards", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc/_{wild}card}_/',
+        querystring_parameters = {},
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+      assert.is_true(mapping_rule:matches('GET', "/abc/_xcard}_/"))
+    end)
+
+    it("matches (ignores) inner left unbalanced escaped wildcards", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc/_{wild\\{card}_/',
+        querystring_parameters = {},
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+    end)
+
+    pending("matches (ignores) inner right unbalanced escaped wildcards", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc/_{wild\\}card}_/',
+        querystring_parameters = {},
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+    end)
+
+    pending("matches (ignores) outer left unbalanced escaped wildcards", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc/_\\{wild{card}_/',
+        querystring_parameters = {},
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+      assert.is_true(mapping_rule:matches('GET', "/abc/_{wildx_/"))
+    end)
+
+    pending("matches (ignores) outer right unbalanced escaped wildcards", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc/_{wild}card\\}_/',
+        querystring_parameters = {},
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+      assert.is_true(mapping_rule:matches('GET', "/abc/_xcard}_/"))
+    end)
+
+    -- Failed to create mapping rule with threescalers!
+    pending("matches (ignores) unbalanced wildcards", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc/_{wildcard_/',
+        querystring_parameters = {},
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_{wildcard_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+    end)
+
+    it("matches multiple wildcards", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc/_{wild}_{card}_/',
+        querystring_parameters = {},
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x__/"))
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_y_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/___/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_x/x_/"))
+    end)
+
+    it("matches escaped dollar", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc/v{version}/id\\$/{n}/$',
+        querystring_parameters = {},
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/id"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/id\\"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/id\\\\"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/id$/1"))
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/v1/id$/1/"))
+      assert.is_true(mapping_rule:matches('GET', "/abc/v1/id$/1//"))
+      assert.is_true(mapping_rule:matches('GET', "/abc/v1/id$/one/"))
+    end)
+
+    it("does not match escaped characters", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc\\{d\\}',
+        querystring_parameters = {},
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      assert.is_false(mapping_rule:matches('GET', '/abc'))
+      assert.is_false(mapping_rule:matches('GET', '/abc$'))
+      assert.is_false(mapping_rule:matches('GET', '/abcd'))
+      assert.is_false(mapping_rule:matches('GET', '/abc/'))
+      assert.is_false(mapping_rule:matches('GET', '/abcdef'))
+      assert.is_false(mapping_rule:matches('GET', '/abc{}'))
+      assert.is_false(mapping_rule:matches('GET', '/abc{x}'))
+      assert.is_false(mapping_rule:matches('GET', '/abc{dd}'))
+      assert.is_false(mapping_rule:matches('GET', '/abc\\{d\\}'))
+    end)
+
+    pending("matches escaped characters literally", function()
+      local mapping_rule = MappingRule.from_proxy_rule({
+        http_method = MappingRule.any_method,
+        pattern = '/abc\\{d\\}',
+        querystring_parameters = {},
+        metric_system_name = 'hits',
+        delta = 1
+      })
+
+      -- Unfortunately this is failing at the moment
+      assert.is_true(mapping_rule:matches('GET', '/abc{d}'))
+    end)
+  end)
 end)

--- a/spec/threescalers/encoding_spec.lua
+++ b/spec/threescalers/encoding_spec.lua
@@ -1,0 +1,74 @@
+local encoding = require('threescalers.encoding')
+
+describe('threescalers encoding', function()
+  describe('encode', function()
+    it('returns an encoded string when changes are needed', function()
+      local needs_changes = "quediu?"
+      local len = #needs_changes
+
+      local res = encoding.encode(needs_changes)
+
+      assert.equal("quediu%3F", res)
+    end)
+
+    it('returns an unchanged string when no changes are needed', function()
+      local no_changes = "quediu"
+      local len = #no_changes
+
+      local res = encoding.encode(no_changes)
+
+      assert.equal(len, #res)
+      assert.equal(no_changes, res)
+    end)
+  end)
+
+  describe('encode_buffer', function()
+    it('returns an encoded string when changes are needed', function()
+      local needs_changes = "quediu?"
+      local len = #needs_changes
+
+      local res, err_bytes = encoding.encode_buffer(needs_changes)
+
+      assert.equal("quediu%3F", res)
+    end)
+
+    it('returns an encoded string when changes are needed without specifying buffer length', function()
+      local needs_changes = "???"
+      local len = #needs_changes
+
+      local res, err_bytes = encoding.encode_buffer(needs_changes)
+
+      assert.equal("%3F%3F%3F", res)
+    end)
+
+    it('returns an error with required size when the buffer is not large enough', function()
+      local needs_changes = "quediu?"
+      local len = #needs_changes
+
+      local res, err_bytes = encoding.encode_buffer(needs_changes, len)
+
+      assert.is_nil(res)
+      assert.equal(#"quediu%3F", err_bytes)
+    end)
+
+    it('returns an error with required size when the buffer is not large enough for even the original string', function()
+      local needs_changes = "quediu"
+      local len = #needs_changes
+
+      local res, err_bytes = encoding.encode_buffer(needs_changes, len - 1)
+
+      assert.is_nil(res)
+      assert.equal(#"quediu", err_bytes)
+    end)
+
+    it('returns an unchanged string when no changes are needed', function()
+      local no_changes = "quediu"
+      local len = #no_changes
+
+      local res, err_bytes = encoding.encode_buffer(no_changes, #no_changes)
+
+      assert.equal(len, #res)
+      assert.equal(no_changes, res)
+    end)
+  end)
+end)

--- a/spec/threescalers/metadata_spec.lua
+++ b/spec/threescalers/metadata_spec.lua
@@ -1,0 +1,21 @@
+-- Minimal metadata calls on the threescalers library
+local metadata = require('threescalers.metadata')
+
+describe('threescalers metadata', function()
+  describe('version', function()
+    it('returns a string with the library version', function()
+      local version = metadata.version()
+
+      assert(#version > 0)
+    end)
+  end)
+
+  describe('user_agent', function()
+    it('returns a string with the library user_agent', function()
+      local user_agent = metadata.user_agent()
+
+      assert(#user_agent > 0)
+      assert.equal("threescalers/", string.sub(user_agent, 1, #"threescalers/"))
+    end)
+  end)
+end)

--- a/spec/threescalers/rest_rule_spec.lua
+++ b/spec/threescalers/rest_rule_spec.lua
@@ -1,0 +1,392 @@
+local rest_rule = require('threescalers.rest_rule')
+
+describe('threescalers rest_rule', function()
+  describe('.matches', function()
+    it('returns true when method, URI, and args match', function()
+      local mapping_rule = rest_rule.new('GET', '/abc?a_param=1')
+      local match = mapping_rule:matches_path_n_qs('GET', '/abc', 'a_param=1')
+      assert.is_true(match)
+    end)
+
+    it('returns true when method and URI match, and no args are required', function()
+      local mapping_rule = rest_rule.new('GET', '/abc')
+      local match = mapping_rule:matches_path_n_qs('GET', '/abc', 'a_param=1')
+      assert.is_true(match)
+    end)
+
+    it('returns false when the method does not match', function()
+      local mapping_rule = rest_rule.new('GET', '/abc?a_param=1')
+      local match = mapping_rule:matches_path_n_qs('POST', '/abc', 'a_param=1')
+      assert.is_false(match)
+    end)
+
+    it('returns false when the URI does not match', function()
+      local mapping_rule = rest_rule.new('GET', '/abc?a_param=1')
+      local match = mapping_rule:matches_path_n_qs('GET', '/aaa', 'a_param=1')
+      assert.is_false(match)
+    end)
+
+    it('returns false when the args do not match', function()
+      local mapping_rule = rest_rule.new('GET', '/abc?a_param=1')
+      local match = mapping_rule:matches_path_n_qs('GET', '/abc', 'a_param=2')
+      assert.is_false(match)
+    end)
+
+    it('returns false when method, URI, and args do not match', function()
+      local mapping_rule = rest_rule.new('GET', '/abc?a_param=1')
+      local match = mapping_rule:matches_path_n_qs('POST', '/def', 'x=y')
+      assert.is_false(match)
+    end)
+
+    it('returns true when wildcard value has special characters: @ : % etc.', function()
+      local mapping_rule = rest_rule.new('GET', '/foo/{wildcard}/bar')
+
+      assert.is_true(mapping_rule:matches('GET', '/foo/a@b/bar'))
+      assert.is_true(mapping_rule:matches('GET', '/foo/a:b/bar'))
+      assert.is_true(mapping_rule:matches('GET', "/foo/a%b/bar"))
+    end)
+
+    it('double slashes are transformed correctly to a simple one', function()
+        local test_cases = {
+            ["/foo//bar"] = "/foo/bar",
+            ["/foo///bar"] = "/foo/bar",
+            ["/foo/ /bar"] = "/foo/ /bar",
+            ["/foo/bar///"] = "/foo/bar/",
+            ["///foo///bar///"] = "/foo/bar/",
+        }
+
+        for key, value in pairs(test_cases) do
+          local mapping_rule = rest_rule.new('GET', key)
+
+          assert.is_true(mapping_rule:matches('GET', value), "Invalid key:" .. key)
+        end
+    end)
+  end)
+
+  describe('.any_method', function()
+    it("allow connections when any method is defined", function()
+      local mapping_rule = rest_rule.new('ANY', '/foo/')
+
+      assert.is_true(mapping_rule:matches('GET', '/foo/'))
+      assert.is_true(mapping_rule:matches('POST', '/foo/'))
+      assert.is_true(mapping_rule:matches('PUT', "/foo/"))
+      assert.is_true(mapping_rule:matches('DELETE', "/foo/"))
+      assert.is_true(mapping_rule:matches('PATCH', "/foo/"))
+    end)
+  end)
+
+  describe('extras suite', function()
+    it("matches a simple case", function()
+      local mapping_rule = rest_rule.new('GET', '/?required=1')
+
+      assert.is_true(mapping_rule:matches_request_line('GET /test?optional=1&required=1&other=1 HTTP/1.1'))
+    end)
+
+    it("matches simple cases", function()
+      local mapping_rule = rest_rule.new('any', '/')
+
+      assert.is_true(mapping_rule:matches('GET', '/'))
+      assert.is_true(mapping_rule:matches_path_n_qs('GET', '/'))
+
+      assert.is_true(mapping_rule:matches('GET', '//'))
+      assert.is_true(mapping_rule:matches_path_n_qs('GET', '//'))
+
+      assert.is_true(mapping_rule:matches('GET', '/?'))
+      assert.is_true(mapping_rule:matches_path_n_qs('GET', '/?'))
+
+      assert.is_true(mapping_rule:matches('GET', '/?a'))
+      assert.is_true(mapping_rule:matches_path_n_qs('GET', '/?a'))
+
+      assert.is_true(mapping_rule:matches('GET', '/?a='))
+      assert.is_true(mapping_rule:matches_path_n_qs('GET', '/?a='))
+
+      assert.is_true(mapping_rule:matches('GET', '/?a=1'))
+      assert.is_true(mapping_rule:matches_path_n_qs('GET', '/?a=1'))
+
+      assert.is_true(mapping_rule:matches('GET', '/?a=1&'))
+      assert.is_true(mapping_rule:matches_path_n_qs('GET', '/?a=1&'))
+
+      assert.is_true(mapping_rule:matches('GET', '/?a=1&b=2'))
+      assert.is_true(mapping_rule:matches_path_n_qs('GET', '/?a=1&b=2'))
+
+      assert.is_true(mapping_rule:matches('GET', '/some/path'))
+      assert.is_true(mapping_rule:matches_path_n_qs('GET', '/some/path'))
+
+      assert.is_true(mapping_rule:matches('GET', '/some/path/'))
+      assert.is_true(mapping_rule:matches_path_n_qs('GET', '/some/path/'))
+
+      assert.is_true(mapping_rule:matches('GET', '/some/path/?a=1&b=2'))
+      assert.is_true(mapping_rule:matches_path_n_qs('GET', '/some/path/?a=1&b=2'))
+    end)
+
+    it("matches edge cases", function()
+      local mapping_rule = rest_rule.new('any', '/auto?maybe_empty=&w=hello&color={color}')
+
+      assert.is_false(mapping_rule:matches('GET', '/'))
+      assert.is_false(mapping_rule:matches('GET', '/auto'))
+      assert.is_false(mapping_rule:matches('GET', '/auto?'))
+      assert.is_false(mapping_rule:matches('GET', '/auto?w=hello&color=red&maybe_empty'))
+      assert.is_true(mapping_rule:matches('GET', '/auto?w=hello&color=red&maybe_empty='))
+      assert.is_true(mapping_rule:matches('GET', '/auto-matic?w=hello&maybe_empty=&color=green'))
+      assert.is_true(mapping_rule:matches('GET', '/auto?maybe_empty=its-full-now&color=blue&w=hello'))
+      assert.is_true(mapping_rule:matches('GET', '/auto-matic?color=black&w=hello&maybe_empty=&'))
+      assert.is_false(mapping_rule:matches('GET', '/auto-matic?w=hello&color&maybe_empty='))
+    end)
+
+    it("matches parameter values", function()
+      local mapping_rule = rest_rule.new('get', '/abc?t=$9&lang={code}&s=1&fmt={fmt}')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc?fmt=html&lang=ca&s=1&t=$9"))
+
+      assert.is_false(mapping_rule:matches('GET', "/abc?fmt=html&langs=ca&s=1&t=$9"))
+      assert.is_false(mapping_rule:matches('GET', "/abc?fmt=html&lang&s=1&t=$9"))
+      assert.is_false(mapping_rule:matches('GET', "/abc?fmt=html&lang=&s=1&t=$9"))
+      assert.is_false(mapping_rule:matches('GET', "/abc?fmt=html&lang=ca&s=2&t=$9"))
+      assert.is_false(mapping_rule:matches('GET', "/abc?fmt=html&lang=ca&s=1"))
+      assert.is_false(mapping_rule:matches('GET', "/abc?fmt=html&s=1&t=$9"))
+    end)
+
+    it("matches parameter values when unknown parameters are present", function()
+      local mapping_rule = rest_rule.new('get', '/abc?t=9')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc?t=9&other=1"))
+      assert.is_true(mapping_rule:matches('GET', "/abc?other=1&t=9"))
+    end)
+
+    it("matches parameter values as prefixes", function()
+      local mapping_rule = rest_rule.new('get', '/abc?lang=1')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc?lang=1"))
+      assert.is_true(mapping_rule:matches('GET', "/abc?lang=123"))
+      assert.is_false(mapping_rule:matches('GET', "/abc?lang=01"))
+    end)
+
+    it("matches partial parameter values", function()
+      local mapping_rule = rest_rule.new('any', '/abc?lang={code}t')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc?lang=cat"))
+      assert.is_true(mapping_rule:matches('GET', "/abc?lang=catalunya"))
+      assert.is_false(mapping_rule:matches('GET', "/abc?lang=ca"))
+    end)
+
+    it("matches partial literal parameter values", function()
+      local mapping_rule = rest_rule.new('any', '/abc?lang={code}t$')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc?lang=cat$"))
+      assert.is_true(mapping_rule:matches('GET', "/abc?lang=cat$alunya"))
+      assert.is_false(mapping_rule:matches('GET', "/abc?lang=cat"))
+    end)
+
+    it("matches parameter keys", function()
+      local mapping_rule = rest_rule.new('get', '/abc?{somekey}=25')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc?fmt=html&choice=25"))
+      assert.is_true(mapping_rule:matches('GET', "/abc?fmt=html&choice=2525"))
+      assert.is_false(mapping_rule:matches('GET', "/abc?fmt=html&choice=abc"))
+      assert.is_true(mapping_rule:matches('GET', "/abc?25=25"))
+      assert.is_false(mapping_rule:matches('GET', "/abc?25=125"))
+    end)
+
+    it("matches partial parameter keys", function()
+      local mapping_rule = rest_rule.new('get', '/abc?la{partial}g=ca')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc?fmt=html&lang=ca"))
+      assert.is_true(mapping_rule:matches('GET', "/abc?fmt=html&lannnnnng=ca"))
+      assert.is_false(mapping_rule:matches('GET', "/abc?lag=ca"))
+      assert.is_true(mapping_rule:matches('GET', "/abc?la1g=ca"))
+      assert.is_false(mapping_rule:matches('GET', "/abc?langs=ca"))
+    end)
+
+    it("matches partial literal parameter keys", function()
+      local mapping_rule = rest_rule.new('get', '/abc?la{partial}g$=ca')
+
+      assert.is_false(mapping_rule:matches('GET', "/abc?fmt=html&lang=ca"))
+      assert.is_false(mapping_rule:matches('GET', "/abc?fmt=html&lannnnnng=ca"))
+      assert.is_true(mapping_rule:matches('GET', "/abc?fmt=html&lannnnnng$=ca"))
+      assert.is_false(mapping_rule:matches('GET', "/abc?lag$=ca"))
+      assert.is_true(mapping_rule:matches('GET', "/abc?la1g$=ca"))
+      assert.is_false(mapping_rule:matches('GET', "/abc?lang$s=ca"))
+    end)
+
+    it("matches combined cases", function()
+      local mapping_rule = rest_rule.new('any', '/abc/v{version}/id\\$$?fmt={fmt}&l{an}g={code}x&s=1&t=$9')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/v1/id$?fmt=html&lang=cax&s=1&t=$9"))
+      assert.is_true(mapping_rule:matches('GET', "///abc/v1//id$?fmt=html&lang=cax&s=1&t=$9"))
+      assert.is_false(mapping_rule:matches('GET', "///abc/v1//id$///?fmt=html&lang=cax&s=1&t=$9"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/v2/id$?fmt=html&lang=cax&s=1&t=$9"))
+      assert.is_true(mapping_rule:matches('GET', "/abc/v1./id$?fmt=html&lang=cax&other=70&s=1&z=2&t=$9"))
+      assert.is_true(mapping_rule:matches('GET', "/abc//v2/id$?misc=1&t=$9&fmt=html&z=2&s=1&leng=enx"))
+      assert.is_true(mapping_rule:matches('GET', "/abc/v2/id$?misc=1&t=$998&fmt=html&z=2&s=1&l.g=cax"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v2/id$?misc=1&t=$998&fmt=html&z=2&s=1&l.g=ca"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1.1/id$?missing_required_params=1"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/id$?fmt=html&lang=cax&other=70&s=2&z=1&t=$9"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/id$?fmt=json&lang=cax&other=70&z=2"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/id?fmt=json&lang=cax&other=70&s=1&z=2&t=$9"))
+    end)
+
+    pending("matches (ignores) inner wildcards", function()
+      local mapping_rule = rest_rule.new('get', '/abc/_{wild{card}}_/')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+    end)
+
+    pending("matches (ignores) escaped inner wildcards", function()
+      local mapping_rule = rest_rule.new('get', '/abc/_{wild\\{card\\}}_/')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+    end)
+
+    it("matches (ignores) inner left unbalanced wildcards", function()
+      local mapping_rule = rest_rule.new('get', '/abc/_{wild{card}_/')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+    end)
+
+    it("matches (ignores) outer right unbalanced wildcards", function()
+      local mapping_rule = rest_rule.new('get', '/abc/_{wild}card}_/')
+
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+      assert.is_true(mapping_rule:matches('GET', "/abc/_xcard}_/"))
+    end)
+
+    it("matches (ignores) inner left unbalanced escaped wildcards", function()
+      local mapping_rule = rest_rule.new('get', '/abc/_{wild\\{card}_/')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+    end)
+
+    pending("matches (ignores) inner right unbalanced escaped wildcards", function()
+      local mapping_rule = rest_rule.new('get', '/abc/_{wild\\}card}_/')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+    end)
+
+    pending("matches (ignores) outer left unbalanced escaped wildcards", function()
+      local mapping_rule = rest_rule.new('get', '/abc/_\\{wild{card}_/')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+      assert.is_true(mapping_rule:matches('GET', "/abc/_{wildx_/"))
+    end)
+
+    pending("matches (ignores) outer right unbalanced escaped wildcards", function()
+      local mapping_rule = rest_rule.new('get', '/abc/_{wild}card\\}_/')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+      assert.is_true(mapping_rule:matches('GET', "/abc/_xcard}_/"))
+    end)
+
+    -- Failed to create mapping rule!
+    pending("matches (ignores) unbalanced wildcards", function()
+      local mapping_rule = rest_rule.new('get', '/abc/_{wildcard_/')
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/_{wildcard_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/__/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_/"))
+    end)
+
+    it("matches multiple wildcards", function()
+      local mapping_rule = rest_rule.new('get', '/abc/_{wild}_{card}_/')
+
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x__/"))
+      assert.is_true(mapping_rule:matches('GET', "/abc/_x_y_/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/___/"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/_x/x_x/x_/"))
+    end)
+  end)
+
+  describe('escaping suite', function()
+    it("matches duped forward slashes in pattern", function()
+      local mapping_rule = rest_rule.new('GET', '/a//b///c////d/////e/')
+
+      assert.is_true(mapping_rule:matches('GET', '/a/b/c/d/e/'))
+    end)
+
+    it("matches duped forward slashes in pattern and request", function()
+      local mapping_rule = rest_rule.new('GET', '/a//b///c////d/////e/')
+
+      assert.is_true(mapping_rule:matches('GET', '/a//b///c////d/////e/'))
+    end)
+
+    it("matches duped forward slashes in request", function()
+      local mapping_rule = rest_rule.new('GET', '/a/b/c/d/e/')
+
+      assert.is_true(mapping_rule:matches('GET', '/a//b///c////d/////e/'))
+      assert.is_true(mapping_rule:matches('GET', '/a//b///c////d/////e//'))
+    end)
+
+    it("matches prefix", function()
+      local mapping_rule = rest_rule.new('GET', '/abc')
+
+      assert.is_true(mapping_rule:matches('GET', '/abcd'))
+    end)
+
+    it("matches dollar sign at end", function()
+      local mapping_rule = rest_rule.new('GET', '/abc\\$')
+
+      assert.is_true(mapping_rule:matches('GET', '/abc$'))
+      assert.is_false(mapping_rule:matches('GET', '/abcd'))
+    end)
+
+    it("matches exactly", function()
+      local mapping_rule = rest_rule.new('GET', '/abc$')
+
+      assert.is_true(mapping_rule:matches('GET', '/abc'))
+      assert.is_false(mapping_rule:matches('GET', '/abc$'))
+      assert.is_false(mapping_rule:matches('GET', '/abcd'))
+      assert.is_false(mapping_rule:matches('GET', '/abc/'))
+    end)
+
+    it("matches escaped dollar", function()
+      local mapping_rule = rest_rule.new('GET', '/abc/v{version}/id\\$/{n}/$')
+
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/id"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/id\\"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/id\\\\"))
+      assert.is_false(mapping_rule:matches('GET', "/abc/v1/id$/1"))
+
+      assert.is_true(mapping_rule:matches('GET', "/abc/v1/id$/1/"))
+      assert.is_true(mapping_rule:matches('GET', "/abc/v1/id$/1//"))
+      assert.is_true(mapping_rule:matches('GET', "/abc/v1/id$/one/"))
+    end)
+
+
+    it("does not match escaped characters", function()
+      local mapping_rule = rest_rule.new('GET', '/abc\\{d\\}')
+
+      assert.is_false(mapping_rule:matches('GET', '/abc'))
+      assert.is_false(mapping_rule:matches('GET', '/abc$'))
+      assert.is_false(mapping_rule:matches('GET', '/abcd'))
+      assert.is_false(mapping_rule:matches('GET', '/abc/'))
+      assert.is_false(mapping_rule:matches('GET', '/abcdef'))
+      assert.is_false(mapping_rule:matches('GET', '/abc{}'))
+      assert.is_false(mapping_rule:matches('GET', '/abc{x}'))
+      assert.is_false(mapping_rule:matches('GET', '/abc{dd}'))
+      assert.is_false(mapping_rule:matches('GET', '/abc\\{d\\}'))
+    end)
+
+    pending("matches escaped characters literally", function()
+      local mapping_rule = rest_rule.new('GET', '/abc\\{d\\}')
+
+      -- Unfortunately this is failing at the moment
+      assert.is_true(mapping_rule:matches('GET', '/abc{d}'))
+    end)
+  end)
+end)

--- a/threescalers/Dockerfile
+++ b/threescalers/Dockerfile
@@ -1,0 +1,7 @@
+FROM quay.io/3scale/s2i-openresty-centos7:master
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain stable --profile minimal -y
+RUN source $HOME/.cargo/env \
+ && ln -s .profile .bashrc \
+ && rustc --version \
+ && cargo install cargo-c


### PR DESCRIPTION
**WARNING: This PR is _NOT MEANT TO BE MERGED_.**

_This is part of the work towards specifying mapping rules across client/proxy implementations and the 3scale administrative interface, see 3scale-rs/threescalers#79 for tracking information._

This branch adds the following:

- [x] A minimal file `README.threescalers.md` explaining how to run these tests.
- [x] A submodule with the `threescalers` library with an independent implementation of mapping rules logic and a C API.
- [x] A development container image (in `make development`) that can build `threescalers`.
- [x] Changes in `Makefile` to ensure the library is built when running `make busted`, along housekeeping targets.
- [x] A `gateway/src/threescalers` folder importing the `threescalers` library via an FFI ABI.
- [x] A `spec/threescalers` folder with specific unit tests for this library runnable via `make threescalers-test`.
- [x] A set of additional specs for the `mapping_rules_spec` file taken from the `threescalers` tests[**1**].
- [x] A small fix in the APIcast mapping rules implementation to avoid a crash under very specific conditions.
- [x] An inline comparison between the `APIcast` and the `threescalers` implementation warning on STDOUT when they differ.
- [x] Uses the `threescalers` implementation as final truth value, as it passes all previous specs and the added ones[**2**].
- [x] One pending spec on matching escaped `{}` in the `threescalers` and `APIcast` specs that neither impl passes yet.
- [x] Several pending specs regarding wildcards in query string parameter keys for `APIcast`[**3**].
- [x] Several pending specs regarding inner and outer unbalanced and escaped wildcards[**4**].

##### Notes
> [1] These need checking for any missing tests, but additionally, the way the Lua interface is designed limits how unit tests/specs can be written, so these lack some tests set as pending and might need further integration tests. In particular, there's no way to test wildcards in query string **parameter keys** (as opposed to values).
> [2] The current solution is not ideal because of the way the interface is designed using Lua tables and arrays. A `threescalers` only solution does not need to spend time preparing  the data, since that is done behind the scenes by the library.
> [3] Note [**1**] above applies, but notice that some tests are defined in terms of what `threescalers` does at the moment, not in terms of what is correct to do, so they fail on `APIcast` because the implementation never considered some features.
> [4] See table below about wildcard edge cases.

## Failures

The `APIcast` implementation, when changing the code to make it the source of truth, will fail several specs. While some of those are obviously missing cases in the implementation, others deal with what to do with query string parameters in special cases, which is undefined as there is no specification.

## Current support comparison

Concept    |   APIcast   |   threescalers
-----------|-----------|--------------
Path prefixes             | :heavy_check_mark: | :heavy_check_mark:
Dedup `//` in pattern | :heavy_check_mark: | :heavy_check_mark: 
Dedup `//` in path | :x: | :heavy_check_mark: 
Support for other wildcards | :x: | :x: (TBD)
Escaping braces | :x: | :heavy_check_mark: 
Match on literal braces | :x: | :x: (bug/wip)
Escaping `$` | :x: | :heavy_check_mark: 
Non significant QS order | :heavy_check_mark: | :heavy_check_mark: 
QS value wildcards | :heavy_check_mark: | :heavy_check_mark: 
QS value partial wildcards | :x: | :heavy_check_mark: 
QS value strictness | :heavy_check_mark: (implied) | :x: (TBD/wip via `$`)
QS value prefixes | :x: | :heavy_check_mark: 
QS key wildcards | :x: | :heavy_check_mark: 
QS key partial wildcards | :x: | :heavy_check_mark: 
QS key strictness | :heavy_check_mark: | :heavy_check_mark: 
QS key prefixes | :x: | :x: (future support:question:)

## Wildcard edge case support

Concept | APIcast | threescalers
---------|---------|-------------
`/_{wild{card}}_/` | :x: | :x:
`/_{wild\\{card\\}}_/` | :x: | :x:
`/_{wild{card}_/` | :heavy_check_mark: | :heavy_check_mark: 
`/_{wild}card}_/` | :heavy_check_mark: | :heavy_check_mark: 
`/_{wild\\{card}_/` | :heavy_check_mark: | :heavy_check_mark: 
`/_{wild\\}card}_/` | :x: | :x:
`/_\\{wild{card}_/` | :x: | :x:
`/_{wild}card\\}_/` | :x: | :x:
`/_{wildcard_/` | :question: | :exclamation: (fails validation)
`/_{wild}_{card}_/` | :heavy_check_mark: | :heavy_check_mark: 

## Mismatches

The code introduces a check in the mapping rules logic to compare `Apicast` and `threescalers` implementation, and outputs text to stdout if there is a mismatch. By default the code uses `threescalers` as it passes all the relevant non-pending specs, but this can be changed (and it is encouraged to do so to compare) at the end of the mapping_rules.lua#matching function.

A few mismatches happen when running `make busted` (whether setting one implementation or the other as source of truth, although the specific mismatching cases will be slightly different). The list below show the important different classes:

```
!!! Test         : { method: GET, uri: /abc/v1/id$/1//, qs_args:  }
!!! Apicast rule : { method: ANY, pattern: /abc/v{version}/id\$/{n}/$, params: nil, qs params:  }
!!! 3scalers rule: RestRule { method: Any, path: \A/abc/v[0-9a-zA-Z_\-.~%!$&'()*+,;=@:]+/id\$/[0-9a-zA-Z_\-.~%!$&'()*+,;=@:]+/$, qs: Some([\A]) }
```
* APIcast  -> :x:
* 3scalers -> :heavy_check_mark: 
* Expected -> :heavy_check_mark:

> This is successful for `threescalers` because it de-duplicates path separators from input paths before evaluating them, whereas `APIcast` might be confused by the escaped dollar sign or alternatively it matches both forward slashes. This currently causes a spec to fail if using `APIcast`s.

```
!!! Test         : { method: GET, uri: /abc, qs_args: s=1&t=$9&fmt=html&lang= }
!!! Apicast rule : { method: ANY, pattern: /abc, params: nil, qs params: s=1&t=$9&fmt={fmt}&lang={code} }
!!! 3scalers rule: RestRule { method: Any, path: \A/abc, qs: Some([\As=1, \At=\$9, \Afmt=[0-9a-zA-Z_\-.~%!$'()*+,;=@:]+, \Alang=[0-9a-zA-Z_\-.~%!$'()*+,;=@:]+]) }
```
* APIcast  -> :heavy_check_mark: 
* 3scalers -> :x:
* Expected -> :x:

> This fails on `threescalers` because the `{...}` notation _requires_ that at least one character is present. This might be reinterpreted to be different for query string parameter values, but there is no specification around that making an exception. This currently causes a spec to fail if using `APIcast`'s.

```
!!! Test         : { method: GET, uri: /abc, qs_args: lang=ca }
!!! APIcast rule : { method: ANY, pattern: /abc, params: nil, qs params: lang={code}t }
!!! 3scalers rule: RestRule { method: Any, path: \A/abc, qs: Some([\Alang=[0-9a-zA-Z_\-.~%!$'()*+,;=@:]+t]) }
```
* APIcast  -> :heavy_check_mark: 
* 3scalers -> :x:
* Expected -> :x:

> This fails on `threescalers` because it looks for a value in the `lang` parameter that has _one or more characters before a `t`_ (which includes but is not limited to the case of ending with a `t`). Presumably the `APIcast` implementation just takes a wildcard for the whole value.

```
!!! Test         : { method: GET, uri: /abc, qs_args: lang=123 }
!!! APIcast rule : { method: ANY, pattern: /abc, params: nil, qs params: lang=1 }
!!! 3scalers rule: RestRule { method: Any, path: \A/abc, qs: Some([\Alang=1]) }
```
* APIcast  -> :x:
* 3scalers -> :heavy_check_mark:
* Expected -> :x: or :question: 

> This is the case of using parameter values as fully specified or as prefixes. This is unspecified, and although `threescalers` uses prefixes, turns out it understands `$` as a literal, so the current implementation only matches prefixes. Conversely the `APIcast` implementation only matches strictly, so it cannot use prefixes. This is arguably more useful with strict matching unless an implementation supports strictness via `$`.