### PR TITLE
ppc64le: Fix issues with shared memory

### DIFF
--- a/gateway/http.d/init.conf
+++ b/gateway/http.d/init.conf
@@ -105,4 +105,4 @@ init_worker_by_lua_block {
     require('apicast.executor'):init_worker()
 }
 
-lua_shared_dict init 16k;
+lua_shared_dict init 256k;


### PR DESCRIPTION
On ppc64le the pagesize is bigger, and shared memory should be bigger

FIX THREESCALE-7535

Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>