### PR TITLE
THREESCALE-7906

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,8 @@ jobs:
       - run: make test-runtime-image gateway-logs --keep-going
       - login-docker:
           command: |
-            IMAGE_TAG="${CIRCLE_TAG:-${CIRCLE_BRANCH}}"
+            CIRCLE_BRANCH_LOWER=`echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]'`
+            IMAGE_TAG="${CIRCLE_TAG:-${CIRCLE_BRANCH_LOWER}}"
             if [ "${IMAGE_TAG}" == "master" ]
             then
               IMAGE_TAG="latest"
@@ -179,7 +180,8 @@ jobs:
 
       - login-docker:
           command: |
-            IMAGE_TAG="${CIRCLE_TAG:-${CIRCLE_BRANCH}}-builder"
+            CIRCLE_BRANCH_LOWER=`echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]'`
+            IMAGE_TAG="${CIRCLE_TAG:-${CIRCLE_BRANCH_LOWER}}-builder"
             if [ "${IMAGE_TAG}" == "master-builder" ]
             then
               IMAGE_TAG="latest-builder"
@@ -281,7 +283,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: IMAGE_TAG=${CIRCLE_TAG:-${CIRCLE_BRANCH}} make benchmark
+      - run: IMAGE_TAG=`echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]'` make benchmark
       - run: IMAGE_TAG=master make benchmark
       - store_artifacts:
           path: tmp/benchmark

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed issues with OIDC filters [PR #1304](https://github.com/3scale/APIcast/pull/1304) [THREESCALE-6042](https://issues.redhat.com/browse/THREESCALE-6042)
 - Fixed issues with Upstream MTLS certs [PR #1307](https://github.com/3scale/APIcast/pull/1307) [THREESCALE-7508](https://issues.redhat.com/browse/THREESCALE-7508)
+- Fixed warning messages [PR #1318](https://github.com/3scale/APIcast/pull/1318) [THREESCALE-7906](https://issues.redhat.com/browse/THREESCALE-7906)
 
 ### Added
 

--- a/gateway/http.d/apicast.conf.liquid
+++ b/gateway/http.d/apicast.conf.liquid
@@ -4,6 +4,15 @@ map $status $extended_access_log {
     default '';
 }
 
+map $status $access_logs_enabled {
+  default '1';
+}
+
+map $status $extended_access_logs_enabled {
+  default '0';
+}
+
+
 log_format extended escape=none '$extended_access_log';
 
 server {
@@ -50,9 +59,7 @@ server {
 server {
   {% capture log_buffer %} {%if log_buffer_size %}buffer={{ log_buffer_size }} {% endif %} {% endcapture %}
 
-  set $access_logs_enabled '1';
   access_log {{ access_log_file | default: "/dev/stdout" }} time if=$access_logs_enabled {{ log_buffer }};
-  set $extended_access_logs_enabled '0';
   access_log {{ access_log_file | default: "/dev/stdout" }} extended if=$extended_access_logs_enabled {{ log_buffer }};
 
   {%- assign http_port = port.apicast | default: 8080 %}


### PR DESCRIPTION
Under some error circumstances (like 414 Request-URI Too Large) the  access log were generated in a phase previous to having defined the access_log_enabled and the extended_access_logs_enabled.

This causes a warning to arise, but most important, prevented that access to be logged.

We use the workaround of declaring the variables as a map with a default value, because maps can be used in the NGINX http context and therefore will be available and initialized even on the given error case.