### PR TITLE
1316: support resilient redis mode for cache util

### DIFF
--- a/gateway/src/apicast/threescale_utils.lua
+++ b/gateway/src/apicast/threescale_utils.lua
@@ -151,29 +151,36 @@ function _M.connect_redis(options)
   red:set_timeout(opts.timeout)
 
   local ok, err = red:connect(_M.resolve(host, port))
-  if not ok and not resilient then
-    return nil, _M.error("failed to connect to redis on ", host, ":", port, ": ", err)
-  elseif not ok and resilient then
-    return nil, _M.error_gracefully("failed to connect to redis on ", host, ":", port, ": ", err)
+
+  if not ok then
+    if not resilient then
+      return nil, _M.error("failed to connect to redis on ", host, ":", port, ": ", err)
+    else
+      return nil, _M.error_gracefully("failed to connect to redis on ", host, ":", port, ": ", err)
+    end
   end
 
   if opts.password then
     ok = red:auth(opts.password)
 
-    if not ok and not resilient then
-      return nil, _M.error("failed to auth on redis ", host, ":", port)
-    elseif not ok and resilient then
-      return nil, _M.error_gracefully("failed to auth on redis ", host, ":", port)
+    if not ok then
+      if not resilient then
+        return nil, _M.error("failed to auth on redis ", host, ":", port)
+      else
+        return nil, _M.error_gracefully("failed to auth on redis ", host, ":", port)
+      end
     end
   end
 
   if opts.db then
     ok = red:select(opts.db)
 
-    if not ok and not resilient then
-      return nil, _M.error("failed to select db ", opts.db, " on redis ", host, ":", port)
-    elseif not ok and resilient then
-      return nil, _M.error_gracefully("failed to select db ", opts.db, " on redis ", host, ":", port)
+    if not ok then
+      if not resilient then
+        return nil, _M.error("failed to select db ", opts.db, " on redis ", host, ":", port)
+      else
+        return nil, _M.error_gracefully("failed to select db ", opts.db, " on redis ", host, ":", port)
+      end
     end
   end
 

--- a/spec/threescale_utils_spec.lua
+++ b/spec/threescale_utils_spec.lua
@@ -10,5 +10,27 @@ describe('3scale utils', function()
 
             assert.equal('one two three', error)
         end)
+
+        it('.error fails the nginx chain', function()
+            stub(ngx, 'get_phase', function() return 'init' end)
+            stub(ngx, 'say', function(...) return nil end)
+            local exit = spy.on(ngx, 'exit', function(s) return 'exited!' end)
+
+            local error = _M.error('cache issue ' .. 'host:' .. 6379)
+
+            assert.spy(ngx.exit).was_called(1)
+            assert.spy(ngx.say).was.called_with('cache issue ' .. 'host:' .. 6379)
+        end)
+
+        it('.error_silently logs the error without exiting chain', function()
+            stub(ngx, 'get_phase', function() return 'init' end)
+            stub(ngx, 'say', function(...) return nil end)
+
+            local exit = spy.on(ngx, 'exit', function(s) return 'exited!' end)
+            local error = _M.error_silently('redis is not reachable')
+
+            assert.spy(ngx.exit).was_not_called()
+            assert.spy(ngx.say).was.called_with('redis is not reachable')
+        end)
     end)
 end)

--- a/spec/threescale_utils_spec.lua
+++ b/spec/threescale_utils_spec.lua
@@ -22,12 +22,12 @@ describe('3scale utils', function()
             assert.spy(ngx.say).was.called_with('cache issue ' .. 'host:' .. 6379)
         end)
 
-        it('.error_silently logs the error without exiting chain', function()
+        it('.error_gracefully logs the error without exiting chain', function()
             stub(ngx, 'get_phase', function() return 'init' end)
             stub(ngx, 'say', function(...) return nil end)
 
             local exit = spy.on(ngx, 'exit', function(s) return 'exited!' end)
-            local error = _M.error_silently('redis is not reachable')
+            local error = _M.error_gracefully('redis is not reachable')
 
             assert.spy(ngx.exit).was_not_called()
             assert.spy(ngx.say).was.called_with('redis is not reachable')


### PR DESCRIPTION
This resolves #1316 and make it useful to use the cache without fail in case of network disconnect, etc.

Tests passing:
_(results included in commit message)_
<img width="848" alt="Screen Shot 2022-02-10 at 12 07 17 PM" src="https://user-images.githubusercontent.com/20784990/153374792-e1d065d1-6095-4547-b4d7-f59c69ec277f.png">

