### PR TITLE
THREESCALE-6448: Change endpoint to System for services

### DIFF
--- a/gateway/src/apicast/configuration_loader/remote_v2.lua
+++ b/gateway/src/apicast/configuration_loader/remote_v2.lua
@@ -104,7 +104,7 @@ local function endpoint_for_services_with_host(portal_endpoint, env, host)
   local query_args = encode_args({ host = host })
 
   return format(
-      "%s/admin/api/services/proxy/configs/%s.json?%s",
+      "%s/admin/api/account/proxy_configs/%s.json?%s",
       portal_endpoint,
       env,
       query_args

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -345,7 +345,7 @@ UwIDAQAB
         -- The important thing for this test is that it sends the request to
         -- the endpoint that returns services by host
         local endpoint = format(
-            "http://example.com/admin/api/services/proxy/configs/staging.json?%s",
+            "http://example.com/admin/api/account/proxy_configs/staging.json?%s",
             encode_args({ host = host })
         )
 

--- a/t/configuration-loading-when-needed.t
+++ b/t/configuration-loading-when-needed.t
@@ -20,7 +20,7 @@ not defined in this test.
   'APICAST_LOAD_SERVICES_WHEN_NEEDED' => 'true',
 )
 --- upstream env
-location = /admin/api/services/proxy/configs/production.json {
+location = /admin/api/account/proxy_configs/production.json {
   content_by_lua_block {
     expected = "host=localhost"
     require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))


### PR DESCRIPTION
> Link to JIRA: https://issues.redhat.com/browse/THREESCALE-6448

The endpoing changes from `/admin/api/services/proxy/configs/:environment` to /admin/api/account/proxy_configs/:environment`.

Update the configuration loader to use the new endpoint and the tests that verify it.

## Verification steps

* Run APIcast alongside Porta with the following configuration:
    ```env
    THREESCALE_PORTAL_ENDPOINT=http://secret@provider-admin.3scale.localhost:3000
    APICAST_LOAD_SERVICES_WHEN_NEEDED=true
    APICAST_CONFIGURATION_CACHE=0
    APICAST_CONFIGURATION_LOADER=lazy
    ```
* Make a request against APIcast and verify that it performs the correct request against the System API to the new endpoint