### PR TITLE
THREESCALE-8000 + THREESCALE-8007 + THREESCALE-8252 (clear context policy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issues with OIDC filters [PR #1304](https://github.com/3scale/APIcast/pull/1304) [THREESCALE-6042](https://issues.redhat.com/browse/THREESCALE-6042)
 - Fixed issues with Upstream MTLS certs [PR #1307](https://github.com/3scale/APIcast/pull/1307) [THREESCALE-7508](https://issues.redhat.com/browse/THREESCALE-7508)
 - Fixed warning messages [PR #1318](https://github.com/3scale/APIcast/pull/1318) [THREESCALE-7906](https://issues.redhat.com/browse/THREESCALE-7906)
+- Fixed dirty context [PR #1328](https://github.com/3scale/APIcast/pull/1328) [THREESCALE-8000](https://issues.redhat.com/browse/THREESCALE-8000) [THREESCALE-8007](https://issues.redhat.com/browse/THREESCALE-8007)
 
 ### Added
 

--- a/gateway/src/apicast/policy/clear_context/clear_context.lua
+++ b/gateway/src/apicast/policy/clear_context/clear_context.lua
@@ -2,27 +2,19 @@ local _M = require('apicast.policy').new('Clear Context')
 local new = _M.new
 
 function _M.new(...)
-  ssl_ctx_reset = false
   return new(...)
 end
 
 function _M:ssl_certificate(context)
-  reset_context(context)
-  ssl_ctx_reset = true
+  --resetting the context after every other policy in the chain
+  --has executed their ssl_certificate phase. 
+  clear_table(ngx.ctx)
 end
 
-function _M:rewrite(context)
-  --Do not reset the context again if the ssl_certificate phase
-  --was executed for this request. This way other policies that edited 
-  --the context in their ssl_* phases won't have their changes cleared
-  if not ssl_ctx_reset then
-    reset_context(context)
+function clear_table(t)
+  for k, _ in pairs(t) do
+    t[k] = nil
   end
-  ssl_ctx_reset = false
-end
-
-function reset_context(context)
-  context.current = {}
 end
 
 return _M

--- a/gateway/src/apicast/policy/clear_context/clear_context.lua
+++ b/gateway/src/apicast/policy/clear_context/clear_context.lua
@@ -1,0 +1,28 @@
+local _M = require('apicast.policy').new('Clear Context')
+local new = _M.new
+
+function _M.new(...)
+  ssl_ctx_reset = false
+  return new(...)
+end
+
+function _M:ssl_certificate(context)
+  reset_context(context)
+  ssl_ctx_reset = true
+end
+
+function _M:rewrite(context)
+  --Do not reset the context again if the ssl_certificate phase
+  --was executed for this request. This way other policies that edited 
+  --the context in their ssl_* phases won't have their changes cleared
+  if not ssl_ctx_reset then
+    reset_context(context)
+  end
+  ssl_ctx_reset = false
+end
+
+function reset_context(context)
+  context.current = {}
+end
+
+return _M

--- a/gateway/src/apicast/policy/clear_context/init.lua
+++ b/gateway/src/apicast/policy/clear_context/init.lua
@@ -1,0 +1,1 @@
+return require('clear_context')

--- a/gateway/src/apicast/policy_chain.lua
+++ b/gateway/src/apicast/policy_chain.lua
@@ -67,6 +67,7 @@ end
 
 
 local DEFAULT_POLICIES = {
+    'apicast.policy.clear_context',
     'apicast.policy.load_configuration',
     'apicast.policy.find_service',
     'apicast.policy.local_chain',

--- a/gateway/src/apicast/policy_chain.lua
+++ b/gateway/src/apicast/policy_chain.lua
@@ -67,11 +67,11 @@ end
 
 
 local DEFAULT_POLICIES = {
-    'apicast.policy.clear_context',
     'apicast.policy.load_configuration',
     'apicast.policy.find_service',
     'apicast.policy.local_chain',
-    'apicast.policy.nginx_metrics'
+    'apicast.policy.nginx_metrics',
+    'apicast.policy.clear_context'
 }
 
 --- Return new policy chain with default policies.

--- a/spec/policy/clear_context/clear_context_spec.lua
+++ b/spec/policy/clear_context/clear_context_spec.lua
@@ -5,9 +5,9 @@ local ngx_variable = require('apicast.policy.ngx_variable')
 describe('Clear Context policy', function()
   local current_ctx = {some_key = 'some_value'}
 
-  describe('.ssl_certificate + .rewrite', function()
+  describe('log phase context reset', function()
     before_each(function()
-      ctx = {}
+      ctx = ngx.ctx
       stub(ngx_variable, 'available_context', function(context) return context end)
     end)
 
@@ -17,56 +17,7 @@ describe('Clear Context policy', function()
       it('clears the context', function()
         ctx.current = current_ctx
         clear_context_policy:ssl_certificate(ctx)
-        assert.are.same({}, ctx.current)
-      end)
-    end)
-
-    context('.rewrite', function()
-      local clear_context_policy = ClearContextPolicy.new()
-  
-      it('clears the context', function()
-        ctx.current = current_ctx
-        clear_context_policy:rewrite(ctx)
-        assert.are.same({}, ctx.current)
-      end)
-    end)
-
-    context('.ssl_certificate and .rewrite', function()
-      local clear_context_policy = ClearContextPolicy.new()
-      
-      it('clears the context once', function()
-        ctx.current = current_ctx
-        clear_context_policy:ssl_certificate(ctx)
-        assert.are.same({}, ctx.current)
-        ctx.current = current_ctx
-        clear_context_policy:rewrite(ctx)
-        assert.are.same(current_ctx, ctx.current)
-      end)
-    end)
-
-    context('.ssl_certificate and .ssl_certificate', function()
-      local clear_context_policy = ClearContextPolicy.new()
-      
-      it('clears the context twice', function()
-        ctx.current = current_ctx
-        clear_context_policy:ssl_certificate(ctx)
-        assert.are.same({}, ctx.current)
-        ctx.current = current_ctx
-        clear_context_policy:ssl_certificate(ctx)
-        assert.are.same({}, ctx.current)
-      end)
-    end)
-
-    context('.rewrite and .rewrite', function()
-      local clear_context_policy = ClearContextPolicy.new()
-      
-      it('clears the context twice', function()
-        ctx.current = current_ctx
-        clear_context_policy:rewrite(ctx)
-        assert.are.same({}, ctx.current)
-        ctx.current = current_ctx
-        clear_context_policy:rewrite(ctx)
-        assert.are.same({}, ctx.current)
+        assert.is_nil(ctx.current)
       end)
     end)
   end)

--- a/spec/policy/clear_context/clear_context_spec.lua
+++ b/spec/policy/clear_context/clear_context_spec.lua
@@ -1,0 +1,75 @@
+local ClearContextPolicy = require('apicast.policy.clear_context')
+local ngx_variable = require('apicast.policy.ngx_variable')
+   
+
+describe('Clear Context policy', function()
+  local current_ctx = {some_key = 'some_value'}
+
+  describe('.ssl_certificate + .rewrite', function()
+    before_each(function()
+      ctx = {}
+      stub(ngx_variable, 'available_context', function(context) return context end)
+    end)
+
+    context('.ssl_certificate', function()
+      local clear_context_policy = ClearContextPolicy.new()
+
+      it('clears the context', function()
+        ctx.current = current_ctx
+        clear_context_policy:ssl_certificate(ctx)
+        assert.are.same({}, ctx.current)
+      end)
+    end)
+
+    context('.rewrite', function()
+      local clear_context_policy = ClearContextPolicy.new()
+  
+      it('clears the context', function()
+        ctx.current = current_ctx
+        clear_context_policy:rewrite(ctx)
+        assert.are.same({}, ctx.current)
+      end)
+    end)
+
+    context('.ssl_certificate and .rewrite', function()
+      local clear_context_policy = ClearContextPolicy.new()
+      
+      it('clears the context once', function()
+        ctx.current = current_ctx
+        clear_context_policy:ssl_certificate(ctx)
+        assert.are.same({}, ctx.current)
+        ctx.current = current_ctx
+        clear_context_policy:rewrite(ctx)
+        assert.are.same(current_ctx, ctx.current)
+      end)
+    end)
+
+    context('.ssl_certificate and .ssl_certificate', function()
+      local clear_context_policy = ClearContextPolicy.new()
+      
+      it('clears the context twice', function()
+        ctx.current = current_ctx
+        clear_context_policy:ssl_certificate(ctx)
+        assert.are.same({}, ctx.current)
+        ctx.current = current_ctx
+        clear_context_policy:ssl_certificate(ctx)
+        assert.are.same({}, ctx.current)
+      end)
+    end)
+
+    context('.rewrite and .rewrite', function()
+      local clear_context_policy = ClearContextPolicy.new()
+      
+      it('clears the context twice', function()
+        ctx.current = current_ctx
+        clear_context_policy:rewrite(ctx)
+        assert.are.same({}, ctx.current)
+        ctx.current = current_ctx
+        clear_context_policy:rewrite(ctx)
+        assert.are.same({}, ctx.current)
+      end)
+    end)
+  end)
+end)
+
+

--- a/t/apicast-policy-oauth-mtls.t
+++ b/t/apicast-policy-oauth-mtls.t
@@ -70,7 +70,7 @@ proxy_ssl_trusted_certificate $TEST_NGINX_SERVER_ROOT/html/ca.crt;
 proxy_ssl_certificate $TEST_NGINX_SERVER_ROOT/html/client.crt;
 proxy_ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/client.key;
 proxy_pass https://$server_addr:$apicast_port/t;
-proxy_set_header Host localhost;
+proxy_set_header Host test;
 proxy_set_header Authorization "Bearer eyJraWQiOiJzb21la2lkIiwiYWxnIjoiUlMyNTYifQ.eyJleHAiOjE5MjY4NzMwNTQsInN1YiI6InNvbWVvbmUiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsiZGlyZWN0b3IiXX0sImZvbyI6IjEiLCJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tL2F1dGgvcmVhbG1zL2FwaWNhc3QiLCJhdWQiOiJhdWRpZW5jZSIsImNuZiI6eyJ4NXQjUzI1NiI6Ilk0X0xWbGtwRTZxa3NjUGJ0b0ttM2lpS0JnZndiT2ZiZEtCRWRuWjZaUFkifX0.Iin-tr6EVhEXjbj9R6xZSToBxZZBDXhl6i9ROw6SJQE6RWJeLt6mKK4jdTMVdxoZfm1J_NqayGJh3N99kHdIbA";
 log_by_lua_block { collectgarbage() }
 --- response_body
@@ -140,7 +140,7 @@ proxy_ssl_trusted_certificate $TEST_NGINX_SERVER_ROOT/html/ca.crt;
 proxy_ssl_certificate $TEST_NGINX_SERVER_ROOT/html/client.crt;
 proxy_ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/client.key;
 proxy_pass https://$server_addr:$apicast_port/t;
-proxy_set_header Host localhost;
+proxy_set_header Host test;
 proxy_set_header Authorization "Bearer eyJraWQiOiJzb21la2lkIiwiYWxnIjoiUlMyNTYifQ.eyJleHAiOjE5MjQxMjQ1ODIsInN1YiI6InNvbWVvbmUiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsiZGlyZWN0b3IiXX0sImZvbyI6IjEiLCJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tL2F1dGgvcmVhbG1zL2FwaWNhc3QiLCJhdWQiOiJhdWRpZW5jZSIsImNuZiI6eyJ4NXQjUzI1NiI6ImludmFsaWQifX0.h9Lay5rff08ipXd2juLS_A0fpJKn6UPD1AIxBCibdTi1wyhF5fCLmxzfwozgtqVTlcOGTu9ZtVfp88tRZ2mE-A";
 log_by_lua_block { collectgarbage() }
 --- response_body chomp
@@ -208,7 +208,7 @@ log_by_lua_block { collectgarbage() }
 proxy_ssl_verify on;
 proxy_ssl_trusted_certificate $TEST_NGINX_SERVER_ROOT/html/ca.crt;
 proxy_pass https://$server_addr:$apicast_port/t;
-proxy_set_header Host localhost;
+proxy_set_header Host test;
 proxy_set_header Authorization "Bearer eyJraWQiOiJzb21la2lkIiwiYWxnIjoiUlMyNTYifQ.eyJleHAiOjE5MjY4NzMwNTQsInN1YiI6InNvbWVvbmUiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsiZGlyZWN0b3IiXX0sImZvbyI6IjEiLCJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tL2F1dGgvcmVhbG1zL2FwaWNhc3QiLCJhdWQiOiJhdWRpZW5jZSIsImNuZiI6eyJ4NXQjUzI1NiI6Ilk0X0xWbGtwRTZxa3NjUGJ0b0ttM2lpS0JnZndiT2ZiZEtCRWRuWjZaUFkifX0.Iin-tr6EVhEXjbj9R6xZSToBxZZBDXhl6i9ROw6SJQE6RWJeLt6mKK4jdTMVdxoZfm1J_NqayGJh3N99kHdIbA";
 log_by_lua_block { collectgarbage() }
 --- response_body chomp
@@ -278,7 +278,7 @@ proxy_ssl_trusted_certificate $TEST_NGINX_SERVER_ROOT/html/ca.crt;
 proxy_ssl_certificate $TEST_NGINX_SERVER_ROOT/html/client.crt;
 proxy_ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/client.key;
 proxy_pass https://$server_addr:$apicast_port/t;
-proxy_set_header Host localhost;
+proxy_set_header Host test;
 proxy_set_header Authorization "Bearer eyJraWQiOiJzb21la2lkIiwiYWxnIjoiUlMyNTYifQ.eyJleHAiOjE5MjQxMjU0MzQsInN1YiI6InNvbWVvbmUiLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsiZGlyZWN0b3IiXX0sImZvbyI6IjEiLCJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tL2F1dGgvcmVhbG1zL2FwaWNhc3QiLCJhdWQiOiJhdWRpZW5jZSJ9.GDYu4nT73_vPV4ZGa5DL8TAWZvn2TI47WxbXFH6wnUMn818slif-gUp_14pGleOR6VcLrEAC3VwEidtn08Ah8A";
 log_by_lua_block { collectgarbage() }
 --- response_body chomp

--- a/t/apicast-policy-routing.t
+++ b/t/apicast-policy-routing.t
@@ -3,6 +3,8 @@ use Test::APIcast::Blackbox 'no_plan';
 
 our $rsa = `cat t/fixtures/rsa.pem`;
 
+$ENV{APICAST_HTTPS_RANDOM_PORT} = Test::APIcast::get_random_port();
+
 run_tests();
 
 __DATA__
@@ -2470,5 +2472,105 @@ operations is an empty array instead of nil
 ["/foo+foo\n", "/foo+foo\n", "/foo/foo\n", "/foo%20foo\n"]
 --- error_code eval
 [200, 200, 200, 200]
+--- no_error_log
+[error]
+
+
+=== TEST 36: Multiple requests that reuse the same TCP connection. 
+Routing must work as expected to the right backend
+--- env eval
+(
+    'APICAST_HTTPS_PORT' => $ENV{APICAST_HTTPS_RANDOM_PORT},
+    'HTTP_KEEPALIVE_TIMEOUT' => '5'
+)
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version": 1,
+      "proxy": {
+        "hosts": [
+          "127.0.0.1"
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.routing",
+            "configuration": {
+              "rules": [
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/foo/",
+                  "condition": {
+                    "operations": [
+                      {
+                        "match": "path",
+                        "op": "==",
+                        "value": "/one"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "url": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/bar/",
+                  "condition": {
+                    "operations": [
+                      {
+                        "match": "path",
+                        "op": "==",
+                        "value": "/two"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.echo"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+location ~ /api-backend(/.+) {
+  echo 'yay, api backend: $1';
+}
+--- test
+content_by_lua_block {
+  local http = require "resty.http"
+  local resty_env = require 'resty.env'
+
+  local https_port = resty_env.get('APICAST_HTTPS_PORT')
+  local uri_one = "https://127.0.0.1:".. https_port .."/one?user_key=foo"
+  local uri_two = "https://127.0.0.1:".. https_port .."/two?user_key=foo"
+
+  local httpc = http.new()
+  local res1, err1 = httpc:request_uri(uri_one, {
+      method = "GET",
+      ssl_verify = false,
+      version = 1.1
+  })
+  assert(res1, "Request failed"..(err1 or ""))
+  assert(string.find(res1.body, "/foo/one"), "Expected: /foo/one, got: "..(res1.body or ""))
+
+  local res2, err2 = httpc:request_uri(uri_two, {
+    method = "GET",
+    ssl_verify = false, 
+    version = 1.1
+  })
+  assert(res2, "Request failed"..(err2 or ""))
+  --check for incorrect routing THREESCALE-8007:
+  assert(not string.find(res2.body, "/foo/two"), "Expected != .*/foo/two, got: "..(res2.body or "")) 
+  assert(string.find(res2.body, "/bar/two"), "Expected: /bar/two, got: "..(res2.body or ""))
+  httpc:close()
+}
 --- no_error_log
 [error]

--- a/t/apicast-policy-routing.t
+++ b/t/apicast-policy-routing.t
@@ -2476,8 +2476,8 @@ operations is an empty array instead of nil
 [error]
 
 
-=== TEST 36: Multiple requests that reuse the same TCP connection. 
-Routing must work as expected to the right backend
+=== TEST 36: Routing policy must choose correct backend 
+based on current configuration & request parameters
 --- env eval
 (
     'APICAST_HTTPS_PORT' => $ENV{APICAST_HTTPS_RANDOM_PORT},
@@ -2549,25 +2549,37 @@ content_by_lua_block {
   local resty_env = require 'resty.env'
 
   local https_port = resty_env.get('APICAST_HTTPS_PORT')
-  local uri_one = "https://127.0.0.1:".. https_port .."/one?user_key=foo"
-  local uri_two = "https://127.0.0.1:".. https_port .."/two?user_key=foo"
-
   local httpc = http.new()
-  local res1, err1 = httpc:request_uri(uri_one, {
+  httpc:connect("127.0.0.1", https_port)
+  httpc:ssl_handshake(nil, "127.0.0.1", false)
+
+  local responses, err = httpc:request_pipeline({
+    {
       method = "GET",
+      path = "/one",
+      version = 1.1,
       ssl_verify = false,
-      version = 1.1
+      query = "?user_key=foo"
+    },
+    {
+      method = "GET",
+      path = "/two",
+      version = 1.1,
+      ssl_verify = false,
+      query = "?user_key=foo"
+    }
   })
-  assert(res1, "Request failed"..(err1 or ""))
+
+  local res1 = responses[1]
+  res1.body = responses[1]:read_body()
+  local res2 = responses[2]
+  res2.body = responses[2]:read_body()
+
+  assert(res1, "Request failed"..(err or ""))
   assert(string.find(res1.body, "/foo/one"), "Expected: /foo/one, got: "..(res1.body or ""))
 
-  local res2, err2 = httpc:request_uri(uri_two, {
-    method = "GET",
-    ssl_verify = false, 
-    version = 1.1
-  })
-  assert(res2, "Request failed"..(err2 or ""))
-  --check for incorrect routing THREESCALE-8007:
+  assert(res2, "Request failed"..(err or ""))
+  --Check if incorrect routing as reported in THREESCALE-8007 is happening:
   assert(not string.find(res2.body, "/foo/two"), "Expected != .*/foo/two, got: "..(res2.body or "")) 
   assert(string.find(res2.body, "/bar/two"), "Expected: /bar/two, got: "..(res2.body or ""))
   httpc:close()

--- a/t/apicast-policy-tls_validation.t
+++ b/t/apicast-policy-tls_validation.t
@@ -40,7 +40,7 @@ proxy_ssl_trusted_certificate $TEST_NGINX_SERVER_ROOT/html/ca.crt;
 proxy_ssl_certificate $TEST_NGINX_SERVER_ROOT/html/client.crt;
 proxy_ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/client.key;
 proxy_pass https://$server_addr:$apicast_port/t;
-proxy_set_header Host localhost;
+proxy_set_header Host test;
 log_by_lua_block { collectgarbage() }
 --- response_body
 GET /t HTTP/1.0
@@ -79,7 +79,7 @@ proxy_ssl_trusted_certificate $TEST_NGINX_SERVER_ROOT/html/ca.crt;
 proxy_ssl_certificate $TEST_NGINX_SERVER_ROOT/html/client.crt;
 proxy_ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/client.key;
 proxy_pass https://$server_addr:$apicast_port/t;
-proxy_set_header Host localhost;
+proxy_set_header Host test;
 log_by_lua_block { collectgarbage() }
 --- response_body
 GET /t HTTP/1.0
@@ -116,7 +116,7 @@ proxy_ssl_trusted_certificate $TEST_NGINX_SERVER_ROOT/html/ca.crt;
 proxy_ssl_certificate $TEST_NGINX_SERVER_ROOT/html/client.crt;
 proxy_ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/client.key;
 proxy_pass https://$server_addr:$apicast_port/t;
-proxy_set_header Host localhost;
+proxy_set_header Host test;
 log_by_lua_block { collectgarbage() }
 --- response_body
 unable to get local issuer certificate
@@ -151,7 +151,7 @@ to_json({
 proxy_ssl_verify on;
 proxy_ssl_trusted_certificate $TEST_NGINX_SERVER_ROOT/html/ca.crt;
 proxy_pass https://$server_addr:$apicast_port/t;
-proxy_set_header Host localhost;
+proxy_set_header Host test;
 log_by_lua_block { collectgarbage() }
 --- response_body
 Invalid certificate verification context
@@ -193,7 +193,7 @@ proxy_ssl_trusted_certificate $TEST_NGINX_SERVER_ROOT/html/ca.crt;
 proxy_ssl_certificate $TEST_NGINX_SERVER_ROOT/html/client-bundle.crt;
 proxy_ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/client.key;
 proxy_pass https://$server_addr:$apicast_port/t;
-proxy_set_header Host localhost;
+proxy_set_header Host test;
 log_by_lua_block { collectgarbage() }
 --- response_body
 GET /t HTTP/1.0


### PR DESCRIPTION
This PR adds compatibility with [this OpenResty change](https://github.com/openresty/lua-nginx-module/pull/1514/files). 
It takes care of clearing the local context at the beginning of every separate request.

We use the context to determine routing to Products (when APICAST_PATH_ROUTING is enabled) or to Backends (when using APIaaP). Both those routing scenarios can be affected by the bug when connections are reused (see also [KCS1](https://access.redhat.com/solutions/6707511) and [KCS2](https://access.redhat.com/solutions/6749581))