### PR TITLE
Fix local unittests issues

### DIFF
--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -1,7 +1,7 @@
 version: '2.2'
 services:
   development:
-    image: ${IMAGE:-quay.io/3scale/s2i-openresty-centos7:master}
+    image: ${IMAGE:-quay.io/3scale/s2i-openresty-centos7:1.19.3.6-20-centos8}
     depends_on:
       - redis
     working_dir: /home/centos/

--- a/spec/policy/rate_limit/rate_limit_spec.lua
+++ b/spec/policy/rate_limit/rate_limit_spec.lua
@@ -135,10 +135,10 @@ describe('Rate limit policy', function()
           connection_limiters = {
             { key = { name = 'test1', scope = 'global' }, conn = 20, burst = 10, delay = 0.5 }
           },
-          redis_url = 'redis://invalidhost:'..redis_port..'/1'
+          redis_url = 'redis://invalidhost.domain:'..redis_port..'/1'
         })
 
-        assert.returns_error('failed to connect to redis on invalidhost:6379: invalidhost could not be resolved (3: Host not found)', rate_limit_policy:access(context))
+        assert.returns_error('failed to connect to redis on invalidhost.domain:6379: invalidhost.domain could not be resolved (3: Host not found)', rate_limit_policy:access(context))
 
         assert.spy(ngx.exit).was_called_with(500)
       end)

--- a/spec/resty/http_ng/backend/async_resty_spec.lua
+++ b/spec/resty/http_ng/backend/async_resty_spec.lua
@@ -6,7 +6,7 @@ describe('resty backend', function()
     local method = 'GET'
 
     it('accesses the url', function()
-      local response = backend:send{method = method, url = 'http://example.com/'}
+      local response = backend:send{method = method, url = 'http://httpbin.org/get'}
       assert.truthy(response)
       assert.falsy(response.error)
       assert.truthy(response.ok)
@@ -31,7 +31,7 @@ describe('resty backend', function()
     end)
 
     it('returns proper error on connect timeout', function()
-      local req = { method = method, url = 'http://example.com:81/', timeout = { connect = 1 } }
+      local req = { method = method, url = 'http://httpbin.org:81/', timeout = { connect = 1 } }
 
       local response = backend:send(req)
 

--- a/spec/resty/http_ng/backend/resty_spec.lua
+++ b/spec/resty/http_ng/backend/resty_spec.lua
@@ -11,7 +11,7 @@ describe('resty backend', function()
     local method = 'GET'
 
     it('accesses the url', function()
-      local response, err = backend:send{method = method, url = 'http://example.com/'}
+      local response, err = backend:send{method = method, url = 'http://httpbin.org/get'}
       assert.falsy(err)
       assert.falsy(response.error)
       assert.truthy(response.ok)


### PR DESCRIPTION
There were 3 issues in the local environment that caused unittests to fail:

```
$ make busted
EXTRA_CFLAGS="-DHAVE_EVP_KDF_CTX=1" /usr/local/openresty/luajit/bin/rover install --roverfile=gateway/Roverfile > /dev/null
/usr/local/openresty/luajit/bin/rover exec bin/busted  
●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●✱●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●◌●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●◼●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●◌●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●◼●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●◼●●◼●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●
1202 successes / 4 failures / 1 error / 2 pending : 8.879907 seconds

Pending → spec/resty/http_ng_spec.lua @ 35
http_ng options method works with default options

Pending → spec/policy/rate_limit/redis_shdict_spec.lua @ 33
Redis Shared Dictionary incr without default

Failure → spec/resty/http_ng/backend/resty_spec.lua @ 13
resty backend GET method #network accesses the url
Random seed: 2246932564
spec/resty/http_ng/backend/resty_spec.lua:16: Expected to be falsy, but value was:
(string) 'example.com could not be resolved (3: Host not found)'

stack traceback:
	spec/resty/http_ng/backend/resty_spec.lua:16: in function <spec/resty/http_ng/backend/resty_spec.lua:13>


Failure → spec/policy/rate_limit/rate_limit_spec.lua @ 133
Rate limit policy .access using #redis invalid redis url
Random seed: 2246932564
spec/policy/rate_limit/rate_limit_spec.lua:141: Expected a different error.
Caught:
(string) 'failed to connect to redis on invalidhost:6379: invalidhost could not be resolved (2: Server failure)'
Expected:
(string) 'failed to connect to redis on invalidhost:6379: invalidhost could not be resolved (3: Host not found)'

stack traceback:
	spec/policy/rate_limit/rate_limit_spec.lua:141: in function <spec/policy/rate_limit/rate_limit_spec.lua:133>


Failure → spec/resty/http_ng/backend/async_resty_spec.lua @ 8
resty backend GET method #network accesses the url
Random seed: 2246932564
spec/resty/http_ng/backend/async_resty_spec.lua:11: Expected to be falsy, but value was:
(string) 'example.com could not be resolved (3: Host not found)'

stack traceback:
	spec/resty/http_ng/backend/async_resty_spec.lua:11: in function <spec/resty/http_ng/backend/async_resty_spec.lua:8>


Failure → spec/resty/http_ng/backend/async_resty_spec.lua @ 33
resty backend GET method #network returns proper error on connect timeout
Random seed: 2246932564
spec/resty/http_ng/backend/async_resty_spec.lua:39: Expected objects to be equal.
Passed in:
(string) 'example.com could not be resolved (3: Host not found)'
Expected:
(string) 'timeout'

stack traceback:
	spec/resty/http_ng/backend/async_resty_spec.lua:39: in function <spec/resty/http_ng/backend/async_resty_spec.lua:33>


Error → spec/policy/upstream_mtls/upstream_mtls_spec.lua @ 176
Upstream MTLS policy CA_Certificates CA certificate is used if verify is enabled
Random seed: 2246932564
...teway/src/apicast/policy/upstream_mtls/upstream_mtls.lua:173: /usr/local/openresty/luajit/lib/libluajit-5.1.so.2: undefined symbol: ngx_http_apicast_ffi_set_ssl_verify

stack traceback:
	...teway/src/apicast/policy/upstream_mtls/upstream_mtls.lua:173: in function 'balancer'
	spec/policy/upstream_mtls/upstream_mtls_spec.lua:184: in function <spec/policy/upstream_mtls/upstream_mtls_spec.lua:176>

make: *** [Makefile:114: busted] Error 1
```

1.- `spec/policy/rate_limit/rate_limit_spec.lua` was failing because one test used `nvalidhost` domain for redis. The embedded DNS server deployed by docker when using custom networks (running the tests with docker-compose), did not return `Host Not Found` as the test expected. Instead it returned `Server failure`. Very likely due to docker version, the embedded DNS server returned `Server failure`

```
# dig invalidhost

; <<>> DiG 9.16.1-Ubuntu <<>> invalidhost
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 26122
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 65494
;; QUESTION SECTION:
;invalidhost.			IN	A
```

Whereas the local DNS server, returns `Host Not Found`

```
# dig invalidhost @192.168.1.1

; <<>> DiG 9.16.1-Ubuntu <<>> invalidhost @192.168.1.1
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 404
;; flags: qr rd ra ad; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;invalidhost.			IN	A
```

The fix was to use proper domain with at least one top level domain: `invalidhost` -> `invalidhost.domain`. For that case, docker embedded DNS and local DNS server returns `Host Not Found` and the test passes. In circleCI the test was passing because both images are run in the same localhost and I guess no embedded DNS server is being used. For the other tests, instead of domain`redis` which is nicely resolved by the docker embedded DNS server, in CI, the redis host used is `127.0.0.1`. 

2.- spec/resty/http_ng/backend/resty_spec.lua and spec/resty/http_ng/backend/async_resty_spec.lua tests were failing locally because the test tries to connect to `example.com` and send GET request. For some unknown reason, my local ISP DNS does not resolve `example.com`. This domain is reserved by IANA for documentation purposes. Google's DNS server, `8.8.8.8` resolves it. So the fix was to use the well known rest services testing service called `httpbin.org`. 

3. spec/policy/upstream_mtls/upstream_mtls_spec.lua was failing because the openresty base image used did not have the [apicast nginx module](https://code.engineering.redhat.com/gerrit/admin/repos/3scale/apicast-nginx-module) loaded. The fix is to use the same openresty base image as used in the circleCI test, `quay.io/3scale/s2i-openresty-centos7:1.19.3.6-20-centos8`. An alternative fix would be to update https://github.com/3scale/s2i-openresty `master` to load the apicast nginx module. But since the s2i building method is deprecated in apicast and will be soon replaced by multi-stage docker builds, I opted to fix the other way, just using the image used in circleci.