### PR TITLE
Development image upgraded to ubi8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,8 +114,8 @@ executors:
   openresty:
     working_directory: /opt/app-root/apicast
     docker:
-    - image: quay.io/3scale/s2i-openresty-centos7:1.19.3.6-20-centos8
-    - image: redis:3.2.8-alpine
+      - image: quay.io/3scale/apicast-ci:openresty-1.19.3
+      - image: redis:3.2.8-alpine
     environment:
       TEST_NGINX_BINARY: openresty
       LUA_BIN_PATH: /opt/app-root/bin
@@ -267,7 +267,7 @@ jobs:
       - attach-workspace
       - run:
           name: 'prove'
-          command: /usr/libexec/s2i/entrypoint make prove
+          command: make prove
           environment:
             JUNIT_OUTPUT_FILE: tmp/junit/prove/report.xml
             TEST_NGINX_ERROR_LOG: tmp/junit/prove/error.log

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,4 @@ tmp/benchmark/
 .cache/
 .cpanm
 /vendor/cache
-/.docker
 /tmp/

--- a/Dockerfile.devel
+++ b/Dockerfile.devel
@@ -44,7 +44,7 @@ ENV PATH="./lua_modules/bin:/usr/local/openresty/luajit/bin/:${PATH}" \
     LUA_CPATH="./lua_modules/lib/lua/5.1/?.so;;" \
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/app-root/lib"
 
-RUN yum install -y luarocks && \
+RUN yum install -y luarocks-${LUAROCKS_VERSION} && \
     luarocks install --server=http://luarocks.org/dev lua-rover && \
     rover -v && \
     yum -y remove luarocks && \

--- a/Dockerfile.devel
+++ b/Dockerfile.devel
@@ -1,0 +1,68 @@
+FROM registry.access.redhat.com/ubi8:8.5
+
+ARG OPENRESTY_RPM_VERSION="1.19.3"
+ARG LUAROCKS_VERSION="2.3.0"
+
+WORKDIR /tmp
+
+ENV APP_ROOT=/opt/app-root \
+    HOME=/opt/app-root/src \
+    PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    PLATFORM="el8"
+
+RUN sed -i s/enabled=./enabled=0/g /etc/yum/pluginconf.d/subscription-manager.conf
+
+RUN yum upgrade -y 
+
+RUN dnf install -y 'dnf-command(config-manager)'
+
+RUN yum install -y \
+        gcc make git which curl expat-devel kernel-headers openssl-devel m4 \
+        libyaml libyaml-devel perl-local-lib perl-App-cpanminus
+
+# perl-Test-Nginx
+RUN cpanm https://cpan.metacpan.org/authors/id/A/AG/AGENT/Test-Nginx-0.29.tar.gz
+
+RUN yum config-manager --add-repo http://packages.dev.3sca.net/dev_packages_3sca_net.repo
+
+RUN yum install -y \
+        openresty-${OPENRESTY_RPM_VERSION} \
+        openresty-resty-${OPENRESTY_RPM_VERSION} \
+        openresty-opentracing-${OPENRESTY_RPM_VERSION} \
+        jaegertracing-cpp-client 
+
+RUN ln -sf /dev/stdout /usr/local/openresty/nginx/logs/access.log \
+    && ln -sf /dev/stderr /usr/local/openresty/nginx/logs/error.log \
+    && mkdir -p /usr/local/openresty/nginx/client_body_temp/ \
+    && chmod 777 /usr/local/openresty/nginx/client_body_temp/
+
+COPY site_config.lua /usr/share/lua/5.1/luarocks/site_config.lua
+COPY config-*.lua /usr/local/openresty/config-5.1.lua
+
+ENV PATH="./lua_modules/bin:/usr/local/openresty/luajit/bin/:${PATH}" \
+    LUA_PATH="./lua_modules/share/lua/5.1/?.lua;./lua_modules/share/lua/5.1/?/init.lua;/usr/lib64/lua/5.1/?.lua;/usr/share/lua/5.1/?.lua" \
+    LUA_CPATH="./lua_modules/lib/lua/5.1/?.so;;" \
+    LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/app-root/lib"
+
+RUN yum install -y luarocks && \
+    luarocks install --server=http://luarocks.org/dev lua-rover && \
+    rover -v && \
+    yum -y remove luarocks && \
+    ln -s /usr/bin/rover /usr/local/openresty/luajit/bin/ && \
+    chmod g+w "${HOME}/.cache" && \
+    rm -rf /var/cache/yum && yum clean all -y && \
+    rm -rf "${HOME}/.cache/luarocks" ./*
+
+# Directory with the sources is set as the working directory so all STI scripts
+# can execute relative to this path.
+WORKDIR ${HOME}
+
+# Reset permissions of modified directories and add default user
+RUN useradd -u 1001 -r -g 0 -d ${HOME} -s /sbin/nologin \
+      -c "Default Application User" default && \
+    chown -R 1001:0 ${APP_ROOT}
+
+USER 1001
+WORKDIR ${HOME}
+EXPOSE 8080
+CMD ["/bin/bash"]

--- a/Dockerfile.devel
+++ b/Dockerfile.devel
@@ -17,7 +17,7 @@ RUN yum upgrade -y
 RUN dnf install -y 'dnf-command(config-manager)'
 
 RUN yum install -y \
-        gcc make git which curl expat-devel kernel-headers openssl-devel m4 \
+        gcc make git which curl iputils bind-utils expat-devel kernel-headers openssl-devel m4 \
         libyaml libyaml-devel perl-local-lib perl-App-cpanminus
 
 # perl-Test-Nginx

--- a/Makefile
+++ b/Makefile
@@ -222,13 +222,14 @@ $(PROJECT_PATH)/lua_modules $(PROJECT_PATH)/local $(PROJECT_PATH)/.cpanm $(PROJE
 
 ifeq ($(origin USER),environment)
 development: USER := $(shell id -u $(USER))
+development: GROUP := $(shell id -g $(USER))
 endif
 development: $(PROJECT_PATH)/lua_modules $(PROJECT_PATH)/local $(PROJECT_PATH)/.cpanm $(PROJECT_PATH)/vendor/cache $(PROJECT_PATH)/.cache
 development: ## Run bash inside the development image
 	@echo "Running on $(os)"
 	- $(DOCKER_COMPOSE) -f $(DEVEL_DOCKER_COMPOSE_FILE) -f $(DEVEL_DOCKER_COMPOSE_VOLMOUNT_FILE) up -d
 	@ # https://github.com/moby/moby/issues/33794#issuecomment-312873988 for fixing the terminal width
-	$(DOCKER_COMPOSE) -f $(DEVEL_DOCKER_COMPOSE_FILE) -f $(DEVEL_DOCKER_COMPOSE_VOLMOUNT_FILE) exec -e COLUMNS="`tput cols`" -e LINES="`tput lines`" --user $(USER) development bash
+	$(DOCKER_COMPOSE) -f $(DEVEL_DOCKER_COMPOSE_FILE) -f $(DEVEL_DOCKER_COMPOSE_VOLMOUNT_FILE) exec -e COLUMNS="`tput cols`" -e LINES="`tput lines`" --user $(USER):$(GROUP) development bash
 
 stop-development: ## Stop development environment
 	- $(DOCKER_COMPOSE) -f $(DEVEL_DOCKER_COMPOSE_FILE) -f $(DEVEL_DOCKER_COMPOSE_VOLMOUNT_FILE) down

--- a/Makefile
+++ b/Makefile
@@ -217,13 +217,13 @@ test-runtime-image: clean-containers ## Smoke test the runtime image. Pass any d
 	@echo -e $(SEPARATOR)
 	$(DOCKER_COMPOSE) run --rm test sh -c 'sleep 5 && curl --fail http://gateway:8090/status/live'
 
-.docker/lua_modules .docker/local .docker/cpanm .docker/vendor/cache :
+$(PROJECT_PATH)/lua_modules $(PROJECT_PATH)/local $(PROJECT_PATH)/.cpanm $(PROJECT_PATH)/vendor/cache $(PROJECT_PATH)/.cache :
 	mkdir -p $@
 
 ifeq ($(origin USER),environment)
 development: USER := $(shell id -u $(USER))
 endif
-development: .docker/lua_modules .docker/local .docker/cpanm .docker/vendor/cache
+development: $(PROJECT_PATH)/lua_modules $(PROJECT_PATH)/local $(PROJECT_PATH)/.cpanm $(PROJECT_PATH)/vendor/cache $(PROJECT_PATH)/.cache
 development: ## Run bash inside the development image
 	@echo "Running on $(os)"
 	- $(DOCKER_COMPOSE) -f $(DEVEL_DOCKER_COMPOSE_FILE) -f $(DEVEL_DOCKER_COMPOSE_VOLMOUNT_FILE) up -d

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,13 @@ export COMPOSE_PROJECT_NAME
 
 .PHONY: benchmark lua_modules
 
+# The development image is also used in CI (circleCI) as the 'openresty' executor
+# When the development image changes, make sure to:
+# * build a new development image:
+#     make dev-build DEVEL_IMAGE=quay.io/3scale/apicast-ci:openresty-1.19.3
+# * push to quay.io/3scale/apicast-ci with a fixed tag (avoid floating tags)
+#     docker push quay.io/3scale/apicast-ci:openresty-1.19.3
+# * update .circleci/config.yaml openresty executor with the image URL
 .PHONY: dev-build
 dev-build: export OPENRESTY_RPM_VERSION?=1.19.3
 dev-build: export LUAROCKS_VERSION?=2.3.0
@@ -219,7 +226,6 @@ endif
 development: .docker/lua_modules .docker/local .docker/cpanm .docker/vendor/cache
 development: ## Run bash inside the development image
 	@echo "Running on $(os)"
-	@$(DOCKER) history -q $(DEVEL_IMAGE) 2> /dev/null >&2 || $(MAKE) -C $(PROJECT_PATH) -f $(MKFILE_PATH) dev-build
 	- $(DOCKER_COMPOSE) -f $(DEVEL_DOCKER_COMPOSE_FILE) -f $(DEVEL_DOCKER_COMPOSE_VOLMOUNT_FILE) up -d
 	@ # https://github.com/moby/moby/issues/33794#issuecomment-312873988 for fixing the terminal width
 	$(DOCKER_COMPOSE) -f $(DEVEL_DOCKER_COMPOSE_FILE) -f $(DEVEL_DOCKER_COMPOSE_VOLMOUNT_FILE) exec -e COLUMNS="`tput cols`" -e LINES="`tput lines`" --user $(USER) development bash

--- a/Makefile
+++ b/Makefile
@@ -76,14 +76,14 @@ export COMPOSE_PROJECT_NAME
 .PHONY: dev-build
 dev-build: export OPENRESTY_RPM_VERSION?=1.19.3
 dev-build: export LUAROCKS_VERSION?=2.3.0
-dev-build:
+dev-build: ## Build development image
 	$(DOCKER) build -t $(DEVEL_IMAGE) \
 		--build-arg OPENRESTY_RPM_VERSION=$(OPENRESTY_RPM_VERSION) \
 		--build-arg LUAROCKS_VERSION=$(LUAROCKS_VERSION) \
 		$(PROJECT_PATH) -f $(DEVEL_DOCKERFILE)
 
 test: ## Run all tests
-	$(MAKE) --keep-going busted prove builder-image test-builder-image prove-docker runtime-image test-runtime-image
+	$(MAKE) --keep-going busted prove dev-build builder-image test-builder-image prove-docker runtime-image test-runtime-image
 
 apicast-source: export IMAGE_NAME ?= apicast-test
 apicast-source: ## Create Docker Volume container with APIcast source code

--- a/config-5.1.lua
+++ b/config-5.1.lua
@@ -1,0 +1,6 @@
+lua_interpreter = [[resty]]
+lib_modules_path = [[/lib/lua/]]..lua_version
+
+variables = {
+	LUAROCKS_PREFIX = [[/usr]]
+}

--- a/docker-compose-devel-volmount-default.yml
+++ b/docker-compose-devel-volmount-default.yml
@@ -5,6 +5,5 @@ services:
     pid: "host"
     volumes:
       - .:/opt/app-root/src/
-      - .docker/cpanm:/opt/app-root/src/.cpanm
       - /sys/kernel/debug:/sys/kernel/debug
       - /lib/modules:/lib/module

--- a/docker-compose-devel-volmount-default.yml
+++ b/docker-compose-devel-volmount-default.yml
@@ -4,7 +4,7 @@ services:
     privileged: true
     pid: "host"
     volumes:
-      - .:/home/centos/
-      - .docker/cpanm:/home/centos/.cpanm
+      - .:/opt/app-root/src/
+      - .docker/cpanm:/opt/app-root/src/.cpanm
       - /sys/kernel/debug:/sys/kernel/debug
       - /lib/modules:/lib/module

--- a/docker-compose-devel-volmount-mac.yml
+++ b/docker-compose-devel-volmount-mac.yml
@@ -2,5 +2,5 @@ version: '2.2'
 services:
   development:
     volumes:
-      - .:/home/centos/:cached
-      - .docker/cpanm:/home/centos/.cpanm:delegated
+      - .:/opt/app-root/src/:cached
+      - .docker/cpanm:/opt/app-root/src/.cpanm:delegated

--- a/docker-compose-devel-volmount-mac.yml
+++ b/docker-compose-devel-volmount-mac.yml
@@ -3,4 +3,3 @@ services:
   development:
     volumes:
       - .:/opt/app-root/src/:cached
-      - .docker/cpanm:/opt/app-root/src/.cpanm:delegated

--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -1,17 +1,18 @@
+---
 version: '2.2'
 services:
   development:
-    image: ${IMAGE:-quay.io/3scale/s2i-openresty-centos7:1.19.3.6-20-centos8}
+    image: ${IMAGE:-apicast-development:latest}
     depends_on:
       - redis
-    working_dir: /home/centos/
+    working_dir: /opt/app-root/src/
     volumes:
-      - .docker/lua_modules:/home/centos/lua_modules
-      - .docker/local:/home/centos/local
-      - .docker/vendor/cache:/home/centos/vendor/cache
+      - .docker/lua_modules:/opt/app-root/src/lua_modules
+      - .docker/local:/opt/app-root/src/local
+      - .docker/vendor/cache:/opt/app-root/src/vendor/cache
       # no need to access those from docker
-      - /home/centos/.docker
-      - /home/centos/.git
+      - /opt/app-root/src/.docker
+      - /opt/app-root/src/.git
     command: cat
     tty: true
     init: true
@@ -19,10 +20,10 @@ services:
       EDITOR: vi
       TEST_NGINX_REDIS_HOST: redis
       TEST_NGINX_BINARY: openresty
-      PROJECT_PATH: /home/centos
-      TEST_NGINX_APICAST_PATH: /home/centos/gateway
+      PROJECT_PATH: /opt/app-root/src
+      TEST_NGINX_APICAST_PATH: /opt/app-root/src/gateway
       ROVER: /usr/local/openresty/luajit/bin/rover
-      HOME: /home/centos/
+      HOME: /opt/app-root/src/
       # https://github.com/jenkinsci/docker/issues/519#issuecomment-313052325
       GIT_COMMITTER_NAME: ${GIT_COMMITTER_NAME:-${USER}}
       GIT_COMMITTER_EMAIL: ${GIT_COMMITTER_EMAIL:-""}

--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -6,13 +6,6 @@ services:
     depends_on:
       - redis
     working_dir: /opt/app-root/src/
-    volumes:
-      - .docker/lua_modules:/opt/app-root/src/lua_modules
-      - .docker/local:/opt/app-root/src/local
-      - .docker/vendor/cache:/opt/app-root/src/vendor/cache
-      # no need to access those from docker
-      - /opt/app-root/src/.docker
-      - /opt/app-root/src/.git
     command: cat
     tty: true
     init: true

--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -2,7 +2,7 @@
 version: '2.2'
 services:
   development:
-    image: ${IMAGE:-apicast-development:latest}
+    image: ${IMAGE:-quay.io/3scale/apicast-ci:openresty-1.19.3}
     depends_on:
       - redis
     working_dir: /opt/app-root/src/

--- a/site_config.lua
+++ b/site_config.lua
@@ -1,0 +1,24 @@
+local site_config = { }
+
+local openresty = [[/usr/local/openresty]]
+local luajit = openresty .. [[/luajit]]
+
+site_config.LUAROCKS_SYSCONFIG=openresty .. [[/config-5.1.lua]]
+site_config.LUA_INTERPRETER=[[resty]]
+site_config.LUA_DIR_SET=false
+site_config.LUAROCKS_PREFIX= [[/usr]]
+site_config.LUA_INCDIR= luajit .. [[/include/luajit-2.1]]
+site_config.LUA_LIBDIR= luajit .. [[/lib/5.1]]
+site_config.LUA_BINDIR= openresty .. [[/bin]]
+site_config.LUAROCKS_SYSCONFDIR=[[/etc/luarocks]]
+site_config.LUAROCKS_ROCKS_TREE=[[/usr/local/openresty/luajit]]
+site_config.LUAROCKS_ROCKS_SUBDIR=[[/luarocks/rocks]]
+site_config.LUAROCKS_UNAME_S=[[Linux]]
+site_config.LUAROCKS_UNAME_M=[[x86_64]]
+site_config.LUAROCKS_DOWNLOADER=[[curl]]
+site_config.LUAROCKS_MD5CHECKER=[[md5sum]]
+
+site_config.LUAROCKS_EXTERNAL_DEPS_SUBDIRS={ bin="bin", lib={ "lib", [[lib64]] }, include="include" }
+site_config.LUAROCKS_RUNTIME_EXTERNAL_DEPS_SUBDIRS={ bin="bin", lib={ "lib", [[lib64]] }, include="include" }
+
+return site_config

--- a/spec/resty/openssl/x509_spec.lua
+++ b/spec/resty/openssl/x509_spec.lua
@@ -33,7 +33,7 @@ describe('OpenSSL X509', function ()
 
     it('does not crash on invalid certificate', function()
       assert.returns_error('no start line', _M.parse_pem_cert('garbage'))
-      assert.returns_error('short header', _M.parse_pem_cert('-----BEGIN CERTIFICATE-----'))
+      assert.returns_error('bad end line', _M.parse_pem_cert('-----BEGIN CERTIFICATE-----'))
       assert.returns_error('invalid certificate', _M.parse_pem_cert(''))
     end)
 


### PR DESCRIPTION
### what

* Remove dependency from openresty base image from https://github.com/3scale/s2i-openresty
* Added `Dockerfile.devel` with the devel image content
* Fixed  `spec/resty/openssl/x509_spec.lua` unittest. Reason:
  * invalid certificate error message changed due to upgrade on `openssl-libs` dep:
  * from `openssl-libs-1.1.1g-15.el8_3.x86_64` in `centos8` -> `openssl-libs-1.1.1k-6.el8_5.x86_64` in `ubi8`
* Development container had overlapping volume mounts, causing (in linux) to create files with the root owner. The overlapping volume mounts have been removed from docker compose config.

### verification steps

run development image

```
make development
```
Inside the container, download dependencies
```
make dependencies
```
Inside the container, run apicast
```
$ cat <<EOF >config.json
{
   "services": [
      {
         "proxy": {
             "hosts": ["one"],
             "proxy_rules": [],
             "api_backend": "https://echo-api.3scale.net",
             "policy_chain": []
         }
      }
   ]
}
EOF

$ APICAST_LOG_LEVEL=debug APICAST_WORKER=1 THREESCALE_CONFIG_FILE=config.json BACKEND_ENDPOINT_OVERRIDE=http://localhost:8081 ./bin/apicast
```
Send request from externally from the host
```
$ APICAST_IP=$(docker inspect apicast_build_0_development_1 | yq e -P '.[0].NetworkSettings.Networks.apicast_build_0_default.IPAddress' -)

$ curl -v http://${APICAST_IP}:8080
*   Trying 192.168.32.3:8080...
* TCP_NODELAY set
* Connected to 192.168.32.3 (192.168.32.3) port 8080 (#0)
> GET / HTTP/1.1
> Host: 192.168.32.3:8080
> User-Agent: curl/7.68.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 Not Found
< Server: openresty
< Date: Wed, 27 Apr 2022 16:27:12 GMT
< Content-Type: text/plain
< Transfer-Encoding: chunked
< Connection: keep-alive
< 
* Connection #0 to host 192.168.32.3 left intact
```


