### PR TITLE
THREESCALE-7349 - Added default value for the append property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue with resolving target server hostnames to IPs when forwarding requests through http/s proxy [PR #1323](https://github.com/3scale/APIcast/pull/1323) [THREESCALE-7967](https://issues.redhat.com/browse/THREESCALE-7967)
 - Fixed dirty context [PR #1328](https://github.com/3scale/APIcast/pull/1328) [THREESCALE-8000](https://issues.redhat.com/browse/THREESCALE-8000) [THREESCALE-8007](https://issues.redhat.com/browse/THREESCALE-8007) [THREESCALE-8252](https://issues.redhat.com/browse/THREESCALE-8252)
 - Fixed dirty context (part 2 of PR #1328) when tls termination policy is in the policy chain [PR #1333](https://github.com/3scale/APIcast/pull/1333)
+- Fixed NGINX filters policy error [PR #1339](https://github.com/3scale/APIcast/pull/1339) [THREESCALE-7349](https://issues.redhat.com/browse/THREESCALE-7349)
 
 ### Added
 

--- a/gateway/src/apicast/policy/nginx_filters/apicast-policy.json
+++ b/gateway/src/apicast/policy/nginx_filters/apicast-policy.json
@@ -30,7 +30,8 @@
             },
             "append": {
               "type": "boolean",
-              "title": "Append header to upstream"
+              "title": "Append header to upstream",
+              "default": false
             }
           },
           "required": [


### PR DESCRIPTION
This gives a default `false` value to the `append` property to make it consistent with the "unchecked" value that is visible in system by default for this policy.

It resolves the error `headers[0].append is a required property` that would otherwise show in the UI when the policy configuration is saved.

https://issues.redhat.com/browse/THREESCALE-7349