### PR TITLE
THREESCALE-7906 - initialization of $post_action_impact and $target_host variables as tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed dirty context [PR #1328](https://github.com/3scale/APIcast/pull/1328) [THREESCALE-8000](https://issues.redhat.com/browse/THREESCALE-8000) [THREESCALE-8007](https://issues.redhat.com/browse/THREESCALE-8007) [THREESCALE-8252](https://issues.redhat.com/browse/THREESCALE-8252)
 - Fixed dirty context (part 2 of PR #1328) when tls termination policy is in the policy chain [PR #1333](https://github.com/3scale/APIcast/pull/1333)
 - Fixed NGINX filters policy error [PR #1339](https://github.com/3scale/APIcast/pull/1339) [THREESCALE-7349](https://issues.redhat.com/browse/THREESCALE-7349)
+- Fix to avoid uninitialized variables when request URI is too large [PR #1340](https://github.com/3scale/APIcast/pull/1340) [THREESCALE-7906](https://issues.redhat.com/browse/THREESCALE-7906)
 
 ### Added
 

--- a/gateway/conf.d/apicast.conf
+++ b/gateway/conf.d/apicast.conf
@@ -156,7 +156,6 @@ location / {
 
   set $ctx_ref -1;
 
-  set $post_action_impact '';
   set $original_request_id $request_id;
   set $original_request_uri '$scheme://$host$request_uri';
 

--- a/gateway/http.d/apicast.conf.liquid
+++ b/gateway/http.d/apicast.conf.liquid
@@ -14,6 +14,13 @@ map "" $extended_access_logs_enabled {
   default '0';
 }
 
+map "" $post_action_impact {
+  default '';
+}
+
+map "" $target_host {
+  default '$host';
+}
 
 log_format extended escape=none '$extended_access_log';
 


### PR DESCRIPTION
As a follow up to https://github.com/3scale/APIcast/pull/1319, 2 more variables require to be initialized with a default value to avoid generating "uninitialized variables" logs in case a large URI is passed in the request (that causes 414 Request-URI Too Large): $target_host and $post_action_impact