### PR TITLE
THREESCALE-8426 - request path is stripped for proxied https requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed dirty context (part 2 of PR #1328) when tls termination policy is in the policy chain [PR #1333](https://github.com/3scale/APIcast/pull/1333)
 - Fixed NGINX filters policy error [PR #1339](https://github.com/3scale/APIcast/pull/1339) [THREESCALE-7349](https://issues.redhat.com/browse/THREESCALE-7349)
 - Fix to avoid uninitialized variables when request URI is too large [PR #1340](https://github.com/3scale/APIcast/pull/1340) [THREESCALE-7906](https://issues.redhat.com/browse/THREESCALE-7906)
+- Fixed issue where request path is stripped for proxied https requests [PR #1342](https://github.com/3scale/APIcast/pull/1342) [THREESCALE-8426](https://issues.redhat.com/browse/THREESCALE-8426)
 
 ### Added
 

--- a/gateway/src/apicast/http_proxy.lua
+++ b/gateway/src/apicast/http_proxy.lua
@@ -82,7 +82,7 @@ local function absolute_url(uri)
 end
 
 local function current_path(uri)
-    return format('%s%s%s', uri.path or ngx.var.uri, ngx.var.is_args, ngx.var.query_string or '')
+    return format('%s%s%s', ngx.var.uri, ngx.var.is_args, ngx.var.query_string or '')
 end
 
 local function forward_https_request(proxy_uri, uri, skip_https_connect)

--- a/gateway/src/apicast/http_proxy.lua
+++ b/gateway/src/apicast/http_proxy.lua
@@ -81,10 +81,6 @@ local function absolute_url(uri)
     )
 end
 
-local function current_path(uri)
-    return format('%s%s%s', ngx.var.uri, ngx.var.is_args, ngx.var.query_string or '')
-end
-
 local function forward_https_request(proxy_uri, uri, skip_https_connect)
     -- This is needed to call ngx.req.get_body_data() below.
     ngx.req.read_body()
@@ -93,7 +89,7 @@ local function forward_https_request(proxy_uri, uri, skip_https_connect)
         uri = uri,
         method = ngx.req.get_method(),
         headers = ngx.req.get_headers(0, true),
-        path = current_path(uri),
+        path = format('%s%s%s', ngx.var.uri, ngx.var.is_args, ngx.var.query_string or ''),
 
         -- We cannot use resty.http's .get_client_body_reader().
         -- In POST requests with HTTPS, the result of that call is nil, and it

--- a/t/http-proxy.t
+++ b/t/http-proxy.t
@@ -1077,7 +1077,7 @@ Request body is bigger than client_body_buffer_size
 --- user_files fixture=tls.pl eval
 
 
-=== TEST 21: https upstream API connection routes to the right path
+=== TEST 21: https upstream API connection routes to the upstream (host + path) + request path
 --- env eval
 (
   "https_proxy" => $ENV{TEST_NGINX_HTTPS_PROXY},
@@ -1133,6 +1133,96 @@ ETag: foobar
 --- expected_response_body_like_multiple eval
 [[
     qr{GET \/somepath\/test\?user_key=test3 HTTP\/1\.1},
+    qr{ETag\: foobar},
+    qr{Connection\: close}, 
+    qr{User\-Agent\: Test\:\:APIcast\:\:Blackbox},
+    qr{Host\: test-upstream.lvh.me\:\d+}
+]]
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- no_error_log
+[error]
+--- user_files fixture=tls.pl eval
+
+
+=== TEST 22: https upstream API connection routes to the upstream (host + path) 
++ request path with routing policy also enabled
+--- env eval
+(
+  "https_proxy" => $ENV{TEST_NGINX_HTTPS_PROXY},
+  'BACKEND_ENDPOINT_OVERRIDE' => "http://test_backend.lvh.me:$ENV{TEST_NGINX_SERVER_PORT}"
+)
+--- configuration random_port env
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT/somepath",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+            {
+              "name": "apicast.policy.routing",
+              "configuration": {
+                "rules": [
+                  {
+                    "url": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT/somepath",
+                    "replace_path": "{{uri | remove_first: '/test'}}",
+                    "condition": {
+                      "operations": [
+                        {
+                          "match": "path",
+                          "op": "matches",
+                          "value": "^(/test/.*|/test/?)"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {"name": "apicast","version": "builtin"}
+        ]
+      }
+    }
+  ]
+}
+--- backend
+server_name test_backend.lvh.me;
+
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream env
+server_name test-upstream.lvh.me;
+
+listen $TEST_NGINX_RANDOM_PORT ssl;
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+location /somepath {
+    echo_foreach_split '\r\n' $echo_client_request_headers;
+    echo $echo_it;
+    echo_end;
+    access_by_lua_block {
+       assert = require('luassert')
+       assert.equal('https', ngx.var.scheme)
+       assert.equal('$TEST_NGINX_RANDOM_PORT', ngx.var.server_port)
+       assert.equal('test-upstream.lvh.me', ngx.var.ssl_server_name)
+    }
+}
+--- request
+GET /test/foo/bar?user_key=test3
+--- more_headers
+User-Agent: Test::APIcast::Blackbox
+ETag: foobar
+--- expected_response_body_like_multiple eval
+[[
+    qr{GET \/somepath\/foo\/bar\?user_key=test3 HTTP\/1\.1},
     qr{ETag\: foobar},
     qr{Connection\: close}, 
     qr{User\-Agent\: Test\:\:APIcast\:\:Blackbox},


### PR DESCRIPTION
This is a fix for THREESCALE-8426 where in some situations the client's request path is stripped away from the proxied upstream request.

### Steps to reproduce the issue:
- Backend with public path = /
- Upstream with https:// scheme and a path in its private URL, like: https://echo-api.3scale.net/some/path
- Https proxy (configured on APIcast for upstream connections)
- Send a request to APIcast with a certain path appended http://public-base-url/foo/bar
- Verify the request was actually sent to https://echo-api.3scale.net/some/path instead of the expected https://echo-api.3scale.net/some/path/foo/bar

### Problem
The problem is that we set the upstream request's path using `uri.path` (when available) [here](https://github.com/3scale/APIcast/blob/132a91cb1869a4a607db69bfd3bb5ad5f2a03053/gateway/src/apicast/http_proxy.lua#L85).

`uri.path`, is [upstream.uri](https://github.com/3scale/APIcast/blob/132a91cb1869a4a607db69bfd3bb5ad5f2a03053/gateway/src/apicast/http_proxy.lua#L161).path, where `upstream.uri` is [self.uri](https://github.com/3scale/APIcast/blob/132a91cb1869a4a607db69bfd3bb5ad5f2a03053/gateway/src/apicast/upstream.lua#L164) i.e. only the prefix (aka the upstream path that is hardcoded in the Private URL when the Backend is defined), which explains the problem as described above.

### Fix
Currently we rewrite `ngx.var.uri` to contain the exact path for the upstream request [here](https://github.com/3scale/APIcast/blob/132a91cb1869a4a607db69bfd3bb5ad5f2a03053/gateway/src/apicast/upstream.lua#L166) by appending the value of `ngx.var.uri` to the Backend prefix.
This means we should use `ngx.var.uri` as the path for the proxied request [here](https://github.com/3scale/APIcast/blob/132a91cb1869a4a607db69bfd3bb5ad5f2a03053/gateway/src/apicast/http_proxy.lua#L85), instead of `uri.path`.
