### PR TITLE
THREESCALE-8453 tests conversion to APIcast::Blackbox

### DIFF
--- a/t/apicast-async-reporting.t
+++ b/t/apicast-async-reporting.t
@@ -1,202 +1,181 @@
 use lib 't';
-use Test::APIcast 'no_plan';
+use Test::APIcast::Blackbox 'no_plan';
 
-env_to_nginx('APICAST_REPORTING_THREADS=1');
+$ENV{APICAST_ACCESS_LOG_FILE} = "$Test::Nginx::Util::ErrLogFile";
+$ENV{TEST_NGINX_HTML_DIR} ||= "$Test::Nginx::Util::ServRoot/html";
+$ENV{APICAST_REPORTING_THREADS} = 1;
 
+check_accum_error_log();
+repeat_each(1);
 run_tests();
 
 __DATA__
 
 === TEST 1: api backend gets the request
 It asks backend and then forwards the request to the api.
---- http_config
-include $TEST_NGINX_UPSTREAM_CONFIG;
-lua_shared_dict api_keys 1m;
-lua_package_path "$TEST_NGINX_LUA_PATH";
-init_by_lua_block {
-  ngx.shared.api_keys:set('42:value:usage%5Bhits%5D=2', 200)
-  require('apicast.configuration_loader').mock({
-    services = {
+--- configuration
+{
+    "services": [
       {
-        id = 42,
-        backend_version = 1,
-        backend_authentication_type = 'service_token',
-        backend_authentication_value = 'token-value',
-        proxy = {
-          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" },
-          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
-          proxy_rules = {
-            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
-          }
+        "id": 42,
+        "backend_version": 1,
+        "backend_authentication_type": "service_token",
+        "backend_authentication_value": "token-value",
+        "proxy": {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/",
+            "proxy_rules": [
+                { "pattern" : "/", "http_method" : "GET", "metric_system_name" : "hits", "delta" : 2 }
+            ]
         }
       }
-    }
-  })
+    ]
 }
---- config
-include $TEST_NGINX_APICAST_CONFIG;
-
+--- backend
 location /transactions/authrep.xml {
   content_by_lua_block {
     local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=2&user_key=value"
     require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
   }
 }
-
+--- upstream
 location /api-backend/ {
   echo 'yay, api backend: $http_host';
 }
---- request
-GET /?user_key=value
---- response_body env
-yay, api backend: 127.0.0.1:$TEST_NGINX_SERVER_PORT
---- error_code: 200
+--- pipelined_requests eval
+["GET /?user_key=value","GET /?user_key=value"]
+--- response_body env eval
+["yay, api backend: test:$TEST_NGINX_SERVER_PORT\x{0a}","yay, api backend: test:$TEST_NGINX_SERVER_PORT\x{0a}"]
+--- error_code eval
+["200","200"]
 --- no_error_log
 [error]
+
 
 === TEST 2: https api backend works
 with async background reporting
 --- ssl random_port
---- http_config
-include $TEST_NGINX_UPSTREAM_CONFIG;
-lua_package_path "$TEST_NGINX_LUA_PATH";
-init_by_lua_block {
-  ngx.shared.api_keys:set('42:foo:usage%5Bhits%5D=1', 200)
-  require('apicast.configuration_loader').mock({
-    services = {
-      {
-        id = 42,
-        backend_version = 1,
-        backend_version = 1,
-        backend_authentication_type = 'service_token',
-        backend_authentication_value = 'token-value',
-        proxy = {
-          backend = { endpoint = "https://127.0.0.1:$TEST_NGINX_RANDOM_PORT" },
-          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api/",
-          proxy_rules = {
-            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1 }
-          }
-        }
+--- env random_port eval
+(
+  'BACKEND_ENDPOINT_OVERRIDE' => "https://test_backend:$ENV{TEST_NGINX_RANDOM_PORT}"
+)
+--- configuration random_port env
+{
+  "services" : [
+    {
+      "id": 42,
+      "backend_version": 1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/",
+        "proxy_rules": [
+            { "pattern" : "/", "http_method" : "GET", "metric_system_name" : "hits", "delta" : 1} 
+        ]
       }
     }
-  })
+  ]
 }
-lua_shared_dict api_keys 1m;
---- config
-include $TEST_NGINX_APICAST_CONFIG;
-listen $TEST_NGINX_RANDOM_PORT ssl;
-
-ssl_certificate ../html/server.crt;
-ssl_certificate_key ../html/server.key;
-
-lua_ssl_trusted_certificate ../html/server.crt;
-
-location /api/ {
-  echo "api response";
-}
-
-location /transactions/authrep.xml {
-  content_by_lua_block {
-    local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=1&user_key=foo"
-    require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
-    ngx.exit(200)
+--- upstream
+  location /api-backend/ {
+     echo 'yay, api backend!';
   }
-}
+--- backend random_port env
+  listen $TEST_NGINX_RANDOM_PORT ssl;
+  ssl_certificate $TEST_NGINX_HTML_DIR/server.crt;
+  ssl_certificate_key $TEST_NGINX_HTML_DIR/server.key;
+  
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_token=token-value&service_id=42&usage%5Bhits%5D=1&user_key=foo"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+      ngx.exit(200)
+    }
+  }
+--- pipelined_requests eval
+["GET /test?user_key=foo","GET /test?user_key=foo"]
+--- response_body eval
+["yay, api backend!\x{0a}","yay, api backend!\x{0a}"]
+--- error_code eval 
+["200","200"]
+--- wait: 3
+--- error_log
+reporting to backend asynchronously
 --- user_files
 >>> server.crt
 -----BEGIN CERTIFICATE-----
-MIIBkjCCATmgAwIBAgIJAOSlu+H4y+4uMAkGByqGSM49BAEwFDESMBAGA1UEAxMJ
-MTI3LjAuMC4xMB4XDTE3MDMzMDA5MDEyMFoXDTI3MDMyODA5MDEyMFowFDESMBAG
-A1UEAxMJMTI3LjAuMC4xMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBmPcgjjx
-OmODfbQGqjkVtbq6qvFC8t0A5FWnL3nRQjI5nB9k7tX7vTx1NzFzq+w3Vf3vX+Fq
-sWLyaBIhDSyUHqN1MHMwHQYDVR0OBBYEFAIqtTXT/E0eFC29bQhicIZcM0tlMEQG
-A1UdIwQ9MDuAFAIqtTXT/E0eFC29bQhicIZcM0tloRikFjAUMRIwEAYDVQQDEwkx
-MjcuMC4wLjGCCQDkpbvh+MvuLjAMBgNVHRMEBTADAQH/MAkGByqGSM49BAEDSAAw
-RQIgAWRI+63VAyJyJJFfLGPRNhdasQZXSvICnCm7w6C/RmACIQCjZvsLCah8h2Sa
-TyxjtHpkHJAzpVuetPVADc/lNN4l/Q==
+MIIB0DCCAXegAwIBAgIJAISY+WDXX2w5MAoGCCqGSM49BAMCMEUxCzAJBgNVBAYT
+AkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRn
+aXRzIFB0eSBMdGQwHhcNMTYxMjIzMDg1MDExWhcNMjYxMjIxMDg1MDExWjBFMQsw
+CQYDVQQGEwJBVTETMBEGA1UECAwKU29tZS1TdGF0ZTEhMB8GA1UECgwYSW50ZXJu
+ZXQgV2lkZ2l0cyBQdHkgTHRkMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhkmo
+6Xp/9W9cGaoGFU7TaBFXOUkZxYbGXQfxyZZucIQPt89+4r1cbx0wVEzbYK5wRb7U
+iWhvvvYDltIzsD75vqNQME4wHQYDVR0OBBYEFOBBS7ZF8Km2wGuLNoXFAcj0Tz1D
+MB8GA1UdIwQYMBaAFOBBS7ZF8Km2wGuLNoXFAcj0Tz1DMAwGA1UdEwQFMAMBAf8w
+CgYIKoZIzj0EAwIDRwAwRAIgZ54vooA5Eb91XmhsIBbp12u7cg1qYXNuSh8zih2g
+QWUCIGTHhoBXUzsEbVh302fg7bfRKPCi/mcPfpFICwrmoooh
 -----END CERTIFICATE-----
 >>> server.key
 -----BEGIN EC PARAMETERS-----
 BggqhkjOPQMBBw==
 -----END EC PARAMETERS-----
 -----BEGIN EC PRIVATE KEY-----
-MHcCAQEEIHIYTPgt2XlDTuL6Ly1jIqhlhM3lEspTyVldsaAoaC54oAoGCCqGSM49
-AwEHoUQDQgAEBmPcgjjxOmODfbQGqjkVtbq6qvFC8t0A5FWnL3nRQjI5nB9k7tX7
-vTx1NzFzq+w3Vf3vX+FqsWLyaBIhDSyUHg==
+MHcCAQEEIFCV3VwLEFKz9+yTR5vzonmLPYO/fUvZiMVU1Hb11nN8oAoGCCqGSM49
+AwEHoUQDQgAEhkmo6Xp/9W9cGaoGFU7TaBFXOUkZxYbGXQfxyZZucIQPt89+4r1c
+bx0wVEzbYK5wRb7UiWhvvvYDltIzsD75vg==
 -----END EC PRIVATE KEY-----
---- request
-GET /test?user_key=foo
 --- no_error_log
 [error]
---- response_body
-api response
---- error_code: 200
---- wait: 3
+
 
 === TEST 3: uses endpoint host as Host header
 when connecting to the backend
---- main_config
-env RESOLVER=127.0.0.1:$TEST_NGINX_RANDOM_PORT;
---- http_config
-include $TEST_NGINX_UPSTREAM_CONFIG;
-lua_package_path "$TEST_NGINX_LUA_PATH";
-lua_shared_dict api_keys 1m;
-init_by_lua_block {
-  ngx.shared.api_keys:set('42:val:usage%5Bhits%5D=2', 200)
-  require('apicast.configuration_loader').mock({
-    services = {
+--- configuration
+{
+    "services": [
       {
-        id = 42,
-        backend_version = 1,
-        backend_authentication_type = 'service_token',
-        backend_authentication_value = 'service-token',
-        proxy = {
-          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api/",
-          backend = {
-            endpoint = 'http://localhost.example.com:$TEST_NGINX_SERVER_PORT'
-          },
-          proxy_rules = {
-            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
-          }
+        "id": 42,
+        "backend_version": 1,
+        "backend_authentication_type": "service_token",
+        "backend_authentication_value": "token-value",
+        "proxy": {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/",
+            "proxy_rules": [
+                { "pattern" : "/", "http_method" : "GET", "metric_system_name" : "hits", "delta" : 2 }
+            ]
         }
-      },
-    }
-  })
+      }
+    ]
 }
---- config
-include $TEST_NGINX_APICAST_CONFIG;
-
-location /api/ {
-  echo "all ok";
-}
-
+--- backend
 location /transactions/authrep.xml {
   content_by_lua_block {
-    if ngx.var.host == 'localhost.example.com' then
-      ngx.exit(200)
-    else
-      ngx.log(ngx.ERR, 'invalid host: ', ngx.var.host)
-      ngx.exit(404)
-    end
+      if ngx.var.host == 'test_backend' then
+        ngx.exit(200)
+      else
+        ngx.log(ngx.ERR, 'invalid host: ', ngx.var.host)
+        ngx.exit(404)
+      end
   }
 }
-
---- request
-GET /t?user_key=val
---- response_body
-all ok
---- error_code: 200
---- udp_listen random_port env chomp
-$TEST_NGINX_RANDOM_PORT
---- udp_reply dns
-[ "localhost.example.com", "127.0.0.1", 60 ]
---- no_error_log
-[error]
+--- upstream
+location /api-backend/ {
+  echo 'yay, api backend';
+}
+--- response_body eval
+["yay, api backend\x{0a}", "yay, api backend\x{0a}"]
+--- pipelined_requests eval
+["GET /?user_key=foo","GET /?user_key=foo"]
+--- error_code eval
+["200","200"]
 --- error_log env eval
 [
-  qr/backend client uri\: http\:\/\/localhost\.example\.com\:$TEST_NGINX_SERVER_PORT\/transactions\/authrep.xml\?.*?(service_id=42).*? ok\: true status\: 200/,
-  qr/backend client uri\: http\:\/\/localhost\.example\.com\:$TEST_NGINX_SERVER_PORT\/transactions\/authrep.xml\?.*?(service_token=service\-token).*? ok\: true status\: 200/,
-  qr/backend client uri\: http\:\/\/localhost\.example\.com\:$TEST_NGINX_SERVER_PORT\/transactions\/authrep.xml\?.*?(user_key=val).*? ok\: true status\: 200/,
-  qr/backend client uri\: http\:\/\/localhost\.example\.com\:$TEST_NGINX_SERVER_PORT\/transactions\/authrep.xml\?.*?(usage%5Bhits%5D=2).*? ok\: true status\: 200/
+  qr/backend client uri\: http\:\/\/test_backend\:$TEST_NGINX_SERVER_PORT\/transactions\/authrep.xml\?.*?(service_id=42).*? ok\: true status\: 200/,
+  qr/backend client uri\: http\:\/\/test_backend\:$TEST_NGINX_SERVER_PORT\/transactions\/authrep.xml\?.*?(service_token=token\-value).*? ok\: true status\: 200/,
+  qr/backend client uri\: http\:\/\/test_backend\:$TEST_NGINX_SERVER_PORT\/transactions\/authrep.xml\?.*?(user_key=foo).*? ok\: true status\: 200/,
+  qr/backend client uri\: http\:\/\/test_backend\:$TEST_NGINX_SERVER_PORT\/transactions\/authrep.xml\?.*?(usage%5Bhits%5D=2).*? ok\: true status\: 200/,
+  qr/reporting to backend asynchronously/
 ]
 --- wait: 3
+--- no_error_log
+[error]
+

--- a/t/apicast-async-reporting.t
+++ b/t/apicast-async-reporting.t
@@ -129,6 +129,10 @@ bx0wVEzbYK5wRb7UiWhvvvYDltIzsD75vg==
 
 === TEST 3: uses endpoint host as Host header
 when connecting to the backend
+--- env eval
+(
+  'BACKEND_ENDPOINT_OVERRIDE' => ''
+)
 --- configuration
 {
     "services": [
@@ -139,6 +143,9 @@ when connecting to the backend
         "backend_authentication_value": "token-value",
         "proxy": {
             "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/",
+            "backend":{
+                "endpoint": "http://test_backend:$TEST_NGINX_SERVER_PORT"
+            },
             "proxy_rules": [
                 { "pattern" : "/", "http_method" : "GET", "metric_system_name" : "hits", "delta" : 2 }
             ]
@@ -178,4 +185,3 @@ location /api-backend/ {
 --- wait: 3
 --- no_error_log
 [error]
-

--- a/t/apicast-policy-3scale-batcher.t
+++ b/t/apicast-policy-3scale-batcher.t
@@ -1,68 +1,55 @@
 use lib 't';
-use Test::APIcast 'no_plan';
+use Test::APIcast::Blackbox 'no_plan';
 
-use Cwd qw(abs_path);
+$ENV{APICAST_ACCESS_LOG_FILE} = "$Test::Nginx::Util::ErrLogFile";
 
-$ENV{TEST_NGINX_LUA_PATH} = "$Test::APIcast::spec/?.lua;$ENV{TEST_NGINX_LUA_PATH}";
+our $public_key = `cat t/fixtures/rsa.pub`;
+our $private_key = `cat t/fixtures/rsa.pem`;
 
-our $rsa = `cat t/fixtures/rsa.pem`;
-
-# Can't run twice because of the report batches
 repeat_each(1);
-
 run_tests();
 
 __DATA__
 
+
 === TEST 1: caches successful authorizations
 This test checks that the policy caches successful authorizations. To do that,
 we define a backend that makes sure that it's called only once.
---- http_config
-include $TEST_NGINX_UPSTREAM_CONFIG;
-lua_shared_dict cached_auths 1m;
-lua_shared_dict batched_reports 1m;
-lua_shared_dict batched_reports_locks 1m;
-lua_package_path "$TEST_NGINX_LUA_PATH";
-
-init_by_lua_block {
-  require('apicast.configuration_loader').mock({
-    services = {
-      {
-        id = 42,
-        backend_version = 1,
-        backend_authentication_type = 'service_token',
-        backend_authentication_value = 'token-value',
-        proxy = {
-          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" },
-          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
-          proxy_rules = {
-            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
-          },
-          policy_chain = {
-            { name = 'apicast.policy.3scale_batcher', configuration = {} },
-            { name = 'apicast.policy.apicast' }
-          }
-        }
+--- configuration
+{
+   "services" : [
+     {
+       "id" : 42,
+       "backend_version": 1,
+       "backend_authentication_type" : "service_token",
+       "backend_authentication_value" : "token-value",
+       "proxy" : {
+         "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/",
+         "proxy_rules": [
+           { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+         ],
+         "policy_chain" : [
+           { "name" : "apicast.policy.3scale_batcher", "configuration" : {} },
+           { "name" : "apicast.policy.apicast" }
+         ] 
+       }
+     }
+   ]
+}
+--- backend
+    location /transactions/authorize.xml {
+      content_by_lua_block {
+        local test_counter = ngx.shared.test_counter or 0
+        if test_counter == 0 then
+          ngx.shared.test_counter = test_counter + 1
+          ngx.exit(200)
+        else
+          ngx.log(ngx.ERR, 'auth should be cached but called backend anyway')
+          ngx.exit(502)
+        end
       }
     }
-  })
-}
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/authorize.xml {
-    content_by_lua_block {
-      local test_counter = ngx.shared.test_counter or 0
-      if test_counter == 0 then
-        ngx.shared.test_counter = test_counter + 1
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, 'auth should be cached but called backend anyway')
-        ngx.exit(502)
-      end
-    }
-  }
-
+--- upstream env
   location /api-backend {
      echo 'yay, api backend';
   }
@@ -75,57 +62,47 @@ init_by_lua_block {
 --- no_error_log
 [error]
 
-=== TEST 2: caches unsuccessful authorizations
-This test checks that the policy caches successful authorizations. To do that,
-we define a backend that makes sure that it's called only once.
---- http_config
-include $TEST_NGINX_UPSTREAM_CONFIG;
-lua_shared_dict cached_auths 1m;
-lua_shared_dict batched_reports 1m;
-lua_shared_dict batched_reports_locks 1m;
-lua_package_path "$TEST_NGINX_LUA_PATH";
 
-init_by_lua_block {
-  require('apicast.configuration_loader').mock({
-    services = {
-      {
-        id = 42,
-        backend_version = 1,
-        backend_authentication_type = 'service_token',
-        backend_authentication_value = 'token-value',
-        proxy = {
-          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" },
-          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
-          proxy_rules = {
-            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
-          },
-          policy_chain = {
-            { name = 'apicast.policy.3scale_batcher', configuration = {} },
-            { name = 'apicast.policy.apicast' }
-          }
-        }
+=== TEST 2: caches unsuccessful authorizations
+This test checks that the policy caches unsuccessful authorizations. To do that,
+we define a backend that makes sure that it's called only once.
+--- configuration
+{
+   "services" : [
+     {
+       "id" : 42,
+       "backend_version": 1,
+       "backend_authentication_type" : "service_token",
+       "backend_authentication_value" : "token-value",
+       "proxy" : {
+         "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/",
+         "proxy_rules": [
+           { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+         ],
+         "policy_chain" : [
+           { "name" : "apicast.policy.3scale_batcher", "configuration" : {} },
+           { "name" : "apicast.policy.apicast" }
+         ] 
+       }
+     }
+   ]
+}
+--- backend
+    location /transactions/authorize.xml {
+      content_by_lua_block {
+        local test_counter = ngx.shared.test_counter or 0
+        if test_counter == 0 then
+          ngx.shared.test_counter = test_counter + 1
+          ngx.header['3scale-rejection-reason'] = 'limits_exceeded'
+          ngx.status = 409
+          ngx.exit(ngx.HTTP_OK)
+        else
+          ngx.log(ngx.ERR, 'auth should be cached but called backend anyway')
+          ngx.exit(502)
+        end
       }
     }
-  })
-}
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/authorize.xml {
-    content_by_lua_block {
-      local test_counter = ngx.shared.test_counter or 0
-      if test_counter == 0 then
-        ngx.shared.test_counter = test_counter + 1
-        ngx.header['3scale-rejection-reason'] = 'limits_exceeded'
-        ngx.status = 409
-        ngx.exit(ngx.HTTP_OK)
-      else
-        ngx.log(ngx.ERR, 'auth should be cached but called backend anyway')
-        ngx.exit(502)
-      end
-    }
-  }
-
+--- upstream env
   location /api-backend {
      echo 'yay, api backend';
   }
@@ -138,6 +115,7 @@ init_by_lua_block {
 --- no_error_log
 [error]
 
+
 === TEST 3: reports hits correctly
 This test is a bit complex. We want to check that reports are sent correctly to
 backend. Reports are sent periodically and also when instances of the policy
@@ -147,71 +125,50 @@ in a shared dictionary that we'll check later. At the end of the test, we force
 a report to ensure that there are no pending reports, and then, we call an
 endpoint defined specifically for this test (/check_reports) that checks
 that the values accumulated in that shared dictionary are correct.
---- http_config
-include $TEST_NGINX_UPSTREAM_CONFIG;
-lua_shared_dict cached_auths 1m;
-lua_shared_dict batched_reports 1m;
-lua_shared_dict batched_reports_locks 1m;
-lua_package_path "$TEST_NGINX_LUA_PATH";
-init_by_lua_block {
-  require('apicast.configuration_loader').mock({
-    services = {
-      {
-        id = 1,
-        backend_version = 1,
-        backend_authentication_type = 'service_token',
-        backend_authentication_value = 'token-value',
-        proxy = {
-          hosts = { 'one' },
-          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" },
-          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
-          proxy_rules = {
-            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
-          },
-          policy_chain = {
-            {
-              name = 'apicast.policy.3scale_batcher',
-              configuration = { batch_report_seconds = 1 }
-            },
-            { name = 'apicast.policy.apicast' }
-          }
-        }
-      },
-      {
-        id = 2,
-        backend_version = 1,
-        backend_authentication_type = 'service_token',
-        backend_authentication_value = 'token-value',
-        proxy = {
-          hosts = { 'two' },
-          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" },
-          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
-          proxy_rules = {
-            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
-          },
-          policy_chain = {
-            {
-              name = 'apicast.policy.3scale_batcher',
-              configuration = { batch_report_seconds = 1 }
-            },
-            { name = 'apicast.policy.apicast' }
-          }
-        }
-      }
-    }
-  })
+--- configuration
+{
+   "services" : [
+     {
+       "id" : 1,
+       "backend_version": 1,
+       "backend_authentication_type" : "service_token",
+       "backend_authentication_value" : "token-value",
+       "proxy" : {
+         "hosts": ["one"],
+         "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+         "proxy_rules": [
+           { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+         ],
+         "policy_chain" : [
+           { "name" : "apicast.policy.3scale_batcher", "configuration" : { "batch_report_seconds": 1 } },
+           { "name" : "apicast.policy.apicast" }
+         ] 
+       }
+     },
+     {
+       "id" : 2,
+       "backend_version": 1,
+       "backend_authentication_type" : "service_token",
+       "backend_authentication_value" : "token-value",
+       "proxy" : {
+         "hosts": ["two"],
+         "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+         "proxy_rules": [
+           { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+         ],
+         "policy_chain" : [
+           { "name" : "apicast.policy.3scale_batcher", "configuration" : { "batch_report_seconds": 1 } },
+           { "name" : "apicast.policy.apicast" }
+         ] 
+       }
+     }
+   ]
 }
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
+--- backend
   location /transactions/authorize.xml {
     content_by_lua_block {
       ngx.exit(200)
     }
-  }
-
-  location /api-backend {
-     echo 'yay, api backend';
   }
 
   location /transactions.xml {
@@ -252,7 +209,11 @@ init_by_lua_block {
       end
     }
   }
-
+--- upstream 
+  location /api-backend {
+     echo 'yay, api backend';
+  }
+  
   location /force_report_to_backend {
     content_by_lua_block {
       local ReportsBatcher = require ('apicast.policy.3scale_batcher.reports_batcher')
@@ -273,7 +234,7 @@ init_by_lua_block {
             id = service_id,
             backend_authentication_type = 'service_token',
             backend_authentication_value = 'token-value',
-            backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" }
+            backend = { endpoint = "http://test_backend:$TEST_NGINX_SERVER_PORT" }
           }, http_ng_resty)
 
         reporter.report(reports, service_id, backend, reports_batcher)
@@ -302,12 +263,12 @@ my $res = [];
 
 for(my $i = 0; $i < 20; $i = $i + 1 ) {
   for(my $n = 1; $n <= 5; $n = $n + 1 ) {
-    push @$res, "GET /test?user_key=$n";
+    push @$res, "GET /api-backend?user_key=$n";
   }
 }
 
-push @$res, "GET /force_report_to_backend";
-push @$res, "GET /check_reports";
+push @$res, "GET /force_report_to_backend?user_key=foo";
+push @$res, "GET /check_reports?user_key=foo";
 
 $res
 --- more_headers eval
@@ -328,6 +289,7 @@ $res
 --- no_error_log
 [error]
 
+
 === TEST 4: after apicast policy in the chain
 We want to check that only the batcher policy is reporting to backend. We know
 that the APIcast policy calls "/transactions/authrep.xml" whereas the batcher
@@ -335,68 +297,55 @@ calls "/transactions/authorize.xml" and "/transactions.xml", because it
 authorizes and reports separately. Therefore, raising an error in
 "/transactions/authrep.xml" is enough to detect that the APIcast policy is
 calling backend when it's not supposed to.
---- http_config
-include $TEST_NGINX_UPSTREAM_CONFIG;
-lua_shared_dict cached_auths 1m;
-lua_shared_dict batched_reports 1m;
-lua_shared_dict batched_reports_locks 1m;
-lua_package_path "$TEST_NGINX_LUA_PATH";
-init_by_lua_block {
-  require('apicast.configuration_loader').mock({
-    services = {
-      {
-        id = 1,
-        backend_version = 1,
-        backend_authentication_type = 'service_token',
-        backend_authentication_value = 'token-value',
-        proxy = {
-          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" },
-          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
-          proxy_rules = {
-            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
-          },
-          policy_chain = {
-            { name = 'apicast.policy.apicast' },
-            {
-              name = 'apicast.policy.3scale_batcher',
-              configuration = { batch_report_seconds = 1 }
-            }
-          }
-        }
+--- configuration
+{
+   "services" : [
+     {
+       "id" : 42,
+       "backend_version": 1,
+       "backend_authentication_type" : "service_token",
+       "backend_authentication_value" : "token-value",
+       "proxy" : {
+         "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/",
+         "proxy_rules": [
+           { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+         ],
+         "policy_chain" : [
+           { "name" : "apicast.policy.apicast" },
+           { "name" : "apicast.policy.3scale_batcher", "configuration" : { "batch_report_seconds" : 1 } }
+         ] 
+       }
+     }
+   ]
+}
+--- backend
+    location /transactions/authrep.xml {
+      content_by_lua_block {
+        ngx.log(ngx.ERR, 'APIcast policy called authrep and it was not supposed to!')
       }
     }
-  })
-}
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/authrep.xml {
-    content_by_lua_block {
-      ngx.log(ngx.ERR, 'APIcast policy called authrep and it was not supposed to!')
+   
+    location /transactions/authorize.xml {
+      content_by_lua_block {
+        ngx.exit(200)
+      }
     }
-  }
 
-  location /transactions/authorize.xml {
-    content_by_lua_block {
-      ngx.exit(200)
+    location /transactions/transactions.xml {
+      content_by_lua_block {
+        ngx.exit(200)
+      }
     }
-  }
-
+--- upstream env
   location /api-backend {
      echo 'yay, api backend';
   }
-
-  location /transactions.xml {
-    content_by_lua_block {
-      ngx.exit(200)
-    }
-  }
-
 --- request
 GET /test?user_key=uk
 --- error_code: 200
 --- no_error_log
 [error]
+
 
 === TEST 5: with caching policy (resilient mode)
 The purpose of this test is to test that the 3scale batcher policy works
@@ -407,176 +356,148 @@ The caching policy will cache the first result and return it while backend is
 down.
 To make sure that nothing is cached in the 3scale batcher policy, we flush its
 auth cache on every request (see rewrite_by_lua_block).
---- http_config
-include $TEST_NGINX_UPSTREAM_CONFIG;
-lua_shared_dict api_keys 10m;
-lua_shared_dict cached_auths 1m;
-lua_shared_dict batched_reports 1m;
-lua_shared_dict batched_reports_locks 1m;
-lua_package_path "$TEST_NGINX_LUA_PATH";
-
-init_by_lua_block {
-  require('apicast.configuration_loader').mock({
-    services = {
-      {
-        id = 42,
-        backend_version = 1,
-        backend_authentication_type = 'service_token',
-        backend_authentication_value = 'token-value',
-        proxy = {
-          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" },
-          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
-          proxy_rules = {
-            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
-          },
-          policy_chain = {
-            {
-              name = 'apicast.policy.3scale_batcher',
-              configuration = { }
-            },
-            {
-              name = 'apicast.policy.apicast'
-            },
-            {
-              name = 'apicast.policy.caching',
-              configuration = { caching_type = 'resilient' }
-            }
-          }
-        }
+--- configuration
+{
+   "services" : [
+     {
+       "id" : 42,
+       "backend_version": 1,
+       "backend_authentication_type" : "service_token",
+       "backend_authentication_value" : "token-value",
+       "proxy" : {
+         "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/",
+         "proxy_rules": [
+           { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+         ],
+         "policy_chain" : [
+           { 
+             "name" : "apicast.policy.3scale_batcher",
+             "configuration" : {} 
+           },
+           { "name" : "apicast.policy.apicast" },
+           { 
+             "name": "apicast.policy.caching", 
+             "configuration": { "caching_type": "resilient" }
+           }
+         ] 
+       }
+     }
+   ]
+}
+--- backend
+    location /transactions/authorize.xml {
+      content_by_lua_block {
+        local test_counter = ngx.shared.test_counter or 0
+        if test_counter == 0 then
+          ngx.shared.test_counter = test_counter + 1
+          ngx.status = 200
+          ngx.exit(ngx.HTTP_OK)
+        else
+          ngx.shared.test_counter = test_counter + 1
+          ngx.exit(502)
+        end
       }
     }
-  })
-}
-
-rewrite_by_lua_block {
-  require('resty.ctx').apply()
-  ngx.shared.cached_auths:flush_all()
-}
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/authorize.xml {
-    content_by_lua_block {
-      local test_counter = ngx.shared.test_counter or 0
-      if test_counter == 0 then
-        ngx.shared.test_counter = test_counter + 1
-        ngx.status = 200
-        ngx.exit(ngx.HTTP_OK)
-      else
-        ngx.shared.test_counter = test_counter + 1
-        ngx.exit(502)
-      end
-    }
-  }
-
+--- upstream env
   location /api-backend {
+    rewrite_by_lua_block {
+      require('resty.ctx').apply()
+      ngx.shared.cached_auths:flush_all()
+    }
      echo 'yay, api backend';
   }
---- request eval
+--- request eval 
 ["GET /test?user_key=foo", "GET /foo?user_key=foo", "GET /?user_key=foo"]
---- response_body eval
+--- response_body eval 
 ["yay, api backend\x{0a}", "yay, api backend\x{0a}", "yay, api backend\x{0a}"]
---- error_code eval
+--- error_code eval 
 [ 200, 200, 200 ]
 --- no_error_log
-[error]
+[error] 
+
 
 === TEST 6: caches successful authorizations with app_id only
 This test checks that the policy a) caches successful authorizations and b) reports correctly.
 For a) we define a backend that makes sure that it's called only once.
 For b) we force the batch reporting and check that transactions.xml receive it in the expected format.
---- http_config
-include $TEST_NGINX_UPSTREAM_CONFIG;
-lua_shared_dict cached_auths 1m;
-lua_shared_dict batched_reports 1m;
-lua_shared_dict batched_reports_locks 1m;
-lua_package_path "$TEST_NGINX_LUA_PATH";
-
-init_by_lua_block {
-  require('apicast.configuration_loader').mock({
-    oidc = {
-      {
-        issuer = "https://example.com/auth/realms/apicast",
-        config = { id_token_signing_alg_values_supported = { "RS256" } },
-        keys = { somekid = { pem = require('fixtures.rsa').pub, alg = 'RS256' } },
-      }
-    },
-    services = {
-      {
-        id = 42,
-        backend_version = 'oauth',
-        backend_authentication_type = 'service_token',
-        backend_authentication_value = 'token-value',
-        proxy = {
-          authentication_method = 'oidc',
-          oidc_issuer_endpoint = 'https://example.com/auth/realms/apicast',
-          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" },
-          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
-          proxy_rules = {
-            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1 }
-          },
-          policy_chain = {
-            { name = 'apicast.policy.3scale_batcher', configuration = {} },
-            { name = 'apicast.policy.apicast' }
-          }
-        }
-      }
-    }
-  })
-}
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/oauth_authorize.xml {
-    content_by_lua_block {
-      local test_counter = ngx.shared.test_counter or 0
-      if test_counter == 0 then
-        ngx.shared.test_counter = test_counter + 1
-        ngx.exit(200)
-      else
-        ngx.log(ngx.ERR, 'auth should be cached but called backend anyway')
-        ngx.exit(502)
-      end
+--- configuration env eval
+use JSON qw(to_json);
+to_json({
+  services => [{
+    id => 42,
+    backend_version => 'oauth',
+    backend_authentication_type => 'service_token',
+    backend_authentication_value => 'token-value',
+    proxy => {
+      authentication_method => 'oidc',
+      oidc_issuer_endpoint => 'https://example.com/auth/realms/apicast',
+      api_backend => "http://test:$TEST_NGINX_SERVER_PORT/",
+      proxy_rules => [
+          { pattern => '/', http_method => 'GET', metric_system_name => 'hits', delta => 1  }
+      ],
+      policy_chain => [
+        {
+          name => "apicast.policy.3scale_batcher",
+          configuration => {}
+        },
+        {name => "apicast.policy.apicast"}
+      ]
     }
   }
-  location /transactions.xml {
-    content_by_lua_block {
-      ngx.req.read_body()
-      local post_args = ngx.req.get_post_args()
-      local app_id_match, usage_match
-      for k, v in pairs(post_args) do
-        if k == 'transactions[0][app_key]' then
-          ngx.exit(500)
-        elseif k == 'transactions[0][usage][hits]' then
-          usage_match = v == '2'
-        elseif k == 'transactions[0][app_id]' then
-          app_id_match = v == 'appid'
+  ],
+    oidc => [{
+    issuer => 'https://example.com/auth/realms/apicast',
+    config => { id_token_signing_alg_values_supported => [ 'RS256' ] },
+    keys => { somekid => { pem => $::public_key, alg => 'RS256' } },
+  }]
+});
+--- backend
+    location /transactions/oauth_authorize.xml {
+      content_by_lua_block {
+        local test_counter = ngx.shared.test_counter or 0
+        if test_counter == 0 then
+          ngx.shared.test_counter = test_counter + 1
+          ngx.exit(200)
+        else
+          ngx.log(ngx.ERR, 'auth should be cached but called backend anyway')
+          ngx.exit(502)
         end
-      end
-      ngx.shared.result = usage_match and app_id_match
+      }
     }
+    location /transactions.xml {
+      content_by_lua_block {
+        ngx.req.read_body()
+        local post_args = ngx.req.get_post_args()
+        local app_id_match, usage_match
+        for k, v in pairs(post_args) do
+          if k == 'transactions[0][app_key]' then
+            ngx.exit(500)
+          elseif k == 'transactions[0][usage][hits]' then
+            usage_match = v == '3'
+          elseif k == 'transactions[0][app_id]' then
+            app_id_match = v == 'appid'
+          end
+        end
+        ngx.shared.result = usage_match and app_id_match
+      }
   }
-
+--- upstream env
   location /force_report_to_backend {
     content_by_lua_block {
       local ReportsBatcher = require ('apicast.policy.3scale_batcher.reports_batcher')
       local reporter = require ('apicast.policy.3scale_batcher.reporter')
       local http_ng_resty = require('resty.http_ng.backend.resty')
       local backend_client = require('apicast.backend_client')
-
       local service_id = '42'
-
       local reports_batcher = ReportsBatcher.new(
         ngx.shared.batched_reports, 'batched_reports_locks')
-
       local reports = reports_batcher:get_all(service_id)
-
       local backend = backend_client:new(
         {
           id = service_id,
           backend_authentication_type = 'service_token',
           backend_authentication_value = 'token-value',
-          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" }
+          backend = { endpoint = "http://test_backend:$TEST_NGINX_SERVER_PORT" }
         }, http_ng_resty)
 
       reporter.report(reports, service_id, backend, reports_batcher)
@@ -599,7 +520,7 @@ init_by_lua_block {
      echo 'yay, api backend';
   }
 --- request eval
-[ "GET /test", "GET /test", "GET /force_report_to_backend", "GET /check_reports"]
+[ "GET /api-backend", "GET /api-backend", "GET /force_report_to_backend", "GET /check_reports"]
 --- error_code eval
 [ 200, 200 , 200, 200 ]
 --- response_body eval
@@ -611,8 +532,8 @@ my $jwt = encode_jwt(payload => {
   azp => 'appid',
   sub => 'someone',
   iss => 'https://example.com/auth/realms/apicast',
-  exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers => { kid => 'somekid' });
-["Authorization: Bearer $jwt", "Authorization: Bearer $jwt", "" , ""]
+  exp => time + 3600 }, key => \$::private_key, alg => 'RS256', extra_headers => { kid => 'somekid' });
+["Authorization: Bearer $jwt", "Authorization: Bearer $jwt", "Authorization: Bearer $jwt" , "Authorization: Bearer $jwt"]
 --- no_error_log
 [error]
 
@@ -625,68 +546,53 @@ backend that returns 500
 The caching policy will allow all request to the Upstream API.
 To make sure that nothing is cached in the 3scale batcher policy, we flush its
 auth cache on every request (see rewrite_by_lua_block).
---- http_config
-include $TEST_NGINX_UPSTREAM_CONFIG;
-lua_shared_dict api_keys 10m;
-lua_shared_dict cached_auths 1m;
-lua_shared_dict batched_reports 1m;
-lua_shared_dict batched_reports_locks 1m;
-lua_package_path "$TEST_NGINX_LUA_PATH";
-
-init_by_lua_block {
-  require('apicast.configuration_loader').mock({
-    services = {
-      {
-        id = 42,
-        backend_version = 1,
-        backend_authentication_type = 'service_token',
-        backend_authentication_value = 'token-value',
-        proxy = {
-          backend = { endpoint = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT" },
-          api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
-          proxy_rules = {
-            { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 2 }
-          },
-          policy_chain = {
-            {
-              name = 'apicast.policy.3scale_batcher',
-              configuration = { }
-            },
-            {
-              name = 'apicast.policy.apicast'
-            },
-            {
-              name = 'apicast.policy.caching',
-              configuration = { caching_type = 'allow' }
-            }
-          }
-        }
+--- configuration
+{
+   "services" : [
+     {
+       "id" : 42,
+       "backend_version": 1,
+       "backend_authentication_type" : "service_token",
+       "backend_authentication_value" : "token-value",
+       "proxy" : {
+         "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/",
+         "proxy_rules": [
+           { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+         ],
+         "policy_chain" : [
+           { 
+             "name" : "apicast.policy.3scale_batcher",
+             "configuration" : {} 
+           },
+           { "name" : "apicast.policy.apicast" },
+           { 
+             "name": "apicast.policy.caching", 
+             "configuration": { "caching_type": "allow" }
+           }
+         ] 
+       }
+     }
+   ]
+}
+--- backend
+    location /transactions/authorize.xml {
+      content_by_lua_block {
+        ngx.exit(500)
       }
     }
-  })
-}
-
-rewrite_by_lua_block {
-  require('resty.ctx').apply()
-  ngx.shared.cached_auths:flush_all()
-}
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/authorize.xml {
-    content_by_lua_block {
-      ngx.exit(500)
-    }
-  }
-
+--- upstream env
   location /api-backend {
+    rewrite_by_lua_block {
+      require('resty.ctx').apply()
+      ngx.shared.cached_auths:flush_all()
+    }
      echo 'yay, api backend';
   }
---- request eval
+--- request eval 
 ["GET /test?user_key=foo", "GET /foo?user_key=foo", "GET /?user_key=foo"]
---- response_body eval
+--- response_body eval 
 ["yay, api backend\x{0a}", "yay, api backend\x{0a}", "yay, api backend\x{0a}"]
---- error_code eval
+--- error_code eval 
 [ 200, 200, 200 ]
 --- no_error_log
-[error]
+[error] 

--- a/t/apicast-policy-chains-crash.t
+++ b/t/apicast-policy-chains-crash.t
@@ -1,0 +1,34 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+$ENV{APICAST_ACCESS_LOG_FILE} = "$Test::Nginx::Util::ErrLogFile";
+$ENV{APICAST_POLICY_LOAD_PATH} = 't/fixtures/policies';
+
+repeat_each(1);
+run_tests();
+
+__DATA__
+
+=== TEST 1: policy chain with a policy that crashes on new()
+Policies that crash when initialized should be removed from the chain
+--- configuration
+{
+    "services": [
+      {
+        "id": 42,
+        "proxy": {
+            "policy_chain" : [
+              { "name" : "error_policy", "version" : "1.0.0" },
+              { "name" : "apicast.policy.echo" } 
+            ]
+        }
+      }
+    ]
+}
+--- request
+GET /test
+--- response_body
+GET /test HTTP/1.1
+--- error_code: 200
+--- error_log
+Policy error_policy crashed in .new()

--- a/t/apicast-policy-chains.t
+++ b/t/apicast-policy-chains.t
@@ -1,13 +1,8 @@
 use lib 't';
-use Test::APIcast 'no_plan';
+use Test::APIcast::Blackbox 'no_plan';
 
-BEGIN {
-    $ENV{APICAST_POLICY_LOAD_PATH} = 't/fixtures/policies';
-}
-
-env_to_nginx(
-    'APICAST_POLICY_LOAD_PATH'
-);
+$ENV{APICAST_ACCESS_LOG_FILE} = "$Test::Nginx::Util::ErrLogFile";
+$ENV{APICAST_POLICY_LOAD_PATH} = 't/fixtures/policies';
 
 run_tests();
 
@@ -19,47 +14,37 @@ when we use a policy chain that contains it. The policy chain also contains the
 normal apicast policy, so we can check that the authorize flow continues working.
 Phases init and init_worker do not appear in the test because they're run just
 once, not on every request.
-
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-  init_by_lua_block {
-    require('apicast.configuration_loader').mock({
-      services = {
-        {
-          id = 42,
-          backend_version = 1,
-          backend_authentication_type = 'service_token',
-          backend_authentication_value = 'token-value',
-          proxy = {
-            policy_chain = { { name = 'apicast.policy.phase_logger' }, { name = 'apicast.policy.apicast' } },
-            api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
-            proxy_rules = {
-              {
-                http_method = "GET",
-                pattern = "/test",
-                metric_system_name = "hits",
-                delta = 1
-              }
-            }
-          }
+--- configuration
+{
+    "services": [
+      {
+        "id": 42,
+        "backend_version": 1,
+        "backend_authentication_type": "service_token",
+        "backend_authentication_value": "token-value",
+        "proxy": {
+            "policy_chain" : [
+              { "name" : "apicast.policy.phase_logger" },
+              { "name" : "apicast.policy.apicast" } 
+            ],
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/",
+            "proxy_rules": [
+                { "pattern" : "/", "http_method" : "GET", "metric_system_name" : "hits", "delta" : 1 }
+            ]
         }
       }
-    })
-  }
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/authrep.xml {
-    content_by_lua_block { ngx.exit(200) }
-  }
-
-  location /api-backend/ {
-     echo 'yay, api backend';
-  }
+    ]
+}
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block { ngx.exit(200) }
+}
+--- upstream
+location /api-backend/ {
+  echo 'yay, api backend';
+}
 --- request
-GET /test?user_key=abc
+GET /?user_key=abc
 --- response_body
 yay, api backend
 --- error_code: 200
@@ -76,50 +61,35 @@ running phase: post_action
 running phase: log
 
 
-
 === TEST 2: custom policy chain responds with content
 This tests uses phase logger policy to verify all needed phases are executed.
 When some policy responds with content header_filter, body_filter and post_actions should
 still be executed.
-
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-  init_by_lua_block {
-    require('apicast.configuration_loader').mock({
-      services = {
-        {
-          id = 42,
-          backend_version = 1,
-          backend_authentication_type = 'service_token',
-          backend_authentication_value = 'token-value',
-          proxy = {
-            policy_chain = { { name = 'apicast.policy.phase_logger' }, { name = 'apicast.policy.echo' } },
-            api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
-            proxy_rules = {
-              {
-                http_method = "GET",
-                pattern = "/test",
-                metric_system_name = "hits",
-                delta = 1
-              }
-            }
-          }
+--- configuration
+{
+    "services": [
+      {
+        "id": 42,
+        "backend_version": 1,
+        "backend_authentication_type": "service_token",
+        "backend_authentication_value": "token-value",
+        "proxy": {
+            "policy_chain" : [
+              { "name" : "apicast.policy.phase_logger" },
+              { "name" : "apicast.policy.echo" } 
+            ],
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/",
+            "proxy_rules": [
+                { "pattern" : "/", "http_method" : "GET", "metric_system_name" : "hits", "delta" : 1 }
+            ]
         }
       }
-    })
-  }
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/authrep.xml {
-    content_by_lua_block { ngx.exit(200) }
-  }
-
-  location /api-backend/ {
-     echo 'yay, api backend';
-  }
+    ]
+}
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block { ngx.exit(200) }
+}
 --- request
 GET /test
 --- response_body
@@ -140,46 +110,34 @@ running phase: log
 === TEST 3: null policy chain
 When policy chain is null, the default Apicast plugin is used and authorizes
 as expected.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-  init_by_lua_block {
-    require('apicast.configuration_loader').mock({
-      services = {
-        {
-          id = 42,
-          backend_version = 1,
-          backend_authentication_type = 'service_token',
-          backend_authentication_value = 'token-value',
-          proxy = {
-            policy_chain = ngx.null,
-            api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
-            proxy_rules = {
-              {
-                http_method = "GET",
-                pattern = "/test",
-                metric_system_name = "hits",
-                delta = 1
-              }
-            }
-          }
+--- configuration
+{
+    "services": [
+      {
+        "id": 42,
+        "backend_version": 1,
+        "backend_authentication_type": "service_token",
+        "backend_authentication_value": "token-value",
+        "proxy": {
+            "policy_chain" : null,
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/",
+            "proxy_rules": [
+                { "pattern" : "/", "http_method" : "GET", "metric_system_name" : "hits", "delta" : 1 }
+            ]
         }
       }
-    })
-  }
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/authrep.xml {
-    content_by_lua_block { ngx.exit(200) }
-  }
-
-  location /api-backend/ {
-     echo 'yay, api backend';
-  }
+    ]
+}
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block { ngx.exit(200) }
+}
+--- upstream
+location /api-backend/ {
+  echo 'yay, api backend';
+}
 --- request
-GET /test?user_key=abc
+GET /?user_key=abc
 --- response_body
 yay, api backend
 --- error_code: 200
@@ -187,47 +145,34 @@ yay, api backend
 [error]
 
 
-
 === TEST 4: policy chain with invalid elements
 Invalid policies are removed from the chain.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-  init_by_lua_block {
-    require('apicast.configuration_loader').mock({
-      services = {
-        {
-          id = 42,
-          backend_version = 1,
-          backend_authentication_type = 'service_token',
-          backend_authentication_value = 'token-value',
-          proxy = {
-            policy_chain = {
-              { name = 'apicast.policy.phase_logger' },
-              { name = 'invalid' },
-              { name = 'apicast.policy.echo' }
-            },
-            api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
-            proxy_rules = {
-              {
-                http_method = "GET",
-                pattern = "/test",
-                metric_system_name = "hits",
-                delta = 1
-              }
-            }
-          }
+--- configuration
+{
+    "services": [
+      {
+        "id": 42,
+        "backend_version": 1,
+        "backend_authentication_type": "service_token",
+        "backend_authentication_value": "token-value",
+        "proxy": {
+            "policy_chain" : [
+              { "name" : "apicast.policy.phase_logger" },
+              { "name" : "invalid" },
+              { "name" : "apicast.policy.echo" } 
+            ],
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/",
+            "proxy_rules": [
+                { "pattern" : "/", "http_method" : "GET", "metric_system_name" : "hits", "delta" : 1 }
+            ]
         }
       }
-    })
-  }
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/authrep.xml {
-    content_by_lua_block { ngx.exit(200) }
-  }
+    ]
+}
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block { ngx.exit(200) }
+}
 --- request
 GET /test
 --- response_body
@@ -243,38 +188,3 @@ running phase: log
 --- error_code: 200
 --- no_error_log
 [error]
-
-=== TEST 5: policy chain with a policy that crashes on new()
-Policies that crash when initialized should be removed from the chain
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-  init_by_lua_block {
-    require('apicast.configuration_loader').mock({
-      services = {
-        {
-          id = 42,
-          proxy = {
-            policy_chain = {
-              { name = 'error_policy', version = '1.0.0' },
-              { name = 'apicast.policy.echo' }
-            }
-          }
-        }
-      }
-    })
-  }
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/authrep.xml {
-    content_by_lua_block { ngx.exit(200) }
-  }
---- request
-GET /test
---- response_body
-GET /test HTTP/1.1
---- error_code: 200
---- error_log
-Policy error_policy crashed in .new()

--- a/t/apicast-policy-rate-limit.t
+++ b/t/apicast-policy-rate-limit.t
@@ -1,969 +1,1105 @@
 use lib 't';
-use Test::APIcast 'no_plan';
-use Cwd qw(abs_path);
+use Test::APIcast::Blackbox 'no_plan';
 
-$ENV{TEST_NGINX_LUA_PATH} = "$Test::APIcast::spec/?.lua;$ENV{TEST_NGINX_LUA_PATH}";
 $ENV{TEST_NGINX_REDIS_HOST} ||= $ENV{REDIS_HOST} || "127.0.0.1";
 $ENV{TEST_NGINX_REDIS_PORT} ||= $ENV{REDIS_PORT} || 6379;
-$ENV{BACKEND_ENDPOINT_OVERRIDE} ||= "http://127.0.0.1:$Test::Nginx::Util::ServerPortForClient/backend";
+$ENV{APICAST_ACCESS_LOG_FILE} = "$Test::Nginx::Util::ErrLogFile";
 
-our $rsa = `cat t/fixtures/rsa.pem`;
-env_to_nginx('BACKEND_ENDPOINT_OVERRIDE');
+our $private_key = `cat t/fixtures/rsa.pem`;
+our $public_key = `cat t/fixtures/rsa.pub`;
 
 repeat_each(1);
+check_accum_error_log();
 run_tests();
 
 __DATA__
 
 === TEST 1: Delay (conn) service scope.
 Return 200 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
-        {
-          id = 42,
-          proxy = {
-            policy_chain = {
-              {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
-                    {
-                      key = {name = "test1", scope = "service"},
-                      conn = 1,
-                      burst = 1,
-                      delay = 2
-                    }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
-                }
-              },
-              {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
-                    {
-                      key = {name = "test1", scope = "service"},
-                      conn = 1,
-                      burst = 1,
-                      delay = 2
-                    }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
-                }
-              }
-            }
-          }
-        }
+--- configuration
+{
+  "services" : [
+    {
+      "id" : 2,
+      "backend_version": 1,
+      "proxy" : {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "hosts": ["flush.redis"]
       }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/authrep.xml {
-    content_by_lua_block { ngx.exit(200) }
-  }
-
-  location /flush_redis {
-    content_by_lua_block {
-      local redis = require('apicast.threescale_utils').connect_redis({
-         host = "$TEST_NGINX_REDIS_HOST",
-         port = "$TEST_NGINX_REDIS_PORT",
-         db=1})
-      redis:del('42_connections_test1')
+    },
+    {
+      "id" : 42,
+      "backend_version" : 1,
+      "proxy" : {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain" : [
+          {
+            "name" : "apicast.policy.rate_limit",
+            "configuration" : {
+              "connection_limiters" : [
+                {
+                  "key" : {"name" : "test2", "scope" : "service"},
+                  "conn" : 1,
+                  "burst" : 1,
+                  "delay" : 2
+                }
+              ],
+              "redis_url" : "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
+            }
+          },{
+            "name" : "apicast.policy.rate_limit",
+            "configuration" : {
+              "connection_limiters" : [
+                {
+                  "key" : {"name" : "test2", "scope" : "service"},
+                  "conn" : 1,
+                  "burst" : 1,
+                  "delay" : 2
+                }
+              ],
+              "redis_url" : "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
+            }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
     }
-  }
-
+  ]
+}
+--- backend
+    location /transactions/authrep.xml {
+      content_by_lua_block {
+        ngx.exit(200)
+      }
+    }
+--- upstream env
+    location /flush {
+        content_by_lua_block {
+          local redis = require('apicast.threescale_utils').connect_redis({
+             host = "$TEST_NGINX_REDIS_HOST",
+             port = "$TEST_NGINX_REDIS_PORT",
+             db = 1})
+          redis:del('connections_test1')
+        }
+    }
 --- pipelined_requests eval
-["GET /flush_redis","GET /"]
+["GET http://flush.redis/flush?user_key=foo","GET /?user_key=value"]
 --- error_code eval
 [200, 200]
+--- no_error_log
+[error]
+--- error_log
+need to delay by
+
 
 === TEST 2: Delay (conn) default service scope.
 Return 200 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
-        {
-          id = 42,
-          proxy = {
-            policy_chain = {
-              {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
-                    {
-                      key = {name = "test2"},
-                      conn = 1,
-                      burst = 1,
-                      delay = 2
-                    }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
-                }
-              },
-              {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
-                    {
-                      key = {name = "test2"},
-                      conn = 1,
-                      burst = 1,
-                      delay = 2
-                    }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
-                }
-              }
-            }
-          }
-        }
+--- configuration
+{
+  "services" : [
+    {
+      "id" : 2,
+      "backend_version": 1,
+      "proxy" : {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "hosts": ["flush.redis"]
       }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/authrep.xml {
-    content_by_lua_block { ngx.exit(200) }
-  }
-
-  location /flush_redis {
-    content_by_lua_block {
-      local redis = require('apicast.threescale_utils').connect_redis({
-         host = "$TEST_NGINX_REDIS_HOST",
-         port = "$TEST_NGINX_REDIS_PORT",
-         db=1})
-      redis:del('42_connections_test2')
+    },
+    {
+      "id" : 42,
+      "backend_version" : 1,
+      "proxy" : {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain" : [
+          {
+            "name" : "apicast.policy.rate_limit",
+            "configuration" : {
+              "connection_limiters" : [
+                {
+                  "key" : {"name" : "test2"},
+                  "conn" : 1,
+                  "burst" : 1,
+                  "delay" : 2
+                }
+              ],
+              "redis_url" : "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
+            }
+          },{
+            "name" : "apicast.policy.rate_limit",
+            "configuration" : {
+              "connection_limiters" : [
+                {
+                  "key" : {"name" : "test2"},
+                  "conn" : 1,
+                  "burst" : 1,
+                  "delay" : 2
+                }
+              ],
+              "redis_url" : "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
+            }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
     }
-  }
-
+  ]
+}
+--- backend
+    location /transactions/authrep.xml {
+      content_by_lua_block {
+        ngx.exit(200)
+      }
+    }
+--- upstream env
+    location /flush {
+        content_by_lua_block {
+          local redis = require('apicast.threescale_utils').connect_redis({
+             host = "$TEST_NGINX_REDIS_HOST",
+             port = "$TEST_NGINX_REDIS_PORT",
+             db = 1})
+          redis:del('connections_test2')
+        }
+    }
 --- pipelined_requests eval
-["GET /flush_redis","GET /"]
+["GET http://flush.redis/flush?user_key=foo","GET /?user_key=value"]
 --- error_code eval
 [200, 200]
+--- no_error_log
+[error]
+--- error_log
+need to delay by
+
 
 === TEST 3: Invalid redis url.
 Return 500 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
-        {
-          id = 42,
-          proxy = {
-            policy_chain = {
-              {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
-                    {
-                      key = {name = "test3", scope = "global"},
-                      conn = 20,
-                      burst = 10,
-                      delay = 0.5
-                    }
-                  },
-                  redis_url = "redis://invalidhost:$TEST_NGINX_REDIS_PORT/1"
+--- configuration
+{
+  "services" : [
+    {
+      "id" : 42,
+      "proxy" : {
+        "policy_chain" : [
+          {
+            "name" : "apicast.policy.rate_limit",
+            "configuration" : {
+              "connection_limiters" : [
+                {
+                  "key" : {"name" : "test3", "scope" : "global"},
+                  "conn" : 20,
+                  "burst" : 10,
+                  "delay" : 0.5
                 }
-              }
+              ],
+              "redis_url" : "redis://invalidhost:$TEST_NGINX_REDIS_PORT/1"
             }
           }
-        }
+        ]
       }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
+    }
+  ]
+}
 --- request
 GET /
 --- error_code: 500
+--- no_error_log
+[error]
+--- error_log
+query for invalidhost finished with no answers
+
 
 === TEST 4: Rejected (conn) logging only.
 Return 200 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
+--- configuration
+    {
+      "services" : [
         {
-          id = 42,
-          proxy = {
-            policy_chain = {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.redis"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
               {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "connection_limiters" : [
                     {
-                      key = {name = "test4", scope = "global"},
-                      conn = 1,
-                      burst = 0,
-                      delay = 2
-                    }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
-                  limits_exceeded_error  = { error_handling = "log" }
-                }
-              },
-              {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
+                      "key" : {"name" : "test4", "scope" : "global"},
+                      "conn" : 1,
+                      "burst" : 0,
+                      "delay" : 2
+                    },
                     {
-                      key = {name = "test4", scope = "global"},
-                      conn = 1,
-                      burst = 0,
-                      delay = 2
+                      "key" : {"name" : "test4", "scope" : "global"},
+                      "conn" : 1,
+                      "burst" : 0,
+                      "delay" : 2
                     }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
-                  limits_exceeded_error  = { error_handling = "log" }
+                  ],
+                  "redis_url" : "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
+                  "limits_exceeded_error" : { "error_handling" : "log" }
                 }
               }
-            }
+            ]
           }
         }
-      }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /flush_redis {
-    content_by_lua_block {
-      local redis = require('apicast.threescale_utils').connect_redis({
-         host = "$TEST_NGINX_REDIS_HOST",
-         port = "$TEST_NGINX_REDIS_PORT",
-         db=1})
-      redis:del('connections_test4')
+      ]
     }
-  }
-
+--- backend
+    location /transactions/authrep.xml {
+      content_by_lua_block {
+        ngx.exit(200)
+      }
+    }
+--- upstream env
+    location /flush {
+        content_by_lua_block {
+          local redis = require('apicast.threescale_utils').connect_redis({
+             host = "$TEST_NGINX_REDIS_HOST",
+             port = "$TEST_NGINX_REDIS_PORT",
+             db = 1})
+          redis:del('connections_test7')
+        }
+    }
 --- pipelined_requests eval
-["GET /flush_redis","GET /"]
+["GET http://flush.redis/flush?user_key=foo","GET /?user_key=foo","GET /?user_key=foo"]
 --- error_code eval
-[200, 200]
+[200, 200, 200]
+--- no_error_log
+[error]
+--- error_log
+Requests over the limit.
+
 
 === TEST 5: No redis url.
 Return 200 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
-        {
-          id = 42,
-          proxy = {
-            policy_chain = {
-              {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
-                    {
-                      key = {name = "test5", scope = "global"},
-                      conn = 20,
-                      burst = 10,
-                      delay = 0.5
-                    }
-                  }
+--- configuration
+{
+  "services" : [
+    {
+      "id" : 2,
+      "backend_version": 1,
+      "proxy" : {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "hosts": ["flush.limiter"]
+      }
+    },
+    {
+      "id" : 42,
+      "proxy" : {
+        "policy_chain" : [
+          {
+            "name" : "apicast.policy.rate_limit",
+            "configuration" : {
+              "connection_limiters" : [
+                {
+                  "key" : {"name" : "test5", "scope" : "global"},
+                  "conn" : 20,
+                  "burst" : 10,
+                  "delay" : 0.5
                 }
-              }
+              ]
             }
           }
-        }
+        ]
       }
-    })
+    }
+  ]
+}
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
   }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
---- request
-GET /
---- error_code: 200
+}
+--- upstream env
+    location /flush {
+      content_by_lua_block {
+        require "resty.core"
+        ngx.shared.limiter:flush_all()
+      }
+    }
+--- request eval
+["GET http://flush.limiter/flush?user_key=foo", "GET /?user_key=foo"]
+--- error_code eval 
+[200, 200]
 --- no_error_log
 [error]
 
+
 === TEST 6: Success with multiple limiters.
 Return 200 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
+--- configuration
+    {
+      "services" : [
         {
-          id = 42,
-          proxy = {
-            policy_chain = {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.redis"]
+          }
+        },
+        {
+          "id" : 42,
+          "backend_version" : 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+            ],
+            "policy_chain" : [
               {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  leaky_bucket_limiters = {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "leaky_bucket_limiters" : [
                     {
-                      key = {name = "test6_1", scope = "global"},
-                      rate = 20,
-                      burst = 10
+                      "key" : {"name" : "test6_1", "scope" : "global"},
+                      "rate" : 20,
+                      "burst" : 10
                     }
-                  },
-                  connection_limiters = {
+                  ],
+                  "connection_limiters" : [
                     {
-                      key = {name = "test6_2", scope = "global"},
-                      conn = 20,
-                      burst = 10,
-                      delay = 0.5
+                      "key" : {"name" : "test6_2", "scope" : "global"},
+                      "conn" : 20,
+                      "burst" : 10,
+                      "delay" : 0.5
                     }
-                  },
-                  fixed_window_limiters = {
+                  ],
+                  "fixed_window_limiters" : [
                     {
-                      key = {name = "test6_3", scope = "global"},
-                      count = 20,
-                      window = 10
+                      "key" : {"name" : "test6_3", "scope" : "global"},
+                      "count" : 20,
+                      "window" : 10
                     }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
+                  ],
+                  "redis_url" : "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
                 }
-              }
-            }
+              },
+              { "name": "apicast.policy.apicast" }
+            ]
           }
         }
-      }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /flush_redis {
-    content_by_lua_block {
-      local redis = require('apicast.threescale_utils').connect_redis({
-         host = "$TEST_NGINX_REDIS_HOST",
-         port = "$TEST_NGINX_REDIS_PORT",
-         db=1})
-      local redis_key = redis:keys('*_fixed_window_test6_3')[1]
-      redis:del('leaky_bucket_test6_1', 'connections_test6_2', redis_key)
+      ]
     }
-  }
-
+--- backend
+    location /transactions/authrep.xml {
+      content_by_lua_block {
+        ngx.exit(200)
+      }
+    }
+--- upstream env
+    location /flush {
+      content_by_lua_block {
+        local redis = require('apicast.threescale_utils').connect_redis({
+           host = "$TEST_NGINX_REDIS_HOST",
+           port = "$TEST_NGINX_REDIS_PORT",
+           db=1})
+        local redis_key = redis:keys('*_fixed_window_test6_3')[1]
+        redis:del('leaky_bucket_test6_1', 'connections_test6_2', redis_key)
+      }
+    }
 --- pipelined_requests eval
-["GET /flush_redis","GET /"]
+["GET http://flush.redis/flush?user_key=foo","GET /?user_key=value"]
 --- error_code eval
 [200, 200]
 --- no_error_log
 [error]
 need to delay by
 
+
 === TEST 7: Rejected (conn).
 Return 429 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
+--- configuration
+    {
+      "services" : [
         {
-          id = 42,
-          proxy = {
-            policy_chain = {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.redis"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
               {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "connection_limiters" : [
                     {
-                      key = {name = "test7", scope = "global"},
-                      conn = 1,
-                      burst = 0,
-                      delay = 2
-                    }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
-                }
-              },
-              {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
+                      "key" : {"name" : "test7", "scope" : "global"},
+                      "conn" : 1,
+                      "burst" : 0,
+                      "delay" : 2
+                    },
                     {
-                      key = {name = "test7", scope = "global"},
-                      conn = 1,
-                      burst = 0,
-                      delay = 2
+                      "key" : {"name" : "test7", "scope" : "global"},
+                      "conn" : 1,
+                      "burst" : 0,
+                      "delay" : 2
                     }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
+                  ],
+                  "redis_url" : "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
                 }
               }
-            }
+            ]
           }
         }
-      }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /flush_redis {
-    content_by_lua_block {
-      local redis = require('apicast.threescale_utils').connect_redis({
-         host = "$TEST_NGINX_REDIS_HOST",
-         port = "$TEST_NGINX_REDIS_PORT",
-         db=1})
-      redis:del('connections_test7')
+      ]
     }
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
   }
-
+}
+--- upstream env
+    location /flush {
+        content_by_lua_block {
+          local redis = require('apicast.threescale_utils').connect_redis({
+             host = "$TEST_NGINX_REDIS_HOST",
+             port = "$TEST_NGINX_REDIS_PORT",
+             db = 1})
+          redis:del('connections_test7')
+        }
+    }
 --- pipelined_requests eval
-["GET /flush_redis","GET /"]
+["GET http://flush.redis/flush?user_key=foo","GET /?user_key=foo","GET /?user_key=foo"]
 --- error_code eval
-[200, 429]
+[200, 429, 429]
 --- no_error_log
 [error]
+--- error_log
+Requests over the limit.
+
 
 === TEST 8: Rejected (req).
 Return 503 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
+--- configuration
+    {
+      "services" : [
         {
-          id = 42,
-          proxy = {
-            policy_chain = {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.redis"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
               {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  leaky_bucket_limiters = {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "leaky_bucket_limiters" : [
                     {
-                      key = {name = "test8", name_type = "plain", scope = "global"},
-                      rate = 1,
-                      burst = 0
+                      "key" : {"name" : "test8", "scope" : "global"},
+                      "rate" : 1,
+                      "burst" : 0
                     }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
-                  limits_exceeded_error  = { status_code = 503 }
+                  ],
+                  "redis_url" : "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
+                  "limits_exceeded_error" : { "status_code" : 503 }
                 }
               }
-            }
+            ]
           }
         }
-      }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /flush_redis {
-    content_by_lua_block {
-      local redis = require('apicast.threescale_utils').connect_redis({
-         host = "$TEST_NGINX_REDIS_HOST",
-         port = "$TEST_NGINX_REDIS_PORT",
-         db=1})
-      redis:del('leaky_bucket_test8')
+      ]
     }
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
   }
-
+}
+--- upstream env
+    location /flush {
+        content_by_lua_block {
+          local redis = require('apicast.threescale_utils').connect_redis({
+             host = "$TEST_NGINX_REDIS_HOST",
+             port = "$TEST_NGINX_REDIS_PORT",
+             db = 1})
+          redis:del('leaky_bucket_test8')
+        }
+    }
 --- pipelined_requests eval
-["GET /flush_redis","GET /","GET /"]
+["GET http://flush.redis/flush?user_key=foo","GET /?user_key=foo","GET /?user_key=foo"]
 --- error_code eval
 [200, 200, 503]
 --- no_error_log
 [error]
+--- error_log
+Requests over the limit.
+
 
 === TEST 9: Rejected (count).
 Return 429 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
+--- configuration
+    {
+      "services" : [
         {
-          id = 42,
-          proxy = {
-            policy_chain = {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.redis"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
               {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  fixed_window_limiters = {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "fixed_window_limiters" : [
                     {
-                      key = {name = "test9", scope = "global"},
-                      count = 1,
-                      window = 10
+                      "key" : {"name" : "test9", "scope" : "global"},
+                      "count" : 1,
+                      "window" : 10
                     }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
-                  limits_exceeded_error = { status_code = 429 }
+                  ],
+                  "redis_url" : "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
+                  "limits_exceeded_error" : { "status_code" : 429 }
                 }
               }
-            }
+            ]
           }
         }
-      }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /flush_redis {
-    content_by_lua_block {
-      local redis = require('apicast.threescale_utils').connect_redis({
-         host = "$TEST_NGINX_REDIS_HOST",
-         port = "$TEST_NGINX_REDIS_PORT",
-         db=1})
-      local redis_key = redis:keys('*_fixed_window_test9')[1]
-      redis:del(redis_key)
+      ]
     }
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
   }
-
+}
+--- upstream env
+    location /flush {
+        content_by_lua_block {
+          local redis = require('apicast.threescale_utils').connect_redis({
+             host = "$TEST_NGINX_REDIS_HOST",
+             port = "$TEST_NGINX_REDIS_PORT",
+             db = 1})
+          local redis_key = redis:keys('*_fixed_window_test9')[1]
+          redis:del(redis_key)
+        }
+    }
 --- pipelined_requests eval
-["GET /flush_redis","GET /","GET /"]
+["GET http://flush.redis/flush?user_key=foo","GET /?user_key=foo","GET /?user_key=foo"]
 --- error_code eval
 [200, 200, 429]
 --- no_error_log
 [error]
-
-=== TEST 10: Delay (conn).
-Return 200 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
-        {
-          id = 42,
-          proxy = {
-            policy_chain = {
-              {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
-                    {
-                      key = {name = "test10", scope = "global"},
-                      conn = 1,
-                      burst = 1,
-                      delay = 2
-                    }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
-                }
-              },
-              {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
-                    {
-                      key = {name = "test10", scope = "global"},
-                      conn = 1,
-                      burst = 1,
-                      delay = 2
-                    }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
-                }
-              }
-            }
-          }
-        }
-      }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/authrep.xml {
-    content_by_lua_block { ngx.exit(200) }
-  }
-
-  location /flush_redis {
-    content_by_lua_block {
-      local redis = require('apicast.threescale_utils').connect_redis({
-         host = "$TEST_NGINX_REDIS_HOST",
-         port = "$TEST_NGINX_REDIS_PORT",
-         db=1})
-      redis:del('connections_test10')
-    }
-  }
-
---- pipelined_requests eval
-["GET /flush_redis","GET /"]
---- error_code eval
-[200, 200]
-
-=== TEST 11: Delay (req).
-Return 200 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
-        {
-          id = 42,
-          proxy = {
-            policy_chain = {
-              {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  leaky_bucket_limiters = {
-                    {
-                      key = {name = "test11", scope = "global"},
-                      rate = 1,
-                      burst = 1
-                    }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
-                }
-              }
-            }
-          }
-        }
-      }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/authrep.xml {
-    content_by_lua_block { ngx.exit(200) }
-  }
-
-  location /flush_redis {
-    content_by_lua_block {
-      local redis = require('apicast.threescale_utils').connect_redis({
-         host = "$TEST_NGINX_REDIS_HOST",
-         port = "$TEST_NGINX_REDIS_PORT",
-         db=1})
-      redis:del('leaky_bucket_test11')
-    }
-  }
-
---- pipelined_requests eval
-["GET /flush_redis","GET /","GET /"]
---- error_code eval
-[200, 200, 200]
-
-=== TEST 12: Rejected (conn) (no redis).
-Return 429 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
-        {
-          id = 42,
-          proxy = {
-            policy_chain = {
-              {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
-                    {
-                      key = {name = "test12", scope = "global"},
-                      conn = 1,
-                      burst = 0,
-                      delay = 2
-                    }
-                  }
-                }
-              },
-              {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
-                    {
-                      key = {name = "test12", scope = "global"},
-                      conn = 1,
-                      burst = 0,
-                      delay = 2
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
---- request
-GET /
---- error_code: 429
 --- error_log
 Requests over the limit.
 
-=== TEST 13: Rejected (req) (no redis).
-Return 429 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
 
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
-        {
-          id = 42,
-          proxy = {
-            policy_chain = {
-              {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  leaky_bucket_limiters = {
-                    {
-                      key = {name = "test13", scope = "global"},
-                      rate = 1,
-                      burst = 0
-                    }
-                  },
-                  limits_exceeded_error = { error_handling = "exit" }
-                }
-              }
-            }
-          }
-        }
-      }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
---- pipelined_requests eval
-["GET /","GET /"]
---- error_code eval
-[200, 429]
-
-=== TEST 14: Rejected (count) (no redis).
-Return 429 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
-        {
-          id = 42,
-          proxy = {
-            policy_chain = {
-              {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  fixed_window_limiters = {
-                    {
-                      key = {name = "test14", scope = "global"},
-                      count = 1,
-                      window = 10
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
---- pipelined_requests eval
-["GET /","GET /"]
---- error_code eval
-[200, 429]
-
-=== TEST 15: Delay (conn) (no redis).
+=== TEST 10: Delay (conn).
 Return 200 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
+--- configuration
+    {
+      "services" : [
         {
-          id = 42,
-          proxy = {
-            policy_chain = {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.redis"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
               {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "connection_limiters" : [
                     {
-                      key = {name = "test15", scope = "global"},
-                      conn = 1,
-                      burst = 1,
-                      delay = 2
+                      "key" : {"name" : "test10", "scope" : "global"},
+                      "conn" : 1,
+                      "burst" : 1,
+                      "delay" : 2
                     }
-                  }
+                  ],
+                  "redis_url" : "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
                 }
               },
               {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  connection_limiters = {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "connection_limiters" : [
                     {
-                      key = {name = "test15", scope = "global"},
-                      conn = 1,
-                      burst = 1,
-                      delay = 2
+                      "key" : {"name" : "test10", "scope" : "global"},
+                      "conn" : 1,
+                      "burst" : 1,
+                      "delay" : 2
                     }
-                  }
+                  ],
+                  "redis_url" : "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
                 }
               }
-            }
+            ]
           }
         }
+      ]
+    }
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+--- upstream env
+    location /flush {
+        content_by_lua_block {
+          local redis = require('apicast.threescale_utils').connect_redis({
+             host = "$TEST_NGINX_REDIS_HOST",
+             port = "$TEST_NGINX_REDIS_PORT",
+             db = 1})
+          redis:del('connections_test10')
+        }
+    }
+--- pipelined_requests eval
+["GET http://flush.redis/flush?user_key=foo","GET /?user_key=foo"]
+--- error_code eval
+[200, 200]
+--- no_error_log
+[error]
+
+
+=== TEST 11: Delay (req).
+Return 200 code.
+--- configuration
+    {
+      "services" : [
+        {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.redis"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
+              {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "leaky_bucket_limiters" : [
+                    {
+                      "key" : {"name" : "test11", "scope" : "global"},
+                      "rate" : 1,
+                      "burst" : 1
+                    }
+                  ],
+                  "redis_url" : "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+--- upstream env
+    location /flush {
+        content_by_lua_block {
+          local redis = require('apicast.threescale_utils').connect_redis({
+             host = "$TEST_NGINX_REDIS_HOST",
+             port = "$TEST_NGINX_REDIS_PORT",
+             db = 1})
+          redis:del('leaky_bucket_test11')
+        }
+    }
+--- pipelined_requests eval
+["GET http://flush.redis/flush?user_key=foo","GET /?user_key=foo","GET /?user_key=foo"]
+--- error_code eval
+[200, 200, 200]
+--- no_error_log
+[error]
+
+
+=== TEST 12: Rejected (conn) (no redis).
+Return 429 code.
+--- configuration
+    {
+      "services" : [
+        {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.limiter"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
+              {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "connection_limiters" : [
+                    {
+                      "key" : {"name" : "test12", "scope" : "global"},
+                      "conn" : 1,
+                      "burst" : 0,
+                      "delay" : 2
+                    }
+                  ]
+                }
+              },
+              {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "connection_limiters" : [
+                    {
+                      "key" : {"name" : "test12", "scope" : "global"},
+                      "conn" : 1,
+                      "burst" : 0,
+                      "delay" : 2
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+--- upstream env
+    location /flush {
+      content_by_lua_block {
+        require "resty.core"
+        ngx.shared.limiter:flush_all()
       }
-    })
+    }
+--- pipelined_requests eval
+["GET http://flush.limiter/flush?user_key=foo", "GET /?user_key=foo"]
+--- error_code eval
+[200, 429]
+--- no_error_log
+[error]
+--- error_log
+Requests over the limit.
+
+
+=== TEST 13: Rejected (req) (no redis).
+--- configuration
+    {
+      "services" : [
+        {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.limiter"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
+              {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "leaky_bucket_limiters" : [
+                    {
+                      "key" : {"name" : "test13", "scope" : "global"},
+                      "rate" : 1,
+                      "burst" : 0
+                    }
+                  ],
+                  "limits_exceeded_error" : { "error_handling" : "exit" }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
   }
-  lua_shared_dict limiter 1m;
+}
+--- upstream env
+    location /flush {
+      content_by_lua_block {
+        require "resty.core"
+        ngx.shared.limiter:flush_all()
+      }
+    }
+--- pipelined_requests eval
+["GET http://flush.limiter/flush?user_key=foo", "GET /?user_key=foo", "GET /?user_key=foo"]
+--- error_code eval 
+[200, 200, 429]
+--- no_error_log
+[error]
+--- error_log
+Requests over the limit.
 
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
 
-  location /transactions/authrep.xml {
-    content_by_lua_block { ngx.exit(200) }
+=== TEST 14: Rejected (count) (no redis).
+--- configuration
+    {
+      "services" : [
+        {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.limiter"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
+              {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "fixed_window_limiters" : [
+                    {
+                      "key" : {"name" : "test14", "scope" : "global"},
+                      "count" : 1,
+                      "window" : 10
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
   }
+}
+--- upstream env
+    location /flush {
+      content_by_lua_block {
+        require "resty.core"
+        ngx.shared.limiter:flush_all()
+      }
+    }
+--- pipelined_requests eval
+["GET http://flush.limiter/flush?user_key=foo", "GET /?user_key=foo", "GET /?user_key=foo"]
+--- error_code eval 
+[200, 200, 429]
+--- no_error_log
+[error]
+--- error_log
+Requests over the limit.
 
---- request
-GET /
---- error_code: 200
+
+=== TEST 15: Delay (conn) (no redis).
+Return 200 code.
+--- configuration
+    {
+      "services" : [
+        {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.limiter"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
+              {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "connection_limiters" : [
+                    {
+                      "key" : {"name" : "test15", "scope" : "global"},
+                      "conn" : 1,
+                      "burst" : 1,
+                      "delay" : 2
+                    }
+                  ]
+                }
+              },
+              {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "connection_limiters" : [
+                    {
+                      "key" : {"name" : "test15", "scope" : "global"},
+                      "conn" : 1,
+                      "burst" : 1,
+                      "delay" : 2
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+--- upstream env
+    location /flush {
+      content_by_lua_block {
+        require "resty.core"
+        ngx.shared.limiter:flush_all()
+      }
+    }
+--- pipelined_requests eval
+["GET http://flush.limiter/flush?user_key=foo", "GET /?user_key=foo"]
+--- error_code eval 
+[200, 200]
+--- no_error_log
+[error]
 --- error_log
 need to delay by
 
+
 === TEST 16: Delay (req) (no redis).
 Return 200 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
+--- configuration
+    {
+      "services" : [
         {
-          id = 42,
-          proxy = {
-            policy_chain = {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.limiter"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
               {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  leaky_bucket_limiters = {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "leaky_bucket_limiters" : [
                     {
-                      key = {name = "test16", scope = "global"},
-                      rate = 1,
-                      burst = 1
+                      "key" : {"name" : "test16", "scope" : "global"},
+                      "rate" : 1,
+                      "burst" : 1
                     }
-                  }
+                  ]
                 }
               }
-            }
+            ]
           }
         }
+      ]
+    }
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+--- upstream env
+    location /flush {
+      content_by_lua_block {
+        require "resty.core"
+        ngx.shared.limiter:flush_all()
       }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /transactions/authrep.xml {
-    content_by_lua_block { ngx.exit(200) }
-  }
-
+    }
 --- pipelined_requests eval
-["GET /","GET /"]
---- error_code eval
-[200, 200]
+["GET http://flush.limiter/flush?user_key=foo", "GET /?user_key=foo", "GET /?user_key=foo"]
+--- error_code eval 
+[200, 200, 200]
+--- no_error_log
+[error]
+
 
 === TEST 17: Liquid templating (jwt.aud).
 Rate Limit policy accesses to the jwt
@@ -972,389 +1108,460 @@ This test uses "jwt.aud" as key name.
 This test calls the service 3 times,
 and the second call has a different jwt.aud,
 so only the third call returns 429.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
+--- configuration env eval
 
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
+use JSON qw(to_json);
+
+to_json({
+  services => [{
+    id => 2,
+    backend_version => 1,
+    proxy => {
+      api_backend => "http://test:$TEST_NGINX_SERVER_PORT/",
+      proxy_rules => [
+          { pattern => '/', http_method => 'GET', metric_system_name => 'hits', delta => 1  }
+      ],
+      hosts => ["flush.redis"]
+    }
+  },
+  {
+    id => 42,
+    backend_version => 'oauth',
+    backend_authentication_type => 'provider_key',
+    proxy => {
+      authentication_method => 'oidc',
+      oidc_issuer_endpoint => 'https://example.com/auth/realms/apicast',
+      api_backend => "http://test:$TEST_NGINX_SERVER_PORT/",
+      proxy_rules => [
+          { pattern => '/', http_method => 'GET', metric_system_name => 'hits', delta => 1  }
+      ],
+      policy_chain => [
         {
-          id = 42,
-          backend_version = 'oauth',
-          backend_authentication_type = 'provider_key',
-          backend_authentication_value = 'fookey',
-          proxy = {
-            authentication_method = 'oidc',
-            oidc_issuer_endpoint = 'https://example.com/auth/realms/apicast',
-            api_backend = "http://127.0.0.1:$TEST_NGINX_SERVER_PORT/api-backend/",
-            proxy_rules = {
-              { pattern = '/', http_method = 'GET', metric_system_name = 'hits', delta = 1  }
-            },
-            policy_chain = {
+          name => "apicast.policy.rate_limit",
+          configuration => {
+            fixed_window_limiters => [
               {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  fixed_window_limiters = {
-                    {
-                      key = {name = "{{jwt.aud}}", name_type = "liquid", scope = "global"},
-                      count = 1,
-                      window = 10
-                    }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
-                  limits_exceeded_error = { status_code = 429 }
-                }
-              },
-              { name = "apicast.policy.apicast" }
-            }
+                key => {name => "{{jwt.aud}}", scope => "global", name_type => "liquid"},
+                count => 1,
+                window => 10
+              }
+            ],
+            redis_url => "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
+            limits_exceeded_error => { status_code => 429 }
           }
+        },
+        {name => "apicast.policy.apicast"}
+      ]
+    }
+  }
+  ],
+    oidc => [{},{
+    issuer => 'https://example.com/auth/realms/apicast',
+    config => { id_token_signing_alg_values_supported => [ 'RS256' ] },
+    keys => { somekid => { pem => $::public_key, alg => 'RS256' } },
+  }]
+});
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+location /transactions/oauth_authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+--- upstream env
+    location /flush {
+        content_by_lua_block {
+          local redis = require('apicast.threescale_utils').connect_redis({
+             host = "$TEST_NGINX_REDIS_HOST",
+             port = "$TEST_NGINX_REDIS_PORT",
+             db = 1})
+          local redis_key1 = redis:keys('*_fixed_window_test17_1')[1]
+          local redis_key2 = redis:keys('*_fixed_window_test17_2')[1]
+          redis:del(redis_key1, redis_key2)
         }
-      },
-      oidc = {
-        {
-          issuer = 'https://example.com/auth/realms/apicast',
-          config = { id_token_signing_alg_values_supported = { 'RS256' } },
-          keys = { somekid = { pem = require('fixtures.rsa').pub, alg = 'RS256' } },
-        }
-      }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /flush_redis {
-    content_by_lua_block {
-      local redis = require('apicast.threescale_utils').connect_redis({
-         host = "$TEST_NGINX_REDIS_HOST",
-         port = "$TEST_NGINX_REDIS_PORT",
-         db=1})
-      local redis_key1 = redis:keys('*_fixed_window_test17_1')[1]
-      local redis_key2 = redis:keys('*_fixed_window_test17_2')[1]
-      redis:del(redis_key1, redis_key2)
     }
-  }
-
-  location /api-backend/ {
-    content_by_lua_block {
-      ngx.exit(200)
-    }
-  }
-
-  location = /backend/transactions/oauth_authrep.xml {
-    content_by_lua_block {
-      ngx.exit(200)
-    }
-  }
-
 --- pipelined_requests eval
-["GET /flush_redis","GET /","GET /", "GET /"]
+["GET http://flush.redis/flush?user_key=foo", "GET /", "GET /", "GET /"]
 --- more_headers eval
 use Crypt::JWT qw(encode_jwt);
 my $jwt1 = encode_jwt(payload => {
   aud => 'test17_1',
   sub => 'someone',
   iss => 'https://example.com/auth/realms/apicast',
-  exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers => { kid => 'somekid' });
+  exp => time + 3600 }, key => \$::private_key, alg => 'RS256', extra_headers => { kid => 'somekid' });
 my $jwt2 = encode_jwt(payload => {
   aud => 'test17_2',
   sub => 'someone',
   iss => 'https://example.com/auth/realms/apicast',
-  exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers => { kid => 'somekid' });
+  exp => time + 3600 }, key => \$::private_key, alg => 'RS256', extra_headers => { kid => 'somekid' });
 ["Authorization: Bearer $jwt1", "Authorization: Bearer $jwt1", "Authorization: Bearer $jwt2", "Authorization: Bearer $jwt1"]
---- error_code eval
+--- error_code eval 
 [200, 200, 200, 429]
 --- no_error_log
 [error]
+--- error_log
+Requests over the limit.
+
 
 === TEST 18: Liquid templating (ngx.***).
 This test uses "ngx.var.host" and "ngx.var.uri" as key name.
 This test calls the service 3 times,
 and the second call has a different ngx.var.uri,
 so only the third call returns 429.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
+--- configuration
+    {
+      "services" : [
         {
-          id = 42,
-          proxy = {
-            policy_chain = {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.redis"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
               {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  fixed_window_limiters = {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "fixed_window_limiters" : [
                     {
-                      key = {name = "{{host}}{{uri}}", name_type = "liquid", scope = "global"},
-                      count = 1,
-                      window = 10
+                      "key" : {"name" : "{{host}}{{uri}}", "scope" : "global", "name_type" : "liquid"},
+                      "count" : 1,
+                      "window" : 10
                     }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
-                  limits_exceeded_error = { status_code = 429 }
+                  ],
+                  "redis_url" : "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
+                  "limits_exceeded_error" : { "status_code" : 429 }
                 }
               }
-            }
+            ]
           }
         }
-      }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /flush_redis {
-    content_by_lua_block {
-      local redis = require('apicast.threescale_utils').connect_redis({
-         host = "$TEST_NGINX_REDIS_HOST",
-         port = "$TEST_NGINX_REDIS_PORT",
-         db=1})
-      local redis_key1 = redis:keys('*_fixed_window_localhost/test18_1')[1]
-      local redis_key2 = redis:keys('*_fixed_window_localhost/test18_2')[1]
-      redis:del(redis_key1, redis_key2)
+      ]
     }
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
   }
-
+}
+--- upstream env
+    location /flush {
+        content_by_lua_block {
+          local redis = require('apicast.threescale_utils').connect_redis({
+             host = "$TEST_NGINX_REDIS_HOST",
+             port = "$TEST_NGINX_REDIS_PORT",
+             db = 1})
+          local redis_key1 = redis:keys('*_fixed_window_localhost/test18_1')[1]
+          local redis_key2 = redis:keys('*_fixed_window_localhost/test18_2')[1]
+          redis:del(redis_key1, redis_key2)
+        }
+    }
 --- pipelined_requests eval
-["GET /flush_redis","GET /test18_1","GET /test18_2", "GET /test18_1"]
---- error_code eval
+["GET http://flush.redis/flush?user_key=foo", "GET /test18_1?user_key=foo", "GET /test18_2?user_key=foo", "GET /test18_1?user_key=foo"]
+--- error_code eval 
 [200, 200, 200, 429]
 --- no_error_log
 [error]
+--- error_log
+Requests over the limit.
+
 
 === TEST 19: Rejected (count). Using multiple limiters of the same type.
 To confirm that multiple limiters of the same type are configurable
 and rejected properly.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
+--- configuration
+    {
+      "services" : [
         {
-          id = 42,
-          proxy = {
-            policy_chain = {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.redis"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
               {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  fixed_window_limiters = {
-                    { key = {name = "{{host}}", name_type = "liquid"}, count = 2, window = 10 },
-                    { key = {name = "{{uri}}", name_type = "liquid"}, count = 1, window = 10 }
-                  },
-                  redis_url = "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
-                  limits_exceeded_error = { status_code = 429 }
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "fixed_window_limiters" : [
+                    {
+                      "key" : {"name" : "{{host}}", "name_type" : "liquid"},
+                      "count" : 2,
+                      "window" : 10
+                    },
+                    {
+                      "key" : {"name" : "{{uri}}", "name_type" : "liquid"},
+                      "count" : 1,
+                      "window" : 10
+                    }
+                  ],
+                  "redis_url" : "redis://$TEST_NGINX_REDIS_HOST:$TEST_NGINX_REDIS_PORT/1",
+                  "limits_exceeded_error" : { "status_code" : 429 }
                 }
               }
-            }
+            ]
           }
         }
-      }
-    })
-  }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location /flush_redis {
-    content_by_lua_block {
-      local redis = require('apicast.threescale_utils').connect_redis({
-         host = "$TEST_NGINX_REDIS_HOST",
-         port = "$TEST_NGINX_REDIS_PORT",
-         db=1})
-      redis:flushdb()
+      ]
     }
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
   }
-
+}
+--- upstream env
+    location /flush {
+        content_by_lua_block {
+          local redis = require('apicast.threescale_utils').connect_redis({
+             host = "$TEST_NGINX_REDIS_HOST",
+             port = "$TEST_NGINX_REDIS_PORT",
+             db = 1})
+          redis:flushdb()
+        }
+    }
 --- pipelined_requests eval
-["GET /flush_redis","GET /test19_1","GET /test19_2","GET /test19_3"]
---- error_code eval
+["GET http://flush.redis/flush?user_key=foo", "GET /test19_1?user_key=foo", "GET /test19_2?user_key=foo", "GET /test19_3?user_key=foo"]
+--- error_code eval 
 [200, 200, 200, 429]
 --- no_error_log
 [error]
+--- error_log
+Requests over the limit.
+
 
 === TEST 20: with conditions
 We define a limit of 1 with a false condition, and a limit of 2 with a
 condition that's true. We check that the false condition does not apply by
 making 3 requests and checking that only the last one is rejected.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
+--- configuration
+    {
+      "services" : [
         {
-          id = 42,
-          proxy = {
-            policy_chain = {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.limiter"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
               {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  fixed_window_limiters = {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "fixed_window_limiters" : [
                     {
-                      key = { name = "test20_key_1" },
-                      count = 2,
-                      window = 10,
-                      condition = {
-                        operations = {
+                      "key" : {"name" : "test20_key_1"},
+                      "count" : 2,
+                      "window" : 10,
+                      "condition" : {
+                        "operations" : [
                           {
-                            left = "{{ uri }}",
-                            left_type = "liquid",
-                            op = "==",
-                            right = "/"
+                            "left" : "{{ uri }}",
+                            "left_type" : "liquid",
+                            "op" : "==",
+                            "right" : "/"
                           }
-                        }
+                        ]
                       }
-                    },
-                    {
-                      key = { name = "test20_key_2" },
-                      count = 1,
-                      window = 10,
-                      condition = {
-                        operations = {
+                    },{
+                      "key" : {"name" : "test20_key_2"},
+                      "count" : 1,
+                      "window" : 10,
+                      "condition" : {
+                        "operations" : [
                           {
-                            left = "1",
-                            op = "==",
-                            right = "2"
+                            "left" : "1",
+                            "op" : "==",
+                            "right" : "2"
                           }
-                        }
+                        ]
                       }
                     }
-                  },
-                  limits_exceeded_error = { status_code = 429 }
+                  ],
+                  "limits_exceeded_error" : { "status_code" : 429 }
                 }
               }
-            }
+            ]
           }
         }
-      }
-    })
+      ]
+    }
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
   }
-  lua_shared_dict limiter 1m;
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
+}
+--- upstream env
+    location /flush {
+      content_by_lua_block {
+        require "resty.core"
+        ngx.shared.limiter:flush_all()
+      }
+    }
 --- pipelined_requests eval
-["GET /", "GET /", "GET /"]
---- error_code eval
-[200, 200, 429]
+["GET http://flush.limiter/flush?user_key=foo", "GET /?user_key=foo", "GET /?user_key=foo", "GET /?user_key=foo"]
+--- error_code eval 
+[200, 200, 200, 429]
 --- no_error_log
 [error]
+--- error_log
+Requests over the limit.
+
 
 === TEST 21: condition with "matches" operation
 This test makes 3 requests that match the URL pattern defined in the
 limit. The limit is set to 2. Only the third one should fail.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
+--- configuration
+    {
+      "services" : [
         {
-          id = 42,
-          proxy = {
-            policy_chain = {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.limiter"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
               {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  fixed_window_limiters = {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "fixed_window_limiters" : [
                     {
-                      key = { name = "test21_key_1" },
-                      count = 2,
-                      window = 60,
-                      condition = {
-                        operations = {
+                      "key" : {"name" : "test21_key_1"},
+                      "count" : 2,
+                      "window" : 60,
+                      "condition" : {
+                        "operations" : [
                           {
-                            left = "{{ uri }}",
-                            left_type = "liquid",
-                            op = "matches",
-                            right = "/v1/.*/something/.*",
-                            right_type = "plain"
+                            "left" : "{{ uri }}",
+                            "left_type" : "liquid",
+                            "op" : "matches",
+                            "right" : "/v1/.*/something/.*"
                           }
-                        }
+                        ]
                       }
                     }
-                  },
-                  limits_exceeded_error = { status_code = 429 }
+                  ],
+                  "limits_exceeded_error" : { "status_code" : 429 }
                 }
               }
-            }
+            ]
           }
         }
-      }
-    })
+      ]
+    }
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
   }
-  lua_shared_dict limiter 1m;
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
+}
+--- upstream env
+    location /flush {
+      content_by_lua_block {
+        require "resty.core"
+        ngx.shared.limiter:flush_all()
+      }
+    }
 --- pipelined_requests eval
-["GET /v1/aaa/something/bbb", "GET /v1/ccc/something/ddd", "GET /v1/eee/something/fff"]
---- error_code eval
-[200, 200, 429]
+["GET http://flush.limiter/flush?user_key=foo", "GET /v1/aaa/something/bbb?user_key=foo", "GET /v1/ccc/something/ddd?user_key=foo", "GET /v1/eee/something/fff?user_key=foo"]
+--- error_code eval 
+[200, 200, 200, 429]
 --- no_error_log
 [error]
+--- error_log
+Requests over the limit.
 
 
 === TEST 22: Window is set to 0 and default is 1.
 Return 429 code.
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
-
-  init_by_lua_block {
-    require "resty.core"
-    ngx.shared.limiter:flush_all()
-    require('apicast.configuration_loader').mock({
-      services = {
+--- configuration
+    {
+      "services" : [
         {
-          id = 42,
-          proxy = {
-            policy_chain = {
+          "id" : 2,
+          "backend_version": 1,
+          "proxy" : {
+            "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+            "proxy_rules": [
+              { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+            ],
+            "hosts": ["flush.limiter"]
+          }
+        },
+        {
+          "id" : 42,
+          "proxy" : {
+            "policy_chain" : [
               {
-                name = "apicast.policy.rate_limit",
-                configuration = {
-                  fixed_window_limiters = {
+                "name" : "apicast.policy.rate_limit",
+                "configuration" : {
+                  "fixed_window_limiters" : [
                     {
-                      key = {name = "test9", scope = "global"},
-                      count = 1,
-                      window = 0
+                      "key" : {"name" : "test22"},
+                      "count" : 1,
+                      "window" : 0
                     }
-                  },
-                  limits_exceeded_error = { status_code = 429 }
+                  ],
+                  "limits_exceeded_error" : { "status_code" : 429 }
                 }
               }
-            }
+            ]
           }
         }
-      }
-    })
+      ]
+    }
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
   }
-  lua_shared_dict limiter 1m;
-
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
+}
+--- upstream env
+    location /flush {
+      content_by_lua_block {
+        require "resty.core"
+        ngx.shared.limiter:flush_all()
+      }
+    }
 --- pipelined_requests eval
-["GET /","GET /"]
---- error_code eval
-[200, 429]
+["GET http://flush.limiter/flush?user_key=foo", "GET /?user_key=foo", "GET /?user_key=foo"]
+--- error_code eval 
+[200, 200, 429]
+--- no_error_log
+[error]
+--- error_log
+Requests over the limit.

--- a/t/apicast.t
+++ b/t/apicast.t
@@ -487,50 +487,7 @@ X-3scale-usage: usage%5Bhits%5D=2
 [error]
 
 
-=== TEST 16: uses endpoint host as Host header
-when connecting to the backend
---- configuration
-{
-  "services" : [
-    {
-      "id": 42,
-      "backend_version": 1,
-      "backend_authentication_type": "service_token",
-      "backend_authentication_value" : "service-token",
-      "proxy": {
-        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api-backend/",
-        "proxy_rules": [
-            { "pattern" : "/", "http_method" : "GET", "metric_system_name" : "hits", "delta" : 2} 
-        ]
-      }
-    }
-  ]
-}
---- upstream
-  location / {
-     echo 'yay, api backend!';
-  }
---- backend
-  location /transactions/authrep.xml {
-     content_by_lua_block {
-       if ngx.var.host == 'test_backend' then
-         ngx.exit(200)
-       else
-         ngx.log(ngx.ERR, 'invalid host: ', ngx.var.host)
-         ngx.exit(404)
-       end
-     }
-  }
---- request
-GET /?user_key=somekey
---- response_body
-yay, api backend!
---- error_code: 200
---- no_error_log
-[error]
-
-
-=== TEST 17: invalid service
+=== TEST 16: invalid service
 The message is configurable and default status is 404.
 --- configuration
 {}
@@ -541,7 +498,7 @@ GET /?user_key=value
 [error]
 
 
-=== TEST 18: default limits exceeded error
+=== TEST 17: default limits exceeded error
 There are defaults defined for the error message, the content-type, and the status code (429).
 --- configuration
 {
@@ -582,7 +539,7 @@ Limits exceeded
 [error]
 
 
-=== TEST 19: configurable limits exceeded error
+=== TEST 18: configurable limits exceeded error
 --- configuration
 {
   "services" : [
@@ -622,7 +579,7 @@ limits exceeded!
 [error]
 
 
-=== TEST 20: Credentials in large POST body
+=== TEST 19: Credentials in large POST body
 POST bodies larger than 'client_body_buffer_size' are written to a temp file,
 and we ignore them. That means that credentials stored in the body are not
 taken into account.
@@ -663,7 +620,7 @@ credentials missing!
 [error]
 
 
-=== TEST 21: returns 'Retry-After' header when rate-limited by 3scale backend
+=== TEST 20: returns 'Retry-After' header when rate-limited by 3scale backend
 --- configuration
 {
   "services" : [
@@ -705,7 +662,7 @@ Limits exceeded
 [error]
 
 
-=== TEST 22: APIcast placed after a policy that denies the request in rewrite()
+=== TEST 21: APIcast placed after a policy that denies the request in rewrite()
 This test checks that APIcast does not call authrep.
 --- configuration
 {
@@ -746,7 +703,7 @@ GET /?user_key=value
 [error]
 
 
-=== TEST 23: APIcast placed after a policy that denies the request in access()
+=== TEST 22: APIcast placed after a policy that denies the request in access()
 This test checks that APIcast does not call authrep.
 --- configuration
 {
@@ -787,7 +744,7 @@ GET /?user_key=value
 [error]
 
 
-=== TEST 24: returns "authorization failed" instead of "limits exceeded" for disabled metrics
+=== TEST 23: returns "authorization failed" instead of "limits exceeded" for disabled metrics
 "Disabled metrics" are those that have a limit of 0 in the 3scale backend.
 --- configuration
 {

--- a/t/configuration-loading-lazy.t
+++ b/t/configuration-loading-lazy.t
@@ -29,7 +29,7 @@ service not found for host localhost
 using lazy configuration loader
 
 === TEST 2: load invalid configuration
-should fail with server error
+should just say service is not found
 --- env eval
 (
   'APICAST_CONFIGURATION_LOADER' => 'lazy',

--- a/t/configuration-loading-lazy.t
+++ b/t/configuration-loading-lazy.t
@@ -1,16 +1,11 @@
 use lib 't';
-use Test::APIcast 'no_plan';
+use Test::APIcast::Blackbox 'no_plan';
 
 $ENV{TEST_NGINX_HTTP_CONFIG} = "$Test::APIcast::path/http.d/init.conf";
-
+$ENV{APICAST_ACCESS_LOG_FILE} = "$Test::Nginx::Util::ErrLogFile";
 $ENV{APICAST_CONFIGURATION_LOADER} = 'lazy';
 
-env_to_nginx(
-    'APICAST_CONFIGURATION_LOADER',
-    'TEST_NGINX_APICAST_PATH',
-    'THREESCALE_CONFIG_FILE',
-    'THREESCALE_PORTAL_ENDPOINT'
-);
+repeat_each(1);
 
 run_tests();
 
@@ -18,161 +13,158 @@ __DATA__
 
 === TEST 1: load empty configuration
 should just say service is not found
---- main_config
-env THREESCALE_PORTAL_ENDPOINT=http://127.0.0.1:$TEST_NGINX_SERVER_PORT;
---- http_config
-  include $TEST_NGINX_HTTP_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location = /admin/api/nginx/spec.json {
-   echo "{}";
-  }
---- request
-GET /t
+--- env eval
+(
+  'APICAST_CONFIGURATION_LOADER' => 'lazy',
+  'THREESCALE_PORTAL_ENDPOINT' => "http://test:$ENV{TEST_NGINX_SERVER_PORT}"
+)
+--- upstream
+location /admin/api/services.json {
+    echo '{}';
+}
+--- request: GET /t
 --- error_code: 404
 --- error_log
 service not found for host localhost
+using lazy configuration loader
 
 === TEST 2: load invalid configuration
 should fail with server error
---- main_config
-env THREESCALE_PORTAL_ENDPOINT=http://127.0.0.1:$TEST_NGINX_SERVER_PORT;
---- http_config
-  include $TEST_NGINX_HTTP_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-
-  location = /admin/api/nginx/spec.json {
-    echo "";
-  }
---- request
-GET /t
+--- env eval
+(
+  'APICAST_CONFIGURATION_LOADER' => 'lazy',
+  'THREESCALE_PORTAL_ENDPOINT' => "http://test:$ENV{TEST_NGINX_SERVER_PORT}"
+)
+--- upstream
+location /admin/api/services.json {
+    echo '';
+}
+--- request: GET /t
 --- error_code: 404
+--- error_log
+service not found for host localhost
+using lazy configuration loader
 
 === TEST 3: load valid configuration
 should correctly route the request
---- main_config
-env THREESCALE_PORTAL_ENDPOINT=http://127.0.0.1:$TEST_NGINX_SERVER_PORT/;
-env APICAST_CONFIGURATION_LOADER=lazy;
---- http_config
-  include $TEST_NGINX_HTTP_CONFIG;
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-  include $TEST_NGINX_BACKEND_CONFIG;
+--- env eval
+(
+  'APICAST_CONFIGURATION_LOADER' => 'lazy',
+  'THREESCALE_PORTAL_ENDPOINT' => "http://test:$ENV{TEST_NGINX_SERVER_PORT}"
+)
+--- upstream env
+    location = /admin/api/services.json {
+        echo '
+        {
+            "services": [
+                { "service": { "id":1 } }
+            ]
+        }';
+    }
 
-  location = /admin/api/nginx/spec.json {
-    try_files /config.json =404;
-  }
+    location = /admin/api/services/1/proxy/configs/production/latest.json {
+        echo '
+        {
+            "proxy_config": {
+                "content": {
+                    "id": 1,
+                    "backend_version": 1,
+                    "proxy": {
+                        "hosts": [ "localhost" ],
+                        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+                        "proxy_rules": [
+                            { "pattern": "/t", "http_method": "GET", "metric_system_name": "test","delta": 1 }
+                        ]
+                    }
+                }
+            }
+        }';
+    }
 
-  location /api/ {
-    echo "all ok";
-  }
+    location /t {
+        echo "all ok";
+    }
+
+--- backend
+    location /transactions/authrep.xml {
+      content_by_lua_block {
+        ngx.exit(200)
+      }
+    }
 --- request
 GET /t?user_key=fake
 --- error_code: 200
---- user_files eval
-[
-  [ 'config.json', qq|
-  {
-    "services": [{
-      "id": 1,
-      "backend_version": 1,
-      "proxy": {
-        "api_backend": "http://127.0.0.1:$Test::Nginx::Util::ServerPortForClient/api/",
-        "backend": {
-          "endpoint": "http://127.0.0.1:$Test::Nginx::Util::ServerPortForClient"
-        },
-        "proxy_rules": [
-          { "pattern": "/t", "http_method": "GET", "metric_system_name": "test","delta": 1 }
-        ]
-      }
-    }]
-  }
-  | ]
-]
+--- error_log
+using lazy configuration loader
+--- no_error_log
+[error]
 
 === TEST 4: load invalid json
 To validate that process does not died with invalid config
---- main_config
-env THREESCALE_PORTAL_ENDPOINT=http://127.0.0.1:$TEST_NGINX_SERVER_PORT/;
-env APICAST_CONFIGURATION_LOADER=lazy;
---- http_config
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-  include $TEST_NGINX_BACKEND_CONFIG;
-
-  location = /admin/api/nginx/spec.json {
-    try_files /config.json =404;
-  }
-
-  location /api/ {
-    echo "all ok";
-  }
+--- env eval
+(
+  'APICAST_CONFIGURATION_LOADER' => 'lazy',
+  'THREESCALE_PORTAL_ENDPOINT' => "http://test:$ENV{TEST_NGINX_SERVER_PORT}"
+)
+--- upstream
+location ~ /admin/(.+) {
+    echo '{Hello, world}';
+}
 --- request
 GET /t?user_key=fake
 --- error_code: 404
---- user_files
->>> config.json
-{Hello, world}
 --- no_error_log
 [error]
 
 === TEST 5: load invalid oidc target url
---- main_config
-env THREESCALE_PORTAL_ENDPOINT=http://127.0.0.1:$TEST_NGINX_SERVER_PORT/;
-env APICAST_CONFIGURATION_LOADER=lazy;
---- http_config
-  include $TEST_NGINX_HTTP_CONFIG;
-  include $TEST_NGINX_UPSTREAM_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
---- config
-  include $TEST_NGINX_APICAST_CONFIG;
-  include $TEST_NGINX_BACKEND_CONFIG;
+--- env eval
+(
+  'APICAST_CONFIGURATION_LOADER' => 'lazy',
+  'THREESCALE_PORTAL_ENDPOINT' => "http://test:$ENV{TEST_NGINX_SERVER_PORT}"
+)
+--- upstream env
+    location = /admin/api/services.json {
+        echo '
+        {
+            "services": [
+                { "service": { "id":1 } }
+            ]
+        }';
+    }
 
-  location = /admin/api/nginx/spec.json {
-    try_files /config.json =404;
-  }
-
-  location /api/ {
-    echo "all ok";
-  }
+    location = /admin/api/services/1/proxy/configs/production/latest.json {
+        echo '
+        {
+            "proxy_config": {
+                "content": {
+                    "id": 1,
+                    "backend_version": "oauth",
+                    "proxy": {
+                        "hosts": [ "localhost" ],
+                        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+                        "service_id": 2555417794444,
+                        "oidc_issuer_endpoint": "www.fgoodl/adasd",
+                        "authentication_method": "oidc",
+                        "service_backend_version": "oauth",
+                        "proxy_rules": [
+                            { "pattern": "/t", "http_method": "GET", "metric_system_name": "test","delta": 1 }
+                        ]
+                    }
+                }
+            }
+        }';
+    }
+--- backend
+    location /transactions/authrep.xml {
+      content_by_lua_block {
+        ngx.exit(200)
+      }
+    }
 --- request
 GET /t?user_key=fake
 --- error_code: 401
---- user_files eval
-[
-  [ 'config.json', qq|
-  {
-    "services": [{
-      "id": 1,
-      "backend_version": 1,
-      "backend_version": "oauth",
-      "proxy": {
-        "api_backend": "http://127.0.0.1:$Test::Nginx::Util::ServerPortForClient/api/",
-        "service_id": 2555417794444,
-        "oidc_issuer_endpoint": "www.fgoodl/adasd",
-        "authentication_method": "oidc",
-        "service_backend_version": "oauth",
-        "hosts": [
-          "localhost"
-        ],
-        "backend": {
-          "endpoint": "http://127.0.0.1:$Test::Nginx::Util::ServerPortForClient"
-        },
-        "proxy_rules": [
-          { "pattern": "/t", "http_method": "GET", "metric_system_name": "test", "delta": 1}
-        ]
-      }
-    }]
-  }
-  | ]
-]
 --- error_log
+using lazy configuration loader
 OIDC url is not valid, uri:
+--- no_error_log
+[error]


### PR DESCRIPTION
This PR tracks the conversion of some test files from `Test::APIcast` to the `Test::APIcast::Blackbox` framework.

Below the list of test files involved:

- apicast-request-logs.t
- resty-ctx.t
- apicast-policy-rate-limit.t
- apicast.t
- configuration-loading-lazy.t
- configuration-loading-boot-remote.t
- apicast-caching.t
- configuration-loading-boot-without-config.t
- custom-config.t
- apicast-async-reporting.t
- apicast-policy-3scale-batcher.t
- backend.t
- resolver.t
- balancer.t
- apicast-upstream-balancer.t
- management.t
- apicast-policy-chains.t
- apicast-mapping-rules.t
- backend-cache-handler.t

Of the above, the following are blocking https://github.com/3scale/APIcast/pull/1340:

- [x] apicast-policy-rate-limit.t (sam)
- [x] apicast.t (sam) https://github.com/3scale/APIcast/pull/1347
- [x] configuration-loading-lazy.t  (eguzki) https://github.com/3scale/APIcast/pull/1346
- [x] apicast-caching.t (eguzki) https://github.com/3scale/APIcast/pull/1351
- [x] apicast-async-reporting.t (sam) https://github.com/3scale/APIcast/pull/1348
- [x] apicast-policy-3scale-batcher.t (sam) https://github.com/3scale/APIcast/pull/1349
- [x] apicast-policy-chains.t (sam) https://github.com/3scale/APIcast/pull/1350
