### PR TITLE
remove container volume from docker-compose

### DIFF
--- a/docker-compose.prove.yml
+++ b/docker-compose.prove.yml
@@ -1,0 +1,13 @@
+version: '2.1'
+services:
+  prove:
+    image: ${IMAGE_NAME:-apicast-test}
+    environment:
+      HOME: /opt/app-root/src/
+      TEST_NGINX_BINARY: openresty
+      TEST_NGINX_REDIS_HOST: redis
+    command: "sh -ec '$$TEST_NGINX_BINARY -V; cd ; make dependencies; make prove; exit $$?'"
+    depends_on:
+      - redis
+  redis:
+    image: redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,17 +43,6 @@ services:
       APICAST_CONFIGURATION_LOADER: test
     dns_search:
       - example.com
-  prove:
-    image: ${IMAGE_NAME:-apicast-test}
-    environment:
-      HOME: /opt/app-root/src/
-      TEST_NGINX_BINARY: openresty
-      TEST_NGINX_REDIS_HOST: redis
-    command: "sh -ec '$$TEST_NGINX_BINARY -V; cd ; make dependencies; make prove; exit $$?'"
-    depends_on:
-      - redis
-    volumes_from:
-    - container:${COMPOSE_PROJECT_NAME:-apicast_build_0}-source
   redis:
     image: redis
   keycloak:


### PR DESCRIPTION
### what

* `apicast-source` target not needed for cleaning up `clean-containers`
  * no need to have a container (running or stopped) to use `docker-compose.yaml` configuration
  * makes easier to support `podman`. But currently I am not sure podman can replace docker, I haven't tested. 
* `prove` service from `docker-compose.yaml` removed and created a dedicated `docker-compose.prove.yml`. That configuration is being used in `make prove-docker` command. Used to run integration tests without running the development image (`make development`)
* `clean-containers` makefile target cleans all docker compose environments there could be up and running. 

### Verification steps

Run integration tests in docker
```
make prove-docker
```

Clean running  environment(s) 

```
make clean-containers
```
check `apicast_build_0_prove` and `apicast_build_0_redis` have been cleaned.
```
docker ps -a | grep apicast_build_0
(empty)
```


