### PR TITLE
THREESCALE-8485 fix: passing "latest" version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix to avoid uninitialized variables when request URI is too large [PR #1340](https://github.com/3scale/APIcast/pull/1340) [THREESCALE-7906](https://issues.redhat.com/browse/THREESCALE-7906)
 - Fixed issue where request path is stripped for proxied https requests [PR #1342](https://github.com/3scale/APIcast/pull/1342) [THREESCALE-8426](https://issues.redhat.com/browse/THREESCALE-8426)
 - Bumped liquid-lua to version 0.2.0-2 [PR #1369](https://github.com/3scale/APIcast/pull/1369) - includes: [THREESCALE-8483](https://issues.redhat.com/browse/THREESCALE-8483) and [THREESCALE-8484](https://issues.redhat.com/browse/THREESCALE-8484)
+- Fixed: APIcast could not retrieve the latest version of the proxy config [PR #1370](https://github.com/3scale/APIcast/pull/1370) [THREESCALE-8485](https://issues.redhat.com/browse/THREESCALE-8485)
 
 ### Added
 

--- a/gateway/src/apicast/configuration_loader/remote_v2.lua
+++ b/gateway/src/apicast/configuration_loader/remote_v2.lua
@@ -101,7 +101,7 @@ local function service_config_endpoint(portal_endpoint, service_id, env, version
 end
 
 local function endpoint_for_services_with_host(portal_endpoint, env, host)
-  local query_args = encode_args({ host = host })
+  local query_args = encode_args({ host = host, version = "latest" })
 
   return format(
       "%s/admin/api/account/proxy_configs/%s.json?%s",

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -334,6 +334,7 @@ UwIDAQAB
       end)
 
       local host = 'test_host.com'
+      local version = 'latest'
 
       local proxy_config_response = {
         version = 1,
@@ -346,7 +347,7 @@ UwIDAQAB
         -- the endpoint that returns services by host
         local endpoint = format(
             "http://example.com/admin/api/account/proxy_configs/staging.json?%s",
-            encode_args({ host = host })
+            encode_args({ host = host, version = version })
         )
 
         test_backend.expect { url = endpoint }.

--- a/t/configuration-loading-when-needed.t
+++ b/t/configuration-loading-when-needed.t
@@ -22,7 +22,7 @@ not defined in this test.
 --- upstream env
 location = /admin/api/account/proxy_configs/production.json {
   content_by_lua_block {
-    expected = "host=localhost"
+    expected = "host=localhost&version=latest"
     require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
 
     local response = {


### PR DESCRIPTION
This PR fixes [THREESCALE-8485](https://issues.redhat.com/browse/THREESCALE-8485) by passing "latest" as the version for the "endpoint_for_services_with_host" (i.e. the endpoint called when the configuration is loaded using [APICAST_LOAD_SERVICES_WHEN_NEEDED](https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.11/html/administering_the_api_gateway/apicast_environment_variables#load-services-when-needed)).