### PR TITLE
fix ci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,7 @@ executors:
     docker:
     - image: docker:stable
     environment:
+      COMPOSE_TLS_VERSION: "TLSv1_2"
       DOCKER_COMPOSE_VERSION: "1.16.1"
 
   openresty:


### PR DESCRIPTION
Fix error

```
#!/bin/sh -eo pipefail
make test-runtime-image gateway-logs --keep-going

docker-compose down --volumes --remove-orphans
ERROR: SSL error: [SSL: TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version (_ssl.c:1131)
make: [Makefile:230: clean-containers] Error 1 (ignored)
docker-compose -f docker-compose.prove.yml down --volumes --remove-orphans
ERROR: SSL error: [SSL: TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version (_ssl.c:1131)
make: [Makefile:231: clean-containers] Error 1 (ignored)
docker-compose -f docker-compose-devel.yml -f docker-compose-devel-volmount-default.yml down --volumes --remove-orphans
ERROR: SSL error: [SSL: TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version (_ssl.c:1131)
make: [Makefile:232: clean-containers] Error 1 (ignored)
docker-compose --version
docker-compose version 1.16.1, build 6d1ac219
docker-compose run --rm --user 100001 gateway apicast -l -d
ERROR: SSL error: [SSL: TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version (_ssl.c:1131)
make: *** [Makefile:170: test-runtime-image] Error 1
docker-compose logs gateway
ERROR: SSL error: [SSL: TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version (_ssl.c:1131)
make: *** [Makefile:165: gateway-logs] Error 1

Exited with code exit status 2

CircleCI received exit code 2

```