### PR TITLE
THREESCALE-7735 THREESCALE-8865 opentelemetry instrumentation 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,9 @@ commands:
   install-docker-compose:
     steps:
       - run: |
-          pip install "docker-compose==${DOCKER_COMPOSE_VERSION}"
+          curl -sLO https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64
+          chmod +x docker-compose-linux-x86_64
+          mv docker-compose-linux-x86_64 /usr/local/bin/docker-compose
           docker-compose version
 
   setup-docker:
@@ -48,7 +50,7 @@ commands:
 
   setup-build-env:
     steps:
-      - run: apk update && apk add wget make bash curl py-pip git openssh-client
+      - run: apk update && apk add wget make bash curl git openssh-client
       - install-docker-compose
       - setup-docker
       - attach-workspace
@@ -107,7 +109,7 @@ executors:
     - image: docker:stable
     environment:
       COMPOSE_TLS_VERSION: "TLSv1_2"
-      DOCKER_COMPOSE_VERSION: "2.14.0"
+      DOCKER_COMPOSE_VERSION: "v2.14.0"
 
   openresty:
     working_directory: /opt/app-root/apicast

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ executors:
     - image: docker:stable
     environment:
       COMPOSE_TLS_VERSION: "TLSv1_2"
-      DOCKER_COMPOSE_VERSION: "1.16.1"
+      DOCKER_COMPOSE_VERSION: "2.14.0"
 
   openresty:
     working_directory: /opt/app-root/apicast

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ executors:
   openresty:
     working_directory: /opt/app-root/apicast
     docker:
-      - image: quay.io/3scale/apicast-ci:openresty-1.19.3-pr1381
+      - image: quay.io/3scale/apicast-ci:openresty-1.19.3-pr1379
       - image: redis:3.2.8-alpine
     environment:
       TEST_NGINX_BINARY: openresty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed: OIDC jwt key verification [PR #1389](https://github.com/3scale/APIcast/pull/1389) [THREESCALE-9009](https://issues.redhat.com/browse/THREESCALE-9009)
+### Added
+
+- Opentelemetry support. Opentracing is now deprecated [PR #1379](https://github.com/3scale/APIcast/pull/1379) [THREESCALE-7735](https://issues.redhat.com/browse/THREESCALE-7735)
 
 ## [3.13.0] 2023-02-07
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8:8.5
 
-ARG OPENRESTY_RPM_VERSION="1.19.3"
+ARG OPENRESTY_RPM_VERSION="1.19.3-19"
 
 LABEL summary="The 3scale API gateway (APIcast) is an OpenResty application, which consists of two parts: NGINX configuration and Lua files." \
       description="APIcast is not a standalone API gateway therefore it needs connection to the 3scale API management platform. The container includes OpenResty and uses LuaRocks to install dependencies (rocks are installed in the application folder)." \
@@ -18,13 +18,17 @@ ENV AUTO_UPDATE_INTERVAL=0 \
     PATH=/opt/app-root/src/bin:/opt/app-root/bin:$PATH \
     PLATFORM="el8"
 
-RUN sed -i s/enabled=./enabled=0/g /etc/yum/pluginconf.d/subscription-manager.conf
+RUN PKGS="perl-interpreter-5.26.3 libyaml-devel-0.1.7 m4 openssl-devel git gcc make curl" && \
+    mkdir -p "$HOME" && \
+    yum -y --setopt=tsflags=nodocs install $PKGS && \
+    rpm -V $PKGS && \
+    yum clean all -y
 
 RUN dnf install -y 'dnf-command(config-manager)'
 
 RUN yum config-manager --add-repo http://packages.dev.3sca.net/dev_packages_3sca_net.repo
 
-RUN PKGS="perl-interpreter-5.26.3 libyaml-devel-0.1.7 m4 openssl-devel git gcc make curl openresty-resty-${OPENRESTY_RPM_VERSION} luarocks-2.3.0 opentracing-cpp-devel-1.3.0 libopentracing-cpp1-1.3.0 jaegertracing-cpp-client openresty-opentracing-${OPENRESTY_RPM_VERSION}" && \
+RUN PKGS="openresty-resty-${OPENRESTY_RPM_VERSION} openresty-opentelemetry-${OPENRESTY_RPM_VERSION} openresty-opentracing-${OPENRESTY_RPM_VERSION} openresty-${OPENRESTY_RPM_VERSION} luarocks-2.3.0 opentracing-cpp-devel-1.3.0 libopentracing-cpp1-1.3.0 jaegertracing-cpp-client" && \
     mkdir -p "$HOME" && \
     yum -y --setopt=tsflags=nodocs install $PKGS && \
     rpm -V $PKGS && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8:8.5
 
-ARG OPENRESTY_RPM_VERSION="1.19.3-19"
+ARG OPENRESTY_RPM_VERSION="1.19.3-21.el8"
 
 LABEL summary="The 3scale API gateway (APIcast) is an OpenResty application, which consists of two parts: NGINX configuration and Lua files." \
       description="APIcast is not a standalone API gateway therefore it needs connection to the 3scale API management platform. The container includes OpenResty and uses LuaRocks to install dependencies (rocks are installed in the application folder)." \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM registry.access.redhat.com/ubi8:8.5
 
 ARG OPENRESTY_RPM_VERSION="1.19.3-21.el8"
+ARG LUAROCKS_VERSION="2.3.0"
+ARG JAEGERTRACING_CPP_CLIENT_RPM_VERSION="0.3.1-13.el8"
 
 LABEL summary="The 3scale API gateway (APIcast) is an OpenResty application, which consists of two parts: NGINX configuration and Lua files." \
       description="APIcast is not a standalone API gateway therefore it needs connection to the 3scale API management platform. The container includes OpenResty and uses LuaRocks to install dependencies (rocks are installed in the application folder)." \
@@ -28,7 +30,7 @@ RUN dnf install -y 'dnf-command(config-manager)'
 
 RUN yum config-manager --add-repo http://packages.dev.3sca.net/dev_packages_3sca_net.repo
 
-RUN PKGS="openresty-resty-${OPENRESTY_RPM_VERSION} openresty-opentelemetry-${OPENRESTY_RPM_VERSION} openresty-opentracing-${OPENRESTY_RPM_VERSION} openresty-${OPENRESTY_RPM_VERSION} luarocks-2.3.0 opentracing-cpp-devel-1.3.0 libopentracing-cpp1-1.3.0 jaegertracing-cpp-client" && \
+RUN PKGS="openresty-resty-${OPENRESTY_RPM_VERSION} openresty-opentelemetry-${OPENRESTY_RPM_VERSION} openresty-opentracing-${OPENRESTY_RPM_VERSION} openresty-${OPENRESTY_RPM_VERSION} luarocks-${LUAROCKS_VERSION} opentracing-cpp-devel-1.3.0 libopentracing-cpp1-1.3.0 jaegertracing-cpp-client-${JAEGERTRACING_CPP_CLIENT_RPM_VERSION}" && \
     mkdir -p "$HOME" && \
     yum -y --setopt=tsflags=nodocs install $PKGS && \
     rpm -V $PKGS && \

--- a/Dockerfile.devel
+++ b/Dockerfile.devel
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8:8.5
 
-ARG OPENRESTY_RPM_VERSION="1.19.3"
+ARG OPENRESTY_RPM_VERSION="1.19.3-21.el8"
 ARG LUAROCKS_VERSION="2.3.0"
 
 WORKDIR /tmp
@@ -29,7 +29,9 @@ RUN yum config-manager --add-repo http://packages.dev.3sca.net/dev_packages_3sca
 RUN yum install -y \
         openresty-${OPENRESTY_RPM_VERSION} \
         openresty-resty-${OPENRESTY_RPM_VERSION} \
+        openresty-opentelemetry-${OPENRESTY_RPM_VERSION} \
         openresty-opentracing-${OPENRESTY_RPM_VERSION} \
+        libopentracing-cpp1-1.3.0 \
         jaegertracing-cpp-client
 
 RUN ln -sf /dev/stdout /usr/local/openresty/nginx/logs/access.log \

--- a/Dockerfile.devel
+++ b/Dockerfile.devel
@@ -2,6 +2,7 @@ FROM registry.access.redhat.com/ubi8:8.5
 
 ARG OPENRESTY_RPM_VERSION="1.19.3-21.el8"
 ARG LUAROCKS_VERSION="2.3.0"
+ARG JAEGERTRACING_CPP_CLIENT_RPM_VERSION="0.3.1-13.el8"
 
 WORKDIR /tmp
 
@@ -31,8 +32,9 @@ RUN yum install -y \
         openresty-resty-${OPENRESTY_RPM_VERSION} \
         openresty-opentelemetry-${OPENRESTY_RPM_VERSION} \
         openresty-opentracing-${OPENRESTY_RPM_VERSION} \
+        opentracing-cpp-devel-1.3.0 \
         libopentracing-cpp1-1.3.0 \
-        jaegertracing-cpp-client
+        jaegertracing-cpp-client-${JAEGERTRACING_CPP_CLIENT_RPM_VERSION}
 
 RUN ln -sf /dev/stdout /usr/local/openresty/nginx/logs/access.log \
     && ln -sf /dev/stderr /usr/local/openresty/nginx/logs/error.log \

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,12 @@ gateway-logs: export IMAGE_NAME = does-not-matter
 gateway-logs:
 	$(DOCKER_COMPOSE) logs gateway
 
+opentelemetry-gateway: ## run gateway instrumented with opentelemetry
+	$(DOCKER_COMPOSE) run opentelemetry-instrumented-gateway
+
+opentracing-gateway: ## run gateway instrumented with opentracing
+	$(DOCKER_COMPOSE) run opentracing-instrumented-gateway
+
 test-runtime-image: export IMAGE_NAME ?= $(RUNTIME_IMAGE)
 test-runtime-image: clean-containers ## Smoke test the runtime image. Pass any docker image in IMAGE_NAME parameter.
 	$(DOCKER_COMPOSE) --version

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ NPROC ?= $(firstword $(shell nproc 2>/dev/null) 1)
 
 SEPARATOR="\n=============================================\n"
 
-DEVEL_IMAGE ?= quay.io/3scale/apicast-ci:openresty-1.19.3-pr1381
+DEVEL_IMAGE ?= quay.io/3scale/apicast-ci:openresty-1.19.3-pr1379
 DEVEL_DOCKERFILE ?= Dockerfile.devel
 
 RUNTIME_IMAGE ?= quay.io/3scale/apicast:latest
@@ -63,9 +63,9 @@ export COMPOSE_PROJECT_NAME
 # The development image is also used in CI (circleCI) as the 'openresty' executor
 # When the development image changes, make sure to:
 # * build a new development image:
-#     make dev-build IMAGE_NAME=quay.io/3scale/apicast-ci:openresty-1.19.3-pr1381
+#     make dev-build IMAGE_NAME=quay.io/3scale/apicast-ci:openresty-1.19.3-pr{NUM}
 # * push to quay.io/3scale/apicast-ci with a fixed tag (avoid floating tags)
-#     docker push quay.io/3scale/apicast-ci:openresty-1.19.3-pr1381
+#     docker push quay.io/3scale/apicast-ci:openresty-1.19.3-pr{NUM}
 # * update .circleci/config.yaml openresty executor with the image URL
 .PHONY: dev-build
 dev-build: export OPENRESTY_RPM_VERSION?=1.19.3

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ oc new-app -f https://raw.githubusercontent.com/3scale/apicast/master/openshift/
 - Rate-limit: can apply limits based on a header, [JWT](https://jwt.io/) claims, the IP of the request and many more.
 - Modular and extensible: thanks to the APIcast [policies framework](doc/policies.md).
 - Monitoring with [Prometheus](https://prometheus.io/).
-- [OpenTracing](https://opentracing.io/) integration with [Jaeger](https://www.jaegertracing.io/).
+- [NGINX instrumentation](https://github.com/open-telemetry/opentelemetry-cpp-contrib) using [OpenTelemetry](https://opentelemetry.io/). Works with [Jaeger](https://www.jaegertracing.io/).
 - Can be deployed in [Openshift](https://www.openshift.com/).
 - Integrates with IDPs like [Keycloak](https://www.keycloak.org) to provide authentication based on [OIDC](https://openid.net/connect/).
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -8,8 +8,8 @@ Note that when deploying APIcast v2 with OpenShift, some of these parameters can
 
 ### `APICAST_BACKEND_CACHE_HANDLER`
 
-**Values:** strict | resilient  
-**Default:** strict  
+**Values:** strict | resilient
+**Default:** strict
 **Deprecated:** Use [Caching](../gateway/src/apicast/policy/caching/apicast-policy.json) policy instead.
 
 Defines how the authorization cache behaves when backend is unavailable.
@@ -18,7 +18,7 @@ Resilient will do so only on getting authorization denied from backend.
 
 ### `APICAST_CONFIGURATION_CACHE`
 
-**Values:** _a number_  
+**Values:** _a number_
 **Default:** 0
 
 Specifies the period (in seconds) that the configuration will be stored in the cache for. Can take the following values:
@@ -39,7 +39,7 @@ initialize all the entries.
 
 ### `APICAST_CONFIGURATION_LOADER`
 
-**Values:** boot | lazy  
+**Values:** boot | lazy
 **Default:** lazy
 
 Defines how to load the configuration.
@@ -54,8 +54,8 @@ Defines the name of the Lua module that implements custom logic overriding the e
 
 ### `APICAST_ENVIRONMENT`
 
-**Default:**  
-**Value:** string\[:<string>\]  
+**Default:**
+**Value:** string\[:<string>\]
 **Example:** production:cloud-hosted
 
 Double colon (`:`) separated list of environments (or paths) APIcast should load.
@@ -89,11 +89,11 @@ Notes:
 
 **Default:** _stderr_
 
-Defines the file that will store the OpenResty error log. It is used by `bin/apicast` in the `error_log` directive. Refer to [NGINX documentation](http://nginx.org/en/docs/ngx_core_module.html#error_log) for more information. The file path can be either absolute, or relative to the prefix directory (`apicast` by default) 
+Defines the file that will store the OpenResty error log. It is used by `bin/apicast` in the `error_log` directive. Refer to [NGINX documentation](http://nginx.org/en/docs/ngx_core_module.html#error_log) for more information. The file path can be either absolute, or relative to the prefix directory (`apicast` by default)
 
 ### `APICAST_LOG_LEVEL`
 
-**Values:** debug | info | notice | warn | error | crit | alert | emerg  
+**Values:** debug | info | notice | warn | error | crit | alert | emerg
 **Default:** warn
 
 Specifies the log level for the OpenResty logs.
@@ -116,7 +116,7 @@ that improve the performance of the whole gateway.
 
 ### `APICAST_OIDC_LOG_LEVEL`
 
-**Values:** debug | info | notice | warn | error | crit | alert | emerg  
+**Values:** debug | info | notice | warn | error | crit | alert | emerg
 **Default:** err
 
 Allows to set the log level for the logs related to OpenID Connect integration
@@ -136,7 +136,7 @@ You should enable the debug level only for debugging.
 
 ### `APICAST_OAUTH_TOKENS_TTL`
 
-**Values:** _a number_  
+**Values:** _a number_
 **Default:** 604800
 
 When configured to authenticate using OAuth, this param specifies the TTL (in seconds) of the tokens created.
@@ -161,8 +161,8 @@ This parameter has precedence over `APICAST_PATH_ROUTING`. If `APICAST_PATH_ROUT
 
 ### `APICAST_POLICY_LOAD_PATH`
 
-**Default**: `APICAST_DIR/policies`  
-**Value:**: string\[:<string>\]  
+**Default**: `APICAST_DIR/policies`
+**Value:**: string\[:<string>\]
 **Example**: `~/apicast/policies:$PWD/policies`
 
 Double colon (`:`) separated list of paths where APIcast should look for policies.
@@ -170,8 +170,8 @@ It can be used to first load policies from a development directory or to load ex
 
 ### `APICAST_PROXY_HTTPS_CERTIFICATE_KEY`
 
-**Default:**  
-**Value:** string  
+**Default:**
+**Value:** string
 **Example:** /home/apicast/my_certificate.key
 
 The path to the key of the client SSL certificate.
@@ -180,8 +180,8 @@ This parameter can be overridden by the Upstream_TLS policy.
 
 ### `APICAST_PROXY_HTTPS_CERTIFICATE`
 
-**Default:**  
-**Value:** string  
+**Default:**
+**Value:** string
 **Example:** /home/apicast/my_certificate.crt
 
 The path to the client SSL certificate that APIcast will use when connecting
@@ -192,8 +192,8 @@ This parameter can be overridden by the Upstream_TLS policy.
 
 ### `APICAST_PROXY_HTTPS_PASSWORD_FILE`
 
-**Default:**  
-**Value:** string  
+**Default:**
+**Value:** string
 **Example:** /home/apicast/passwords.txt
 
 Path to a file with passphrases for the SSL cert keys specified with
@@ -201,15 +201,15 @@ Path to a file with passphrases for the SSL cert keys specified with
 
 ### `APICAST_PROXY_HTTPS_SESSION_REUSE`
 
-**Default:** on  
+**Default:** on
 **Values:**
 - `on`: reuses SSL sessions.
 - `off`: does not reuse SSL sessions.
 
 ### `APICAST_REPORTING_THREADS`
 
-**Default**: 0  
-**Value:** integer >= 0  
+**Default**: 0
+**Value:** integer >= 0
 **Experimental:** Under extreme load might have unpredictable performance and lose reports.
 
 Value greater than 0 is going to enable out-of-band reporting to backend.
@@ -236,7 +236,7 @@ Find more information about the Response Codes feature on the [3scale support si
 Used to filter the service configured in the 3scale API Manager, the filter
 matches with the public base URL (Staging or production). Services that do not
 match the filter will be discarded. If the regular expression cannot be compiled
-no services will be loaded. 
+no services will be loaded.
 
 Note: If a service does not match, but is included in the
 `APICAST_SERVICES_LIST`, service will not be discarded
@@ -274,15 +274,15 @@ This accepts the same values as https://nginx.org/en/docs/http/ngx_http_proxy_mo
 
 ### `APICAST_WORKERS`
 
-**Default:** auto  
+**Default:** auto
 **Values:** _number_ | auto
 
 This is the value that will be used in the nginx `worker_processes` [directive](http://nginx.org/en/docs/ngx_core_module.html#worker_processes). By default, APIcast uses `auto`, except for the development environment where `1` is used.
 
 ### `BACKEND_ENDPOINT_OVERRIDE`
 
-URI that overrides the backend endpoint. By default, it is the external route. 
-This parameter is useful when deploying APIcast into the same OpenShift cluster than 3scale, as when using the internal hostname of the backend listener service instead of the public route. 
+URI that overrides the backend endpoint. By default, it is the external route.
+This parameter is useful when deploying APIcast into the same OpenShift cluster than 3scale, as when using the internal hostname of the backend listener service instead of the public route.
 
 **Example**: `http://backend-listener.<3scale-namespace>.svc.cluster.local:3000`
 
@@ -332,7 +332,7 @@ It is **required** to provide either `THREESCALE_PORTAL_ENDPOINT` or `THREESCALE
 
 ### `THREESCALE_DEPLOYMENT_ENV`
 
-**Values:** staging | production  
+**Values:** staging | production
 **Default:** production
 
 The value of this environment variable will be used to define the environment for which the configuration will be downloaded from 3scale (Staging or Production), when using new APIcast.
@@ -352,6 +352,7 @@ It is **required** to provide either `THREESCALE_PORTAL_ENDPOINT` or `THREESCALE
 
 ### `OPENTRACING_TRACER`
 
+**Deprecated:** Check out [OPENTELEMETRY](#opentelemetry) configuration instead.
 **Example:** `jaeger`
 
 This environment variable controls which tracing library will be loaded, right now, there's only one opentracing tracer available, `jaeger`.
@@ -360,6 +361,8 @@ If empty, opentracing support will be disabled.
 
 
 ### `OPENTRACING_CONFIG`
+
+**Deprecated:** Check out [OPENTELEMETRY](#opentelemetry) configuration instead.
 
 This environment variable is used to determine the config file for the opentracing tracer, if `OPENTRACING_TRACER` is not set, this variable will be ignored.
 
@@ -372,10 +375,10 @@ You can choose to mount a different configuration than the provided by default b
 
 ### `OPENTRACING_FORWARD_HEADER`
 
+**Deprecated:** Check out [OPENTELEMETRY](#opentelemetry) configuration instead.
 **Default:** `uber-trace-id`
 
 This environment variable controls the HTTP header used for forwarding opentracing information, this HTTP header will be forwarded to upstream servers.
-
 
 ### `APICAST_HTTPS_PORT`
 
@@ -406,7 +409,7 @@ If this parameter has `1` as its value, it is possible to include an additional 
 ### `all_proxy`, `ALL_PROXY`
 
 **Default:** no value
-**Value:** string  
+**Value:** string
 **Example:** `http://forward-proxy:80`
 
 Defines a HTTP proxy to be used for connecting to services if a protocol-specific proxy is not specified. Authentication is not supported.
@@ -414,7 +417,7 @@ Defines a HTTP proxy to be used for connecting to services if a protocol-specifi
 ### `http_proxy`, `HTTP_PROXY`
 
 **Default:** no value
-**Value:** string  
+**Value:** string
 **Example:** `http://forward-proxy:80`
 
 Defines a HTTP proxy to be used for connecting to HTTP services. Authentication is not supported.
@@ -422,7 +425,7 @@ Defines a HTTP proxy to be used for connecting to HTTP services. Authentication 
 ### `https_proxy`, `HTTPS_PROXY`
 
 **Default:** no value
-**Value:** string  
+**Value:** string
 **Example:** `http://forward-proxy:80`
 
 Defines a HTTP proxy to be used for connecting to HTTPS services. Authentication is not supported.
@@ -430,7 +433,7 @@ Defines a HTTP proxy to be used for connecting to HTTPS services. Authentication
 ### `no_proxy`, `NO_PROXY`
 
 **Default:** no value
-**Values:** string\[,<string>\]; `*`  
+**Values:** string\[,<string>\]; `*`
 **Example:** `foo,bar.com,.extra.dot.com`
 
 Defines a comma-separated list of hostnames and domain names for which the requests should not be proxied. Setting to a single `*` character, which matches all hosts, effectively disables the proxy.
@@ -438,7 +441,7 @@ Defines a comma-separated list of hostnames and domain names for which the reque
 ### `APICAST_HTTP_PROXY_PROTOCOL`
 
 **Default:** false
-**Values:** boolean  
+**Values:** boolean
 **Example:** "true"
 
 This parameter enables the Proxy Protocol for the HTTP listener.
@@ -446,7 +449,7 @@ This parameter enables the Proxy Protocol for the HTTP listener.
 ### `APICAST_HTTPS_PROXY_PROTOCOL`
 
 **Default:** false
-**Values:** boolean  
+**Values:** boolean
 **Example:** "true"
 
 This parameter enables the Proxy Protocol for the HTTPS listener.
@@ -507,3 +510,55 @@ directive](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_
 
 This parameter is only used by the services that are using content caching
 policy.
+
+### `OPENTELEMETRY`
+
+**Default:** 1
+**Value:** string
+
+This environment variable enables NGINX instrumentation using opentelemetry tracing library.
+It works with [Jaeger](https://www.jaegertracing.io/) since v1.35.
+If the existing collector does not support Opentelemetry traces, an [Opentelemetry Collector](https://opentelemetry.io/docs/collector/) is required as tracing proxy.
+
+If empty or not set, nginx instrumentation with opentelemetry is disabled.
+
+Currently, the only implemeneted [exporter](https://opentelemetry.io/docs/reference/specification/protocol/exporter/)
+in APIcast is OTLP over gRPC `OTLP/gRPC`. Eventhough Opentelemetry spec supports also OTLP over HTTP (`OTLP/HTTP`),
+this exporter is not included in APIcast.
+
+Supported propagation types: [W3C](https://w3c.github.io/trace-context/)
+
+### `OPENTELEMETRY_CONFIG`
+
+**Example:** `/tmp/otel.toml`
+
+This environment variable provides location of the configuration file for the tracer. If `OPENTELEMETRY` is not set, this variable will be ignored.
+
+The configuration file spec is defined in the [nginx instrumentation library repo](https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/nginx).
+
+`otlp` is the only supported exporter.
+
+Configuration example
+
+```toml
+exporter = "otlp"
+processor = "batch"
+
+[exporters.otlp]
+# Alternatively the OTEL_EXPORTER_OTLP_ENDPOINT environment variable can also be used.
+host = "localhost"
+port = 4317
+
+[processors.batch]
+max_queue_size = 2048
+schedule_delay_millis = 5000
+max_export_batch_size = 512
+
+[service]
+name = "apicast" # Opentelemetry resource name
+
+[sampler]
+name = "AlwaysOn" # Also: AlwaysOff, TraceIdRatioBased
+ratio = 0.1
+parent_based = false
+```

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -513,14 +513,14 @@ policy.
 
 ### `OPENTELEMETRY`
 
-This environment variable enables NGINX instrumentation using opentelemetry tracing library.
-It works with [Jaeger](https://www.jaegertracing.io/) since v1.35.
-If the existing collector does not support Opentelemetry traces, an [Opentelemetry Collector](https://opentelemetry.io/docs/collector/) is required as tracing proxy.
+This environment variable enables NGINX instrumentation using OpenTelemetry tracing library.
+It works with [Jaeger](https://www.jaegertracing.io/) since version 1.35.
+If the existing collector does not support OpenTelemetry traces, an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) is required as tracing proxy.
 
-If empty or not set, nginx instrumentation with opentelemetry is disabled.
+If empty or not set, Nginx instrumentation with OpenTelemetry is disabled.
 
 Currently, the only implemeneted [exporter](https://opentelemetry.io/docs/reference/specification/protocol/exporter/)
-in APIcast is OTLP over gRPC `OTLP/gRPC`. Eventhough Opentelemetry spec supports also OTLP over HTTP (`OTLP/HTTP`),
+in APIcast is OTLP over gRPC `OTLP/gRPC`. Even though OpenTelemetry specification supports also OTLP over HTTP (`OTLP/HTTP`),
 this exporter is not included in APIcast.
 
 Supported propagation types: [W3C](https://w3c.github.io/trace-context/)
@@ -531,7 +531,7 @@ Supported propagation types: [W3C](https://w3c.github.io/trace-context/)
 
 This environment variable provides location of the configuration file for the tracer. If `OPENTELEMETRY` is not set, this variable will be ignored.
 
-The configuration file spec is defined in the [nginx instrumentation library repo](https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/nginx).
+The configuration file specification is defined in the [Nginx instrumentation library repo](https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/nginx).
 
 `otlp` is the only supported exporter.
 
@@ -542,7 +542,7 @@ exporter = "otlp"
 processor = "batch"
 
 [exporters.otlp]
-# Alternatively the OTEL_EXPORTER_OTLP_ENDPOINT environment variable can also be used.
+# Alternatively, the OTEL_EXPORTER_OTLP_ENDPOINT environment variable can also be used.
 host = "localhost"
 port = 4317
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -513,9 +513,6 @@ policy.
 
 ### `OPENTELEMETRY`
 
-**Default:** 1
-**Value:** string
-
 This environment variable enables NGINX instrumentation using opentelemetry tracing library.
 It works with [Jaeger](https://www.jaegertracing.io/) since v1.35.
 If the existing collector does not support Opentelemetry traces, an [Opentelemetry Collector](https://opentelemetry.io/docs/collector/) is required as tracing proxy.

--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -2,7 +2,7 @@
 version: '2.2'
 services:
   development:
-    image: ${IMAGE:-quay.io/3scale/apicast-ci:openresty-1.19.3-pr1381}
+    image: ${IMAGE:-quay.io/3scale/apicast-ci:openresty-1.19.3-pr1379}
     platform: "linux/amd64"
     depends_on:
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,15 +53,40 @@ services:
       KEYCLOAK_LOGLEVEL: INFO
     ports:
       - "8080"
+  opentracing-instrumented-gateway:
+    image: ${IMAGE_NAME:-apicast-test}
+    depends_on:
+    - jaeger
+    environment:
+      THREESCALE_CONFIG_FILE: /tmp/config.json
+      THREESCALE_DEPLOYMENT_ENV: staging
+      APICAST_CONFIGURATION_LOADER: lazy
+      APICAST_LOG_LEVEL: debug
+      APICAST_CONFIGURATION_CACHE: "0"
+      OPENTRACING_TRACER: jaeger
+      OPENTRACING_CONFIG: /opt/app-root/src/tracing-configs/tracing-config-jaeger-jaeger-config.json
+    volumes:
+      - ./examples/opentracing/apicast-config.json:/tmp/config.json
+      - ./examples/opentracing/jaeger-config.json:/opt/app-root/src/tracing-configs/tracing-config-jaeger-jaeger-config.json
+  opentelemetry-instrumented-gateway:
+    image: ${IMAGE_NAME:-apicast-test}
+    depends_on:
+    - jaeger
+    environment:
+      THREESCALE_CONFIG_FILE: /tmp/config.json
+      THREESCALE_DEPLOYMENT_ENV: staging
+      APICAST_CONFIGURATION_LOADER: lazy
+      APICAST_LOG_LEVEL: debug
+      APICAST_CONFIGURATION_CACHE: "0"
+      OPENTELEMETRY: "1"
+      OPENTELEMETRY_CONFIG: /opt/app-root/src/tracing-configs/otel.toml
+    volumes:
+      - ./examples/opentelemetry/apicast-config.json:/tmp/config.json
+      - ./examples/opentelemetry/otel.toml:/opt/app-root/src/tracing-configs/otel.toml
   jaeger:
     image: jaegertracing/all-in-one:latest
     environment:
-      COLLECTOR_ZIPKIN_HTTP_PORT: 9411
+      JAEGER_DISABLED: "false"
+      COLLECTOR_OTLP_ENABLED: "true"
     ports:
-      - 5775:5775/udp
-      - 6831:6831/udp
-      - 6832:6832/udp
-      - 5778:5778
       - 16686:16686
-      - 14268:14268
-      - 9411:9411

--- a/examples/opentelemetry/apicast-config.json
+++ b/examples/opentelemetry/apicast-config.json
@@ -1,0 +1,12 @@
+{
+    "services": [
+        {
+            "proxy": {
+                "hosts": ["one"],
+                "proxy_rules": [],
+                "api_backend": "https://echo-api.3scale.net",
+                "policy_chain": []
+            }
+        }
+    ]
+}

--- a/examples/opentelemetry/apicast-config.json
+++ b/examples/opentelemetry/apicast-config.json
@@ -1,11 +1,24 @@
 {
     "services": [
         {
+            "backend_version": "1",
             "proxy": {
                 "hosts": ["one"],
-                "proxy_rules": [],
-                "api_backend": "https://echo-api.3scale.net",
-                "policy_chain": []
+                "api_backend": "http://httpbin.org",
+                "backend": {
+                    "endpoint": "http://127.0.0.1:8081",
+                    "host": "backend"
+                },
+                "proxy_rules": [
+                    {
+                        "http_method": "GET",
+                        "pattern": "/",
+                        "metric_system_name": "hits",
+                        "delta": 1,
+                        "parameters": [],
+                        "querystring_parameters": {}
+                    }
+                ]
             }
         }
     ]

--- a/examples/opentelemetry/otel.toml
+++ b/examples/opentelemetry/otel.toml
@@ -1,0 +1,20 @@
+exporter = "otlp"
+processor = "simple"
+
+[exporters.otlp]
+# Alternatively the OTEL_EXPORTER_OTLP_ENDPOINT environment variable can also be used.
+host = "jaeger"
+port = 4317
+# Optional: enable SSL, for endpoints that support it
+# use_ssl = true
+# Optional: set a filesystem path to a pem file to be used for SSL encryption
+# (when use_ssl = true)
+# ssl_cert_path = "/path/to/cert.pem"
+
+[processors.batch]
+max_queue_size = 2048
+schedule_delay_millis = 5000
+max_export_batch_size = 512
+
+[service]
+name = "apicast" # Opentelemetry resource name

--- a/examples/opentracing/apicast-config.json
+++ b/examples/opentracing/apicast-config.json
@@ -1,0 +1,12 @@
+{
+    "services": [
+        {
+            "proxy": {
+                "hosts": ["one"],
+                "proxy_rules": [],
+                "api_backend": "https://echo-api.3scale.net",
+                "policy_chain": []
+            }
+        }
+    ]
+}

--- a/examples/opentracing/apicast-config.json
+++ b/examples/opentracing/apicast-config.json
@@ -1,11 +1,24 @@
 {
     "services": [
         {
+            "backend_version": "1",
             "proxy": {
                 "hosts": ["one"],
-                "proxy_rules": [],
-                "api_backend": "https://echo-api.3scale.net",
-                "policy_chain": []
+                "api_backend": "http://httpbin.org",
+                "backend": {
+                    "endpoint": "http://127.0.0.1:8081",
+                    "host": "backend"
+                },
+                "proxy_rules": [
+                    {
+                        "http_method": "GET",
+                        "pattern": "/",
+                        "metric_system_name": "hits",
+                        "delta": 1,
+                        "parameters": [],
+                        "querystring_parameters": {}
+                    }
+                ]
             }
         }
     ]

--- a/examples/opentracing/jaeger-config.json
+++ b/examples/opentracing/jaeger-config.json
@@ -1,0 +1,26 @@
+{
+    "service_name": "apicast",
+    "disabled": false,
+    "sampler": {
+        "type": "const",
+        "param": 1
+    },
+    "reporter": {
+        "queueSize": 100,
+        "bufferFlushInterval": 10,
+        "logSpans": false,
+        "localAgentHostPort": "jaeger:6831"
+    },
+    "headers": {
+        "jaegerDebugHeader": "debug-id",
+        "jaegerBaggageHeader": "baggage",
+        "TraceContextHeaderName": "uber-trace-id",
+        "traceBaggageHeaderPrefix": "testctx-"
+    },
+    "baggage_restrictions": {
+        "denyBaggageOnInitializationFailure": false,
+        "hostPort": "127.0.0.1:5778",
+        "refreshInterval": 60
+    }
+}
+

--- a/gateway/conf.d/apicast.conf
+++ b/gateway/conf.d/apicast.conf
@@ -85,6 +85,13 @@ location @upstream {
   #{{ proxy_cache_valid | replace: "#{#}", "" }}
   #
 
+  #{% if opentelemetry != empty %}
+  #   {% capture opentelemetry_propagate_directive %}
+  #{#} opentelemetry_propagate;
+  #   {% endcapture %}
+  #   {{ opentelemetry_propagate_directive | replace: "#{#}", "" }}
+  #{% endif %}
+
   proxy_pass $proxy_pass;
 
   proxy_http_version 1.1;

--- a/gateway/conf.d/opentelemetry/otel.conf.liquid
+++ b/gateway/conf.d/opentelemetry/otel.conf.liquid
@@ -1,0 +1,7 @@
+opentelemetry on;
+
+{% if opentelemetry_config_file == nil or opentelemetry_config_file == empty %}
+    {% assign opentelemetry_config_file = "conf.d/opentelemetry/jaeger.example.toml" | filesystem | first%}
+{% endif %}
+
+opentelemetry_config {{ opentelemetry_config_file }};

--- a/gateway/conf.d/opentelemetry/otel.example.toml
+++ b/gateway/conf.d/opentelemetry/otel.example.toml
@@ -1,0 +1,25 @@
+exporter = "otlp"
+processor = "batch"
+
+[exporters.otlp]
+# Alternatively the OTEL_EXPORTER_OTLP_ENDPOINT environment variable can also be used.
+host = "localhost"
+port = 4317
+# Optional: enable SSL, for endpoints that support it
+# use_ssl = true
+# Optional: set a filesystem path to a pem file to be used for SSL encryption
+# (when use_ssl = true)
+# ssl_cert_path = "/path/to/cert.pem"
+
+[processors.batch]
+max_queue_size = 2048
+schedule_delay_millis = 5000
+max_export_batch_size = 512
+
+[service]
+name = "apicast" # Opentelemetry resource name
+
+[sampler]
+name = "AlwaysOn" # Also: AlwaysOff, TraceIdRatioBased
+ratio = 0.1
+parent_based = false

--- a/gateway/conf/nginx.conf.liquid
+++ b/gateway/conf/nginx.conf.liquid
@@ -9,6 +9,10 @@ env OPENSSL_VERIFY;
   {% for file in "modules/ngx_http_opentracing_module.so" | filesystem %}
 load_module {{file}};
   {% endfor %}
+{% elsif opentelemetry != empty %}
+  {% for file in "modules/otel_ngx_module.so" | filesystem %}
+load_module {{file}};
+  {% endfor %}
 {% else %}
   {% if timer_resolution %}
     timer_resolution {{ timer_resolution }};
@@ -79,6 +83,11 @@ http {
   {% if opentracing_tracer != empty %}
     {%- capture tracer_conf %}conf.d/opentracing/{{ opentracing_tracer }}.conf.liquid{%- endcapture -%}
     {% include tracer_conf %}
+  {% endif %}
+
+  {% if opentelemetry != empty %}
+    {%- capture otel_conf %}conf.d/opentelemetry/otel.conf.liquid{%- endcapture -%}
+    {% include otel_conf %}
   {% endif %}
 
   {% for file in template | default: 'http.d/apicast.conf.liquid' | filesystem %}

--- a/gateway/http.d/apicast.conf.liquid
+++ b/gateway/http.d/apicast.conf.liquid
@@ -1,6 +1,6 @@
 log_format time '[$time_local] $target_host:$server_port $remote_addr:$remote_port "$request" $status $body_bytes_sent ($request_time) $post_action_impact';
 
-# Use maps as variables because some logs can be raised out of the server context 
+# Use maps as variables because some logs can be raised out of the server context
 # where variables cannot be set, this allow us to avoid a warning
 map "" $extended_access_log {
     default '';
@@ -33,6 +33,10 @@ server {
   opentracing_trace_locations off;
   {% endif %}
 
+  {% if opentelemetry != empty %}
+  opentelemetry_operation_name apicast_management;
+  {% endif %}
+
   {% include "conf.d/management.conf" %}
 }
 
@@ -43,6 +47,10 @@ server {
   {% if opentracing_tracer != empty %}
   opentracing_operation_name "apicast_mockbackend";
   opentracing_trace_locations off;
+  {% endif %}
+
+  {% if opentelemetry != empty %}
+  opentelemetry_operation_name apicast_mockbackend;
   {% endif %}
 
   {% include "conf.d/backend.conf" %}
@@ -60,6 +68,10 @@ server {
   {% if opentracing_tracer != empty %}
   opentracing_operation_name "apicast_echo";
   opentracing_trace_locations off;
+  {% endif %}
+
+  {% if opentelemetry != empty %}
+  opentelemetry_operation_name apicast_echo;
   {% endif %}
 
   {% include "conf.d/echo.conf" %}
@@ -113,6 +125,12 @@ server {
   opentracing_operation_name "apicast";
   opentracing_trace_locations on;
   opentracing_tag original_request_uri $original_request_uri;
+  {% endif %}
+
+  {% if opentelemetry != empty %}
+  opentelemetry_operation_name apicast;
+  opentelemetry_propagate;
+  opentelemetry_attribute original_request_uri $original_request_uri;
   {% endif %}
 
   {% include "http.d/ssl.conf" %}

--- a/gateway/http.d/apicast.conf.liquid
+++ b/gateway/http.d/apicast.conf.liquid
@@ -129,7 +129,6 @@ server {
 
   {% if opentelemetry != empty %}
   opentelemetry_operation_name apicast;
-  opentelemetry_propagate;
   opentelemetry_attribute original_request_uri $original_request_uri;
   {% endif %}
 

--- a/gateway/src/apicast/cli/environment.lua
+++ b/gateway/src/apicast/cli/environment.lua
@@ -98,6 +98,8 @@ _M.default_environment = 'production'
 -- @tfield ?string opentracing_tracer loads an opentracing tracer library, for example: jaeger
 -- @tfield ?string opentracing_config opentracing config file to load
 -- @tfield ?string opentracing_forward_header opentracing http header to forward upstream
+-- @tfield ?string opentelemetry enables server instrumentation using opentelemetry SDKs
+-- @tfield ?string opentelemetry_config_file opentelemetry config file to load
 -- @tfield ?string upstream_retry_cases error cases where the call to the upstream should be retried
 --         follows the same format as https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream
 -- @tfield ?policy_chain policy_chain @{policy_chain} instance
@@ -116,6 +118,8 @@ _M.default_config = {
     opentracing_tracer = env_value_ref('OPENTRACING_TRACER'),
     opentracing_config = env_value_ref('OPENTRACING_CONFIG'),
     opentracing_forward_header = env_value_ref('OPENTRACING_FORWARD_HEADER'),
+    opentelemetry = env_value_ref('OPENTELEMETRY'),
+    opentelemetry_config_file = env_value_ref('OPENTELEMETRY_CONFIG'),
     upstream_retry_cases = env_value_ref('APICAST_UPSTREAM_RETRY_CASES'),
     http_keepalive_timeout = env_value_ref('HTTP_KEEPALIVE_TIMEOUT'),
     policy_chain = require('apicast.policy_chain').default(),

--- a/gateway/src/apicast/cli/environment.lua
+++ b/gateway/src/apicast/cli/environment.lua
@@ -23,6 +23,7 @@ local insert = table.insert
 local concat = table.concat
 local re = require('ngx.re')
 
+
 local function parse_nameservers()
     local resolver = require('resty.resolver')
     local nameservers = {}
@@ -83,6 +84,16 @@ local function env_value_ref(name)
     return setmetatable({ name = name }, env_value_mt)
 end
 
+local function read_opentracing_tracer(varname)
+    local opentracing_tracer = env_value_ref(varname)
+
+    if tostring(opentracing_tracer) ~= nil then
+        ngx.log(ngx.WARN, 'opentracing use is DEPRECATED. Use Opentelemetry instead with OPENTELEMETRY env var')
+    end
+
+    return opentracing_tracer
+end
+
 local _M = {}
 ---
 -- @field default_environment Default environment name.
@@ -115,7 +126,7 @@ _M.default_config = {
     proxy_ssl_session_reuse = env_value_ref('APICAST_PROXY_HTTPS_SESSION_REUSE'),
     proxy_ssl_password_file = env_value_ref('APICAST_PROXY_HTTPS_PASSWORD_FILE'),
     proxy_ssl_verify = resty_env.enabled('OPENSSL_VERIFY'),
-    opentracing_tracer = env_value_ref('OPENTRACING_TRACER'),
+    opentracing_tracer = read_opentracing_tracer('OPENTRACING_TRACER'),
     opentracing_config = env_value_ref('OPENTRACING_CONFIG'),
     opentracing_forward_header = env_value_ref('OPENTRACING_FORWARD_HEADER'),
     opentelemetry = env_value_ref('OPENTELEMETRY'),

--- a/t/fixtures/otel.toml
+++ b/t/fixtures/otel.toml
@@ -1,0 +1,7 @@
+exporter = "otlp"
+processor = "simple"
+[exporters.otlp]
+host = "127.0.0.1"
+port = 4317
+[service]
+name = "apicast"

--- a/t/opentelemetry.t
+++ b/t/opentelemetry.t
@@ -1,0 +1,39 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+$ENV{OPENTELEMETRY} = '1';
+$ENV{OPENTELEMETRY_CONFIG} = 't/fixtures/otel.toml';
+
+repeat_each(1);
+run_tests();
+
+__DATA__
+=== TEST 1: OpenTelemetry
+Request passing through APIcast should publish OpenTelemetry info.
+--- configuration
+    {
+        "services": [
+        {
+            "proxy": {
+                "policy_chain": [
+                    {
+                        "name": "apicast.policy.upstream",
+                        "configuration": {
+                            "rules": [ { "regex": "/", "url": "http://echo" } ]
+                        }
+                    }
+                ]
+            }
+        }
+        ]
+    }
+--- request
+GET /a_path?
+--- response_body eval
+qr/traceparent: /
+--- error_code: 200
+--- no_error_log
+[error]
+--- tcp_listen: 4317
+--- tcp_reply
+--- wait: 10


### PR DESCRIPTION
### what

implements [THREESCALE-7735](https://issues.redhat.com/browse/THREESCALE-7735)
Specifically the subtask [THREESCALE-8865](https://issues.redhat.com/browse/THREESCALE-8865)

Adds OpenTelemetry distributed tracing support to Apicast.

Supported propagation types: [W3C](https://w3c.github.io/trace-context/)

Jaeger has deprecated the jaeger native clients. From [Jaeger doc](https://www.jaegertracing.io/docs/1.42/client-libraries/#deprecating-jaeger-clients)
> For new applications, we recommend using the OpenTelemetry APIs, SDKs, and instrumentation. Since v1.35, the Jaeger backend can receive trace data from the OpenTelemetry SDKs in their native OpenTelemetry Protocol (OTLP).

Jaeger client (based on opentracing) support is still in place, but gets deprecated in favor of the Opentelemetry use. When opentracing is enabled, APIcast will log warning:
```
2023/02/07 13:35:19 [warn] 47387#47387: [lua] environment.lua:91: read_opentracing_tracer(): opentracing use is DEPRECATED. Use Opentelemetry instead with OPENTELEMETRY env va
```

Add local dev environment with docker compose `make opentelemetry-gateway IMAGE_NAME=my-local-image`

### Tasks

- [X] Expose opentelemetry feature and its configuration via env vars
- [X] In community, docker-compose test opentracing works
- [x] Install opentelemetry SDK and test jaeger traces
- [x] Bring opentelemetry SDK to the devel image
- [x] Bring opentelemetry SDK to the community image
- [x] Documentation
- [x] Testing

### Verification steps

Build runtime image

```
make runtime-image
```

Run test env with APIcast enabled with Opentelemetry and with jeager instance up and running

```
IMAGE_NAME=apicast-runtime-image:latest make opentelemetry-gateway
```

Get the IP of APIcast

```bash
# docker ps
CONTAINER ID   IMAGE                             COMMAND                  CREATED         STATUS         PORTS                                                                                                    NAMES
9598cc711f5e   apicast-runtime-image:latest      "container-entrypoin…"   8 seconds ago   Up 7 seconds                                                                                                            apicast_build_0_opentelemetry-instrumented-gateway_run_87b6f818be1b
00e3146b48b8   jaegertracing/all-in-one:latest   "/go/bin/all-in-one-…"   8 seconds ago   Up 7 seconds   5775/udp, 5778/tcp, 14250/tcp, 6831-6832/udp, 14268/tcp, 0.0.0.0:16686->16686/tcp, :::16686->16686/tcp   apicast_build_0-jaeger-1

# APICAST_IP=$(docker inspect apicast_build_0_opentelemetry-instrumented-gateway_run_87b6f818be1b | yq e -P '.[0].NetworkSettings.Networks.apicast_build_0_default.IPAddress' -)
```

Send request to APIcast
```bash
curl -v -H "Host: one"  http://${APICAST_IP}:8080/get?user_key=foo
*   Trying 172.20.0.3:8080...
* Connected to 172.20.0.3 (172.20.0.3) port 8080 (#0)
> GET /get?user_key=foo HTTP/1.1
> Host: one
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Server: openresty
< Date: Tue, 07 Feb 2023 14:34:41 GMT
< Content-Type: application/json
< Content-Length: 371
< Connection: keep-alive
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Credentials: true
< 
{
  "args": {
    "user_key": "foo"
  }, 
  "headers": {
    "Accept": "*/*", 
    "Host": "httpbin.org", 
    "Traceparent": "00-4335058ae8ec72f9636d8c0da08c62be-137a4beaae638572-01", 
    "User-Agent": "curl/7.81.0", 
    "X-Amzn-Trace-Id": "Root=1-63e26181-28866f82081058f20cfe47a1"
  }, 
  "origin": "91.126.156.31", 
  "url": "http://httpbin.org/get?user_key=foo"
}
* Connection #0 to host 172.20.0.3 left intact
```
Note that upstream echo'ed request headers show `Traceparent` W3C standard tracing header

Open in local browser jaeger dashboard 
```
http://127.0.0.1:16686/search
```
Hit "Find Traces" with *Services* set to `apicast`. There should be at lease one trace

![Screenshot 2023-02-07 at 15-38-27 Jaeger UI](https://user-images.githubusercontent.com/881529/217275446-f13b5f78-a940-4e56-9bc1-5b8a86b85d98.png)

And opening the, the "process" should show attribute `telemetry.sdk.name = opentelemetry`

![Screenshot 2023-02-07 at 15-40-22 Jaeger UI](https://user-images.githubusercontent.com/881529/217275740-9cd324ec-1e0f-474a-ac1a-3cbe1d2dbcf3.png)






