### PR TITLE
Adds matches operation to Conditional policy

### DIFF
--- a/gateway/src/apicast/policy/conditional/apicast-policy.json
+++ b/gateway/src/apicast/policy/conditional/apicast-policy.json
@@ -19,7 +19,7 @@
           },
           "op": {
             "type": "string",
-            "enum": ["==", "!="]
+            "enum": ["==", "!=", "matches"]
           },
           "right": {
             "type": "string"


### PR DESCRIPTION
It's already possible to use the 'matches' operator with APIcast Conditional Policy just editing the Product's policy chain yaml and using it instead of "==" and "!=", enabling the possibility of using regular expressions to match left and right. 