### PR TITLE
THREESCALE-9009 fix OIDC jwt key verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed: OIDC jwt key verification [PR #1389](https://github.com/3scale/APIcast/pull/1389) [THREESCALE-9009](https://issues.redhat.com/browse/THREESCALE-9009)
+
 ## [3.13.0] 2023-02-07
 
 ### Fixed

--- a/gateway/src/apicast/oauth/oidc.lua
+++ b/gateway/src/apicast/oauth/oidc.lua
@@ -186,7 +186,8 @@ function _M:verify(jwt, cache_key)
   local jwk_obj = find_jwk(jwt, self.keys)
 
   if jwk_obj == nil then
-    return false, '[jwk] jwk not found, token might not belong to right realm'
+    ngx.log(ngx.ERR, "[jwt] failed verification for kid: ", jwt.header.kid)
+    return false, '[jwk] not found, token might belong to a different realm'
   end
 
   local pubkey = jwk_obj.pem

--- a/gateway/src/apicast/oauth/oidc.lua
+++ b/gateway/src/apicast/oauth/oidc.lua
@@ -105,7 +105,7 @@ end
 
 local function find_jwk(jwt, keys)
   local jwk = keys and keys[jwt.header.kid]
-  if jwk then return jwk end
+  return jwk
 end
 
 -- Parses the token - in this case we assume it's a JWT token
@@ -185,8 +185,12 @@ function _M:verify(jwt, cache_key)
   -- Find jwk with matching kid for current JWT in request
   local jwk_obj = find_jwk(jwt, self.keys)
 
+  if jwk_obj == nil then
+    return false, '[jwk] jwk not found, token might not belong to right realm'
+  end
+
   local pubkey = jwk_obj.pem
-  -- Check the jwk for the alg field and if not present skip the validation as it is 
+  -- Check the jwk for the alg field and if not present skip the validation as it is
   -- OPTIONAL according to https://www.rfc-editor.org/rfc/rfc7517#section-4.4
   if jwk_obj.alg and jwk_obj.alg ~= jwt.header.alg then
     return false, '[jwt] alg mismatch'

--- a/spec/oauth/oidc_spec.lua
+++ b/spec/oauth/oidc_spec.lua
@@ -292,6 +292,24 @@ describe('OIDC', function()
       assert(credentials, err)
     end)
 
+    it('token key id not found', function()
+      local oidc = _M.new(oidc_config)
+      local access_token = jwt:sign(rsa.private, {
+        header = { typ = 'JWT', alg = 'RS256', kid = 'otherkid' },
+        payload = {
+          iss = oidc_config.issuer,
+          aud = 'notused',
+          azp = 'ce3b2e5e',
+          sub = 'someone',
+          exp = ngx.now() + 10,
+        },
+      })
+
+      local credentials, _, _, err = oidc:transform_credentials({ access_token = access_token })
+
+      assert.match('jwk not found', err, nil, true)
+    end)
+
     describe('getting client_id from any JWT claim', function()
 
       before_each(function()

--- a/spec/oauth/oidc_spec.lua
+++ b/spec/oauth/oidc_spec.lua
@@ -292,7 +292,7 @@ describe('OIDC', function()
       assert(credentials, err)
     end)
 
-    it('token key id not found', function()
+    it('token was signed by a different key', function()
       local oidc = _M.new(oidc_config)
       local access_token = jwt:sign(rsa.private, {
         header = { typ = 'JWT', alg = 'RS256', kid = 'otherkid' },
@@ -307,7 +307,25 @@ describe('OIDC', function()
 
       local credentials, _, _, err = oidc:transform_credentials({ access_token = access_token })
 
-      assert.match('jwk not found', err, nil, true)
+      assert.match('[jwk] not found, token might belong to a different realm', err, nil, true)
+    end)
+
+    it('token was signed by a different issuer', function()
+      local oidc = _M.new(oidc_config)
+      local access_token = jwt:sign(rsa.private, {
+        header = { typ = 'JWT', alg = 'RS256', kid = 'somekid' },
+        payload = {
+          iss = 'other_issuer',
+          aud = 'notused',
+          azp = 'ce3b2e5e',
+          sub = 'someone',
+          exp = ngx.now() + 10,
+        },
+      })
+
+      local credentials, _, _, err = oidc:transform_credentials({ access_token = access_token })
+
+      assert.match('Claim \'iss\' (\'other_issuer\') returned failure', err, nil, true)
     end)
 
     describe('getting client_id from any JWT claim', function()

--- a/t/apicast-oidc.t
+++ b/t/apicast-oidc.t
@@ -389,17 +389,6 @@ to_json({
     keys => { somekid => { pem => $::public_key, alg => 'RS256' } },
   }]
 });
---- upstream
-  location /test {
-    echo "yes";
-  }
---- backend
-  location = /transactions/oauth_authrep.xml {
-    content_by_lua_block {
-      local expected = "provider_key=fookey&service_id=42&usage%5Bhits%5D=1&app_id=appid"
-      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
-    }
-  }
 --- request: GET /test
 --- error_code: 403
 --- more_headers eval


### PR DESCRIPTION
### what

Fixes [THREESCALE-9009](https://issues.redhat.com/browse/THREESCALE-9009) Token generated for a realm associated with a different 3scale Product is able to reach the upstream with no verification performed

When a oidc JWT belonging to realm A is used in a request targeting a 3scale service configured with OIDC authentication with clients configured in realm B, the first conflict APIcast finds is that the referenced public key (in the JWT) does not exist. This PR address this issue adding a check on the JWKey object. 

In the absence of this check, the lua code was working with a `nil` object and raised an error (runtime error: nil pointer dereference) captured only by the [policy chain manager](https://github.com/3scale/APIcast/blob/3scale-2.13.1-GA/gateway/src/apicast/policy_chain.lua#L215).

```lua
local status, return_val = pcall(self[i][phase_name], self[i], context)
```
When this error is raised, the current policy processing stage is halted and skipped, moving on to the next policy in the chain. The token is not even verified with the JWT library as it should be in the next step
```
local pubkey = jwk_obj.pem          -> Raises runtime error                                                
    
if jwk_obj.alg and jwk_obj.alg ~= jwt.header.alg then          -> Not executed                      
  return false, '[jwt] alg mismatch'                                                
end                                                                                 
                                                                                    
jwt = JWT:verify_jwt_obj(pubkey, jwt, self.jwt_claims)    ->Not executed                                      

```

 That causes the APIcast context to enter in a inconsistent state. Specifically, nginx `ctx.credentials` is not populated. Maybe more info but I have not gone through all of them because it is inconsistent, hence unpredictable behavior:
* When the routing policy is added, the request makes its way to upstream and APIcast sends a request to backend with a missing `app_id`. Backend responds with `404 Not Found` (as expected) but APICast ignores this and returns 200 OK to the downstream client.  
* When the routing policy is not in place, APIcast (under this incosisten state) is unable to find an upstream for the request and returns `404 Not Found` to the upstream client. Additionally, APIcast sends a request to backend with a missing `app_id`. Backend responds with `404 Not Found` (as expected).

With the check on the JWKey object, APIcast deals with a managed error (the token is invalid) and the behavior is expected, returning `403 Forbidden` to the downstream client as expected. In that case, backend is **not** called.

### Verification steps
* Setup Keycloak instance, realms, clients and users
* Install 3scale
* [Integrating 3scale with Red Hat Single Sign-On as the OpenID Connect identity provider](https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.13/html/administering_the_api_gateway/integrating-threescale-with-an-openid-connect-identity-provider#integrating-threescale-with-rhsso-as-the-openid-connect-identity-provider_oidc)
  * Configure a single Product A with an OpenID Provider + realm A
* Start dev environment
```
make development
make dependencies
```
* Run apicast locally
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=debug APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=lazy APICAST_CONFIGURATION_CACHE=0 THREESCALE_PORTAL_ENDPOINT=https://token@3scale-admin.example.com ./bin/apicast
```
* Generate token from a realm B (not the same as configured for the Product A)
```
export ACCESS_TOKEN=$(curl -k -H "Content-Type: application/x-www-form-urlencoded" \
        -d 'grant_type=password' \
        -d 'client_id=my-client' \
        -d 'username=bob' \
        -d 'password=p' "https://myoidcprovider.example.com/auth/realms/B/protocol/openid-connect/token" | jq -r '.access_token')
```
* Run query with the invalid jwt
```
# capture apicast IP
APICAST_IP=$(docker inspect apicast_build_0-development-1 | yq e -P '.[0].NetworkSettings.Networks.apicast_build_0_default.IPAddress' -)

curl -v -k -H "Host: example.com:443" -H "Accept: application/json" -H "Authorization: Bearer ${ACCESS_TOKEN}" http://${APICAST_IP}:8080/
```
* APIcast should notify the invalid token error in logs
```
2023/02/16 17:05:33 [debug] 100542#100542: *33 proxy.lua:287: rewrite(): oauth failed with [jwk] jwk not found, token might not belong to right realm, requestID=94a325d7d76eff70d6dd70d6a490a157
```
* The response should be `HTTP/1.1 403 Forbidden`
```
< HTTP/1.1 403 Forbidden
< Server: openresty
< Date: Thu, 16 Feb 2023 17:05:33 GMT
< Content-Type: text/plain; charset=us-ascii
< Transfer-Encoding: chunked
< Connection: keep-alive
< 
* Connection #0 to host 172.20.0.3 left intact
Authentication failed
```





