### PR TITLE
THREESCALE-7942: Apicast logs shows permission denied in a tmp file

### DIFF
--- a/gateway/bin/apicast
+++ b/gateway/bin/apicast
@@ -129,7 +129,7 @@ local function resty(code)
 
     if not cmd then return nil, 'could not find resty' end
 
-    local handle = io.popen(([[/usr/bin/env -i %q -e %q]]):format(cmd, code))
+    local handle = io.popen(([[/usr/bin/env -i %q -e %q 2>/dev/null]]):format(cmd, code))
     local result = handle:read("*l")
 
     handle:close()


### PR DESCRIPTION
 This commit removes the warning message at the start of APIcast POD
 like this one:
 `env: '/tmp/FXal6CekIq': Permission denied`

 The message occur at the start of OpenResty script, that check their own
 script, but there's no execution permission to do that, showing this
 warning message.

 To not change the behavior of the script, this patch just added a
 "2>/dev/null" at the end of the command, so, if it works, will not
 change what's expected.

 If changed the file mode to 0755, another error will be shown. This
 indicates that this command was coded for a specific function not used
 here.

 This commit fix the Jira issue THREESCALE-7942.

 [https://issues.redhat.com/browse/THREESCALE-7942](https://issues.redhat.com/browse/THREESCALE-7942)