### PR TITLE
THREESCALE-8373 Pagination services and proxy config endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Opentelemetry support. Opentracing is now deprecated [PR #1379](https://github.com/3scale/APIcast/pull/1379) [THREESCALE-7735](https://issues.redhat.com/browse/THREESCALE-7735)
 - `/admin/api/account/proxy_configs` endpoint for configuration loading [PR #1352](https://github.com/3scale/APIcast/pull/1352) [THREESCALE-8508](https://issues.redhat.com/browse/THREESCALE-8508)
+- Pagination of services and proxy config endpoints [PR #1397](https://github.com/3scale/APIcast/pull/1397) [THREESCALE-8373](https://issues.redhat.com/browse/THREESCALE-8373)
 
 ### Removed
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -337,6 +337,8 @@ In that case, the gateway would load service's proxy configuration one by one:
 
 Note that when the `THREESCALE_PORTAL_ENDPOINT` has no path, the gateway will iterate over the pages of `/admin/api/account/proxy_configs/${env}.json` sending `pages` and `per_page` query parameters.
 
+**Note**: Pages in 3scale API services and proxy config endpoints were implemented on 3scale 2.10 [THREESCALE-4528](https://issues.redhat.com/browse/THREESCALE-4528). Older releases should not be used.
+
 **Example:** `https://access-token@account-admin.3scale.net`.
 
 When `THREESCALE_PORTAL_ENDPOINT` environment variable is provided, the gateway will download the configuration from 3scale on initializing. The configuration includes all the settings provided on the Integration page of the API(s).

--- a/gateway/src/apicast/configuration_loader/remote_v2.lua
+++ b/gateway/src/apicast/configuration_loader/remote_v2.lua
@@ -250,7 +250,7 @@ end
 -- @param env gateway environment
 -- @param page page in the paginated list. Defaults to 1 for the API, as the client will not send the page param.
 -- @param per_page number of results per page. Default and max is 500 for the API, as the client will not send the per_page param.
-local proxy_configs_per_page = function(http_client, portal_endpoint, host, env, page, per_page)
+local function proxy_configs_per_page(http_client, portal_endpoint, host, env, page, per_page)
   local args = { host = host, version = "latest", page = page, per_page = per_page }
 
   local query_args = '?'..ngx.encode_args(args)
@@ -350,7 +350,7 @@ function _M:call(host)
   end
 end
 
-local services_subset = function()
+local function services_subset()
   local services = resty_env.value('APICAST_SERVICES_LIST') or resty_env.value('APICAST_SERVICES')
   if resty_env.value('APICAST_SERVICES') then ngx.log(ngx.WARN, 'DEPRECATION NOTICE: Use APICAST_SERVICES_LIST not APICAST_SERVICES as this will soon be unsupported') end
   if services and len(services) > 0 then
@@ -368,7 +368,7 @@ end
 -- @param portal_endpoint 3scale API endpoint
 -- @param page page in the paginated list. Defaults to 1 for the API, as the client will not send the page param.
 -- @param per_page number of results per page. Default and max is 500 for the API, as the client will not send the per_page param.
-local services_per_page = function(http_client, portal_endpoint, page, per_page)
+local function services_per_page(http_client, portal_endpoint, page, per_page)
   local encoded_args = ngx.encode_args({page = page, per_page = per_page})
   local query_args = encoded_args ~= '' and '?'..encoded_args
   local base_url = services_index_endpoint(portal_endpoint)

--- a/gateway/src/apicast/configuration_loader/remote_v2.lua
+++ b/gateway/src/apicast/configuration_loader/remote_v2.lua
@@ -265,7 +265,7 @@ local proxy_configs_per_page = function(http_client, portal_endpoint, host, env,
     return nil, err
   end
 
-  ngx.log(ngx.DEBUG, 'proxy configs get status: ', res.status, ' url: ', url)
+  ngx.log(ngx.DEBUG, 'proxy configs get status: ', res.status, ' url: ', url, ' body: ', res.body)
 
   if res and res.status == 200 and res.body then
     local ok, res = pcall(cjson.decode, res.body)
@@ -381,7 +381,7 @@ local services_per_page = function(http_client, portal_endpoint, page, per_page)
     return nil, err
   end
 
-  ngx.log(ngx.DEBUG, 'services get status: ', res.status, ' url: ', url)
+  ngx.log(ngx.DEBUG, 'services get status: ', res.status, ' url: ', url, ' body: ', res.body)
 
   if res.status == 200 then
     local ok, res = pcall(cjson.decode, res.body)

--- a/gateway/src/apicast/configuration_loader/remote_v2.lua
+++ b/gateway/src/apicast/configuration_loader/remote_v2.lua
@@ -144,22 +144,6 @@ local function parse_resp_body(self, resp_body)
   return parse_proxy_configs(self, proxy_configs)
 end
 
-local function is_service_filter_by_url_set()
-  if resty_env.value('APICAST_SERVICES_FILTER_BY_URL') then
-    return true
-  else
-    return false
-  end
-end
-
-local function is_service_list_set()
-  if resty_env.value('APICAST_SERVICES_LIST') then
-    return true
-  else
-    return false
-  end
-end
-
 local function is_service_version_set()
   local vars = resty_env.list()
   for n, v in pairs(vars) do
@@ -348,30 +332,16 @@ function _M:call(host)
   -- When specific version for a specific service is defined,
   -- loading services one by one is required
   --
-  -- APICAST_SERVICE_%s_CONFIGURATION_VERSION does not work then THREESCALE_PORTAL_ENDPOINT
+  -- APICAST_SERVICE_%s_CONFIGURATION_VERSION does not work when the THREESCALE_PORTAL_ENDPOINT
   -- points to master (the API does not allow it), hence error is returned
 
   local use_service_version = is_service_version_set()
-  local use_service_list = is_service_list_set()
-  local use_service_filter_by_url = is_service_filter_by_url_set()
 
   if use_service_version and proxy_config_path then
     return nil, 'APICAST_SERVICE_%s_CONFIGURATION_VERSION cannot be used when proxy config path is provided'
   end
 
-  if use_service_list and proxy_config_path then
-    return nil, 'APICAST_SERVICES_LIST cannot be used when proxy config path is provided'
-  end
-
-  if use_service_filter_by_url and proxy_config_path then
-    return nil, 'APICAST_SERVICES_FILTER_BY_URL cannot be used when proxy config path is provided'
-  end
-
   if use_service_version then
-    return self:index_per_service()
-  elseif use_service_list then
-    return self:index_per_service()
-  elseif use_service_filter_by_url then
     return self:index_per_service()
   elseif proxy_config_path then
     return self:index_custom_path(host)

--- a/gateway/src/apicast/configuration_loader/remote_v2.lua
+++ b/gateway/src/apicast/configuration_loader/remote_v2.lua
@@ -267,10 +267,9 @@ end
 -- @param page page in the paginated list. Defaults to 1 for the API, as the client will not send the page param.
 -- @param per_page number of results per page. Default and max is 500 for the API, as the client will not send the per_page param.
 local proxy_configs_per_page = function(http_client, portal_endpoint, host, env, page, per_page)
-  local encoded_args = ngx.encode_args({
-    host = host, version = "latest", page = page, per_page = per_page
-  })
-  local query_args = '?'..encoded_args
+  local args = { host = host, version = "latest", page = page, per_page = per_page }
+
+  local query_args = '?'..ngx.encode_args(args)
   local base_url = proxy_configs_index_endpoint(portal_endpoint, env)
   local url = base_url..query_args
 

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -6,6 +6,15 @@ local env = require 'resty.env'
 local format = string.format
 local encode_args = ngx.encode_args
 
+local service_generator = function(n)
+  local services = {}
+  for i = 1,n,1 do
+    services[i] = { service = { id = 1 } }
+  end
+
+  return { services = services }
+end
+
 describe('Configuration Remote Loader V2', function()
 
   local test_backend
@@ -44,7 +53,8 @@ describe('Configuration Remote Loader V2', function()
 
   describe(':services', function()
     it('retuns list of services', function()
-      test_backend.expect{ url = 'http://example.com/admin/api/services.json' }.
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+      ngx.encode_args({ per_page = 500, page = 1 })}.
         respond_with{ status = 200, body = cjson.encode({ services = {
             { service = { id = 1 }},
             { service = { id = 2 }}
@@ -80,7 +90,8 @@ describe('Configuration Remote Loader V2', function()
     it('ignores APICAST_SERVICES_LIST when empty', function()
       env.set('APICAST_SERVICES_LIST', '')
 
-      test_backend.expect{ url = "http://example.com/admin/api/services.json" }.
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+      ngx.encode_args({ per_page = 500, page = 1 })}.
         respond_with{ status = 200, body = cjson.encode({ services = { { service = { id = 1 }} }}) }
 
       local services = loader:services()
@@ -93,7 +104,8 @@ describe('Configuration Remote Loader V2', function()
     it('ignores APICAST_SERVICES when empty', function()
       env.set('APICAST_SERVICES', '')
 
-      test_backend.expect{ url = "http://example.com/admin/api/services.json" }.
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+      ngx.encode_args({ per_page = 500, page = 1 })}.
         respond_with{ status = 200, body = cjson.encode({ services = { { service = { id = 1 }} }}) }
 
       local services = loader:services()
@@ -123,6 +135,55 @@ describe('Configuration Remote Loader V2', function()
       assert.truthy(services)
       assert.equal(2, #services)
       assert.same({ { service = { id = 11 } }, { service = { id = 42 } } }, services)
+    end)
+
+    it('retuns list of services with multiple pages', function()
+      -- Will serve: 3 pages
+      -- page 1 => SERVICES_PER_PAGE
+      -- page 2 => SERVICES_PER_PAGE
+      -- page 3 => 51
+      local SERVICES_PER_PAGE = 500
+      local page1 = service_generator(SERVICES_PER_PAGE)
+      local page2 = service_generator(SERVICES_PER_PAGE)
+      local page3 = service_generator(51)
+
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+      ngx.encode_args({ per_page = 500, page = 1 })}.
+        respond_with{ status = 200, body = cjson.encode(page1) }
+
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+      ngx.encode_args({ per_page = 500, page = 2 })}.
+        respond_with{ status = 200, body = cjson.encode(page2) }
+
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+      ngx.encode_args({ per_page = 500, page = 3 })}.
+        respond_with{ status = 200, body = cjson.encode(page3) }
+
+      local services = loader:services()
+
+      assert.truthy(services)
+      assert.equal(2*SERVICES_PER_PAGE + 51, #services)
+    end)
+
+    it('does not crash on error when getting services', function()
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+      ngx.encode_args({ per_page = 500, page = 1 })}.
+        respond_with{ status = 404 }
+
+      local services, err = loader:services()
+
+      assert.falsy(services)
+      assert.equal('invalid status: 404 (Not Found)', tostring(err))
+    end)
+
+    it('returns nil and an error if the response body is not a valid', function()
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+      ngx.encode_args({ per_page = 500, page = 1 })}.
+      respond_with{ status = 200, body = '{ invalid json }'}
+
+      local services, err = loader:services()
+      assert.falsy(services)
+      assert.equals('Expected object key string but found invalid token at character 3', err)
     end)
   end)
 
@@ -247,7 +308,8 @@ UwIDAQAB
     end)
 
     it('returns configuration for all services', function()
-      test_backend.expect{ url = 'http://example.com/admin/api/services.json' }.
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+      ngx.encode_args({ per_page = 500, page = 1 })}.
         respond_with{ status = 200, body = cjson.encode({ services = {
             { service = { id = 1 }},
             { service = { id = 2 }}
@@ -283,7 +345,8 @@ UwIDAQAB
     end)
 
     it('does not crash on error when getting services', function()
-      test_backend.expect{ url = 'http://example.com/admin/api/services.json' }.
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+      ngx.encode_args({ per_page = 500, page = 1 })}.
         respond_with{ status = 404 }
 
       local config, err = loader:index_per_service()
@@ -293,7 +356,8 @@ UwIDAQAB
     end)
 
     it('returns simple message on undefined errors', function()
-      test_backend.expect{ url = 'http://example.com/admin/api/services.json' }.
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+      ngx.encode_args({ per_page = 500, page = 1 })}.
       respond_with{ status = 412 }
 
       local config, err = loader:index_per_service()
@@ -303,7 +367,8 @@ UwIDAQAB
     end)
 
     it('returns configuration even when some services are missing', function()
-      test_backend.expect{ url = 'http://example.com/admin/api/services.json' }.
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+      ngx.encode_args({ per_page = 500, page = 1 })}.
         respond_with{ status = 200, body = cjson.encode({ services = {
             { service = { id = 1 }},
             { service = { id = 2 }}
@@ -332,7 +397,8 @@ UwIDAQAB
 
     describe("When using APICAST_SERVICES_FILTER_BY_URL", function()
       before_each(function()
-        test_backend.expect{ url = 'http://example.com/admin/api/services.json' }.
+        test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+        ngx.encode_args({ per_page = 500, page = 1 })}.
           respond_with{ status = 200, body = cjson.encode({ services = {
               { service = { id = 1 }},
               { service = { id = 2 }}
@@ -444,6 +510,129 @@ UwIDAQAB
         assert.equals(1, res_services[1].id)
         assert.equals(2, res_services[2].id)
       end)
+    end)
+
+    -- When only some of the services have an OIDC configuration.
+    -- This is a regression test. APIcast crashed when loading a config where only
+    -- some of the services used OIDC.
+    -- The reason is that we created an array of OIDC configs with
+    -- size=number_of_services. Let's say we have 100 services and only the 50th has an
+    -- OIDC config. In this case, we created this Lua table:
+    -- { [50] = oidc_config_here }.
+    -- The problem is that cjson raises an error when trying to convert a sparse array
+    -- like that into JSON. Using the default cjson configuration, the minimum number
+    -- of elements to reproduce the error is 11. So in this test, we create 11 services
+    -- and assign an OIDC config only to the last one. Check
+    -- https://www.kyne.com.au/~mark/software/lua-cjson-manual.html#encode_sparse_array
+    -- for more details.
+    -- Now we assign to _false_ the elements of the array that do not have an OIDC
+    -- config, so this test should not crash.
+    it('only some services have oidc config', function()
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+      ngx.encode_args({ per_page = 500, page = 1 })}.
+      respond_with{ status = 200, body = cjson.encode({ services = {
+        { service = { id = 1 }}, { service = { id = 2 }}, { service = { id = 3 }},
+        { service = { id = 4 }}, { service = { id = 5 }}, { service = { id = 6 }},
+        { service = { id = 7 }}, { service = { id = 8 }}, { service = { id = 9 }},
+        { service = { id = 10 }}, { service = { id = 11 }}
+      }})}
+
+      local response_body = cjson.encode(
+        {
+          proxy_config = { version = 13, environment = 'staging',
+            content = { id = 1, backend_version = 1, proxy = { hosts = {"one.com", "first.dev"} } }
+          }
+        })
+      test_backend.expect{ url = 'http://example.com/admin/api/services/1/proxy/configs/staging/latest.json' }.
+          respond_with{ status = 200, body = response_body }
+      test_backend.expect{ url = 'http://example.com/admin/api/services/2/proxy/configs/staging/latest.json' }.
+          respond_with{ status = 200, body = response_body }
+      test_backend.expect{ url = 'http://example.com/admin/api/services/3/proxy/configs/staging/latest.json' }.
+          respond_with{ status = 200, body = response_body }
+      test_backend.expect{ url = 'http://example.com/admin/api/services/4/proxy/configs/staging/latest.json' }.
+          respond_with{ status = 200, body = response_body }
+      test_backend.expect{ url = 'http://example.com/admin/api/services/5/proxy/configs/staging/latest.json' }.
+          respond_with{ status = 200, body = response_body }
+      test_backend.expect{ url = 'http://example.com/admin/api/services/6/proxy/configs/staging/latest.json' }.
+          respond_with{ status = 200, body = response_body }
+      test_backend.expect{ url = 'http://example.com/admin/api/services/7/proxy/configs/staging/latest.json' }.
+          respond_with{ status = 200, body = response_body }
+      test_backend.expect{ url = 'http://example.com/admin/api/services/8/proxy/configs/staging/latest.json' }.
+          respond_with{ status = 200, body = response_body }
+      test_backend.expect{ url = 'http://example.com/admin/api/services/9/proxy/configs/staging/latest.json' }.
+          respond_with{ status = 200, body = response_body }
+      test_backend.expect{ url = 'http://example.com/admin/api/services/10/proxy/configs/staging/latest.json' }.
+          respond_with{ status = 200, body = response_body }
+
+      test_backend.expect{ url = 'http://example.com/admin/api/services/11/proxy/configs/staging/latest.json' }.
+          respond_with{ status = 200, body = cjson.encode(
+            {
+              proxy_config = {
+                content = {
+                  proxy = { oidc_issuer_endpoint = 'http://user:pass@idp.example.com/auth/realms/foo/' }
+                }
+              }
+            }
+          )}
+
+      test_backend.expect{ url = "http://idp.example.com/auth/realms/foo/.well-known/openid-configuration" }.
+      respond_with{
+        status = 200,
+        headers = { content_type = 'application/json' },
+        body = [[
+            {
+              "issuer": "https://idp.example.com/auth/realms/foo",
+              "jwks_uri": "https://idp.example.com/auth/realms/foo/jwks",
+              "id_token_signing_alg_values_supported": [ "RS256" ]
+            }
+          ]]
+      }
+
+      test_backend.expect{ url = "https://idp.example.com/auth/realms/foo/jwks" }.
+      respond_with{
+        status = 200,
+        headers = { content_type = 'application/json' },
+        body =  [[
+            { "keys": [{
+                "kid": "3g-I9PWt6NrznPLcbE4zZrakXar27FDKEpqRPlD2i2Y",
+                "kty": "RSA",
+                "n": "iqXwBiZgN2q1dCKU1P_vzyiGacdQhfqgxQST7GFlWU_PUljV9uHrLOadWadpxRAuskNpXWsrKoU_hDxtSpUIRJj6hL5YTlrvv-IbFwPNtD8LnOfKL043_ZdSOe3aT4R4NrBxUomndILUESlhqddylVMCGXQ81OB73muc9ovR68Ajzn8KzpU_qegh8iHwk-SQvJxIIvgNJCJTC6BWnwS9Bw2ns0fQOZZRjWFRVh8BjkVdqa4vCAb6zw8hpR1y9uSNG-fqUAPHy5IYQaD8k8QX0obxJ0fld61fH-Wr3ENpn9YZWYBcKvnwLm2bvxqmNVBzW4rhGEZb9mf-KrSagD5GUw",
+                "e": "AQAB"
+            }] }
+        ]]
+      }
+
+      local config = assert(loader:index_per_service())
+
+      assert.truthy(config)
+      assert.equals('string', type(config))
+
+      result_config = cjson.decode(config)
+      assert.equals(11, #result_config.services)
+      assert.equals(11, #result_config.oidc)
+      assert.same({
+          id_token_signing_alg_values_supported = { 'RS256' },
+          issuer = 'https://idp.example.com/auth/realms/foo',
+          jwks_uri = 'https://idp.example.com/auth/realms/foo/jwks'
+      }, result_config.oidc[11].config)
+      assert.same('https://idp.example.com/auth/realms/foo', result_config.oidc[11].issuer)
+      assert.same({ ['3g-I9PWt6NrznPLcbE4zZrakXar27FDKEpqRPlD2i2Y'] = {
+        e = 'AQAB',
+        kid = '3g-I9PWt6NrznPLcbE4zZrakXar27FDKEpqRPlD2i2Y',
+        kty = 'RSA',
+        n = 'iqXwBiZgN2q1dCKU1P_vzyiGacdQhfqgxQST7GFlWU_PUljV9uHrLOadWadpxRAuskNpXWsrKoU_hDxtSpUIRJj6hL5YTlrvv-IbFwPNtD8LnOfKL043_ZdSOe3aT4R4NrBxUomndILUESlhqddylVMCGXQ81OB73muc9ovR68Ajzn8KzpU_qegh8iHwk-SQvJxIIvgNJCJTC6BWnwS9Bw2ns0fQOZZRjWFRVh8BjkVdqa4vCAb6zw8hpR1y9uSNG-fqUAPHy5IYQaD8k8QX0obxJ0fld61fH-Wr3ENpn9YZWYBcKvnwLm2bvxqmNVBzW4rhGEZb9mf-KrSagD5GUw',
+        pem = [[
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiqXwBiZgN2q1dCKU1P/v
+zyiGacdQhfqgxQST7GFlWU/PUljV9uHrLOadWadpxRAuskNpXWsrKoU/hDxtSpUI
+RJj6hL5YTlrvv+IbFwPNtD8LnOfKL043/ZdSOe3aT4R4NrBxUomndILUESlhqddy
+lVMCGXQ81OB73muc9ovR68Ajzn8KzpU/qegh8iHwk+SQvJxIIvgNJCJTC6BWnwS9
+Bw2ns0fQOZZRjWFRVh8BjkVdqa4vCAb6zw8hpR1y9uSNG+fqUAPHy5IYQaD8k8QX
+0obxJ0fld61fH+Wr3ENpn9YZWYBcKvnwLm2bvxqmNVBzW4rhGEZb9mf+KrSagD5G
+UwIDAQAB
+-----END PUBLIC KEY-----
+]], }
+      }, result_config.oidc[11].keys)
     end)
   end)
 
@@ -572,7 +761,29 @@ UwIDAQAB
       assert.equals(1, #result_config.services)
       assert.equals(1, #result_config.oidc)
       assert.same('2', result_config.oidc[1].service_id)
-      assert.same('https://idp.example.com/auth/realms/foo', result_config.oidc[1].config.issuer)
+      assert.same({
+          id_token_signing_alg_values_supported = { 'RS256' },
+          issuer = 'https://idp.example.com/auth/realms/foo',
+          jwks_uri = 'https://idp.example.com/auth/realms/foo/jwks'
+      }, result_config.oidc[1].config)
+      assert.same('https://idp.example.com/auth/realms/foo', result_config.oidc[1].issuer)
+      assert.same({ ['3g-I9PWt6NrznPLcbE4zZrakXar27FDKEpqRPlD2i2Y'] = {
+        e = 'AQAB',
+        kid = '3g-I9PWt6NrznPLcbE4zZrakXar27FDKEpqRPlD2i2Y',
+        kty = 'RSA',
+        n = 'iqXwBiZgN2q1dCKU1P_vzyiGacdQhfqgxQST7GFlWU_PUljV9uHrLOadWadpxRAuskNpXWsrKoU_hDxtSpUIRJj6hL5YTlrvv-IbFwPNtD8LnOfKL043_ZdSOe3aT4R4NrBxUomndILUESlhqddylVMCGXQ81OB73muc9ovR68Ajzn8KzpU_qegh8iHwk-SQvJxIIvgNJCJTC6BWnwS9Bw2ns0fQOZZRjWFRVh8BjkVdqa4vCAb6zw8hpR1y9uSNG-fqUAPHy5IYQaD8k8QX0obxJ0fld61fH-Wr3ENpn9YZWYBcKvnwLm2bvxqmNVBzW4rhGEZb9mf-KrSagD5GUw',
+        pem = [[
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiqXwBiZgN2q1dCKU1P/v
+zyiGacdQhfqgxQST7GFlWU/PUljV9uHrLOadWadpxRAuskNpXWsrKoU/hDxtSpUI
+RJj6hL5YTlrvv+IbFwPNtD8LnOfKL043/ZdSOe3aT4R4NrBxUomndILUESlhqddy
+lVMCGXQ81OB73muc9ovR68Ajzn8KzpU/qegh8iHwk+SQvJxIIvgNJCJTC6BWnwS9
+Bw2ns0fQOZZRjWFRVh8BjkVdqa4vCAb6zw8hpR1y9uSNG+fqUAPHy5IYQaD8k8QX
+0obxJ0fld61fH+Wr3ENpn9YZWYBcKvnwLm2bvxqmNVBzW4rhGEZb9mf+KrSagD5G
+UwIDAQAB
+-----END PUBLIC KEY-----
+]], }
+      }, result_config.oidc[1].keys)
     end)
 
     it('returns configuration from master endpoint', function()
@@ -722,7 +933,29 @@ UwIDAQAB
       assert.equals(1, #result_config.services)
       assert.equals(1, #result_config.oidc)
       assert.same('2', result_config.oidc[1].service_id)
-      assert.same('https://idp.example.com/auth/realms/foo', result_config.oidc[1].config.issuer)
+      assert.same({
+          id_token_signing_alg_values_supported = { 'RS256' },
+          issuer = 'https://idp.example.com/auth/realms/foo',
+          jwks_uri = 'https://idp.example.com/auth/realms/foo/jwks'
+      }, result_config.oidc[1].config)
+      assert.same('https://idp.example.com/auth/realms/foo', result_config.oidc[1].issuer)
+      assert.same({ ['3g-I9PWt6NrznPLcbE4zZrakXar27FDKEpqRPlD2i2Y'] = {
+        e = 'AQAB',
+        kid = '3g-I9PWt6NrznPLcbE4zZrakXar27FDKEpqRPlD2i2Y',
+        kty = 'RSA',
+        n = 'iqXwBiZgN2q1dCKU1P_vzyiGacdQhfqgxQST7GFlWU_PUljV9uHrLOadWadpxRAuskNpXWsrKoU_hDxtSpUIRJj6hL5YTlrvv-IbFwPNtD8LnOfKL043_ZdSOe3aT4R4NrBxUomndILUESlhqddylVMCGXQ81OB73muc9ovR68Ajzn8KzpU_qegh8iHwk-SQvJxIIvgNJCJTC6BWnwS9Bw2ns0fQOZZRjWFRVh8BjkVdqa4vCAb6zw8hpR1y9uSNG-fqUAPHy5IYQaD8k8QX0obxJ0fld61fH-Wr3ENpn9YZWYBcKvnwLm2bvxqmNVBzW4rhGEZb9mf-KrSagD5GUw',
+        pem = [[
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiqXwBiZgN2q1dCKU1P/v
+zyiGacdQhfqgxQST7GFlWU/PUljV9uHrLOadWadpxRAuskNpXWsrKoU/hDxtSpUI
+RJj6hL5YTlrvv+IbFwPNtD8LnOfKL043/ZdSOe3aT4R4NrBxUomndILUESlhqddy
+lVMCGXQ81OB73muc9ovR68Ajzn8KzpU/qegh8iHwk+SQvJxIIvgNJCJTC6BWnwS9
+Bw2ns0fQOZZRjWFRVh8BjkVdqa4vCAb6zw8hpR1y9uSNG+fqUAPHy5IYQaD8k8QX
+0obxJ0fld61fH+Wr3ENpn9YZWYBcKvnwLm2bvxqmNVBzW4rhGEZb9mf+KrSagD5G
+UwIDAQAB
+-----END PUBLIC KEY-----
+]], }
+      }, result_config.oidc[1].keys)
     end)
 
     it('returns configuration from admin portal endpoint', function()
@@ -787,7 +1020,8 @@ UwIDAQAB
 
     it('with service filter by url call index per service', function()
       env.set('APICAST_SERVICES_FILTER_BY_URL','one.*')
-      test_backend.expect{ url = 'http://example.com/admin/api/services.json' }.
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+      ngx.encode_args({ per_page = 500, page = 1 })}.
         respond_with{ status = 200, body = cjson.encode({ services = {} }) }
       local config = assert(loader:call())
       assert.truthy(config)
@@ -825,7 +1059,8 @@ UwIDAQAB
 
     it('with service version call index per service', function()
       env.set('APICAST_SERVICE_42_CONFIGURATION_VERSION', '2')
-      test_backend.expect{ url = 'http://example.com/admin/api/services.json' }.
+      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
+      ngx.encode_args({ per_page = 500, page = 1 })}.
         respond_with{ status = 200, body = cjson.encode({ services = {
             { service = { id = 42 }}
           }})

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -999,65 +999,6 @@ UwIDAQAB
       assert.equal('APICAST_SERVICE_%s_CONFIGURATION_VERSION cannot be used when proxy config path is provided', tostring(err))
     end)
 
-    it('with path on endpoint service list cannot be set', function()
-      loader = _M.new('http://example.com/something/with/path', { client = test_backend })
-      env.set('APICAST_SERVICES_LIST', '11,42')
-
-      local config, err = loader:call()
-
-      assert.falsy(config)
-      assert.equal('APICAST_SERVICES_LIST cannot be used when proxy config path is provided', tostring(err))
-    end)
-
-    it('with path on endpoint service filter by url cannot be set', function()
-      loader = _M.new('http://example.com/something/with/path', { client = test_backend })
-      env.set('APICAST_SERVICES_FILTER_BY_URL','one.*')
-
-      local config, err = loader:call()
-
-      assert.falsy(config)
-      assert.equal('APICAST_SERVICES_FILTER_BY_URL cannot be used when proxy config path is provided', tostring(err))
-    end)
-
-    it('with service filter by url call index per service', function()
-      env.set('APICAST_SERVICES_FILTER_BY_URL','one.*')
-      test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..
-      ngx.encode_args({ per_page = 500, page = 1 })}.
-        respond_with{ status = 200, body = cjson.encode({ services = {} }) }
-      local config = assert(loader:call())
-      assert.truthy(config)
-      assert.equals('string', type(config))
-      assert.equals(0, #(cjson.decode(config).services))
-    end)
-
-    it('with service list call index per service', function()
-      env.set('APICAST_SERVICES_LIST', '11,42')
-      test_backend.expect{ url = 'http://example.com/admin/api/services/11/proxy/configs/production/latest.json' }.
-        respond_with{ status = 200, body = cjson.encode(
-          {
-            proxy_config = {
-              version = 13,
-              environment = 'production',
-              content = { id = 11, backend_version = 1, proxy = { oidc_issuer_endpoint = ngx.null } }
-            }
-          }
-        ) }
-      test_backend.expect{ url = 'http://example.com/admin/api/services/42/proxy/configs/production/latest.json' }.
-        respond_with{ status = 200, body = cjson.encode(
-          {
-            proxy_config = {
-              version = 13,
-              environment = 'production',
-              content = { id = 42, backend_version = 1, proxy = { oidc_issuer_endpoint = ngx.null } }
-            }
-          }
-        ) }
-      local config = assert(loader:call())
-      assert.truthy(config)
-      assert.equals('string', type(config))
-      assert.equals(2, #(cjson.decode(config).services))
-    end)
-
     it('with service version call index per service', function()
       env.set('APICAST_SERVICE_42_CONFIGURATION_VERSION', '2')
       test_backend.expect{ url = 'http://example.com/admin/api/services.json?'..

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -4,7 +4,6 @@ local cjson = require 'cjson'
 local user_agent = require 'apicast.user_agent'
 local env = require 'resty.env'
 local format = string.format
-local encode_args = ngx.encode_args
 
 local service_generator = function(n)
   local services = {}
@@ -817,13 +816,15 @@ UwIDAQAB
     end)
 
     it('invalid status is handled', function()
-      test_backend.expect{ url = 'http://example.com/admin/api/account/proxy_configs/production.json?version=latest' }.
+      test_backend.expect{ url = 'http://example.com/admin/api/account/proxy_configs/production.json?'..
+      ngx.encode_args({ page = 1, per_page = 500, version = "latest" })}.
         respond_with{ status = 512, body = nil}
       assert.same({ nil, 'invalid status' }, { loader:index() })
     end)
 
-    it('returns configuration for all services with no host', function()
-      test_backend.expect{ url = 'http://example.com/admin/api/account/proxy_configs/production.json?version=latest' }.
+    it('returns configuration for all proxy configs with no host', function()
+      test_backend.expect{ url = 'http://example.com/admin/api/account/proxy_configs/production.json?'..
+      ngx.encode_args({ version = "latest", page = 1, per_page = 500 })}.
         respond_with{ status = 200, body = cjson.encode({ proxy_configs = {
           {
             proxy_config = {
@@ -847,7 +848,7 @@ UwIDAQAB
 
     it('returns configuration for all services with host', function()
       test_backend.expect{ url = 'http://example.com/admin/api/account/proxy_configs/production.json?'..
-      ngx.encode_args({ host = "foobar.example.com", version = "latest" })}.
+      ngx.encode_args({ host = "foobar.example.com", version = "latest", page = 1, per_page = 500 })}.
         respond_with{ status = 200, body = cjson.encode({ proxy_configs = {
           {
             proxy_config = {
@@ -871,7 +872,7 @@ UwIDAQAB
 
     it('returns nil and an error if the config is not a valid', function()
       test_backend.expect{ url = 'http://example.com/admin/api/account/proxy_configs/production.json?'..
-      ngx.encode_args({ host = "foobar.example.com", version = "latest" })}.
+      ngx.encode_args({ host = "foobar.example.com", version = "latest", page = 1, per_page = 500 })}.
       respond_with{ status = 200, body = '{ invalid json }'}
 
       local config, err = loader:index('foobar.example.com')
@@ -882,7 +883,7 @@ UwIDAQAB
 
     it('returns configuration with oidc config complete', function()
       test_backend.expect{ url = 'http://example.com/admin/api/account/proxy_configs/production.json?'..
-      ngx.encode_args({ host = "foobar.example.com", version = "latest" })}.
+      ngx.encode_args({ host = "foobar.example.com", version = "latest", page = 1, per_page = 500 })}.
         respond_with{ status = 200, body = cjson.encode({ proxy_configs = {
           {
             proxy_config = {
@@ -961,7 +962,7 @@ UwIDAQAB
     it('returns configuration from admin portal endpoint', function()
       test_backend.expect{
         url = 'http://example.com/admin/api/account/proxy_configs/production.json?' ..
-        ngx.encode_args({ host = "foobar.example.com", version = "latest" })
+        ngx.encode_args({ host = "foobar.example.com", version = "latest", page = 1, per_page = 500 })
       }.respond_with{ status = 200, body = cjson.encode({ proxy_configs = {
           {
             proxy_config = {
@@ -1108,7 +1109,7 @@ UwIDAQAB
 
     it('by default call index', function()
       test_backend.expect{ url = 'http://example.com/admin/api/account/proxy_configs/production.json?'..
-      ngx.encode_args({ host = "foobar.example.com", version = "latest" })}.
+      ngx.encode_args({ host = "foobar.example.com", version = "latest", page = 1, per_page = 500 })}.
         respond_with{ status = 200, body = cjson.encode({ proxy_configs = {
           {
             proxy_config = {

--- a/t/apicast-policy-3scale-batcher-blackbox.t
+++ b/t/apicast-policy-3scale-batcher-blackbox.t
@@ -110,7 +110,8 @@ __DATA__
           {
             "name": "apicast.policy.3scale_batcher",
             "configuration": {
-              "batch_report_seconds" : 1
+              "batch_report_seconds" : 10,
+              "auths_ttl": 30
             }
           },
           {
@@ -139,6 +140,7 @@ __DATA__
     }
   ]
 }
+--- timeout: 25s
 --- test env
 content_by_lua_block {
   local function request(path)
@@ -163,7 +165,7 @@ content_by_lua_block {
   request('/foo/bar')
 
   request('/foo')
-  ngx.sleep(2)
+  ngx.sleep(15)
 }
 --- response_body
 connected: 1

--- a/t/configuration-loading-boot-remote.t
+++ b/t/configuration-loading-boot-remote.t
@@ -42,34 +42,7 @@ GET /t
 {"services":[],"oidc":[]}
 --- exit_code: 200
 
-=== TEST 2: lazy load configuration from remote account/proxy_configs
-endpoint should load that configuration and not fail
---- main_config
-env THREESCALE_PORTAL_ENDPOINT=http://127.0.0.1:$TEST_NGINX_SERVER_PORT;
-env APICAST_CONFIGURATION_LOADER=lazy;
-env THREESCALE_DEPLOYMENT_ENV=foobar;
-env PATH;
---- http_config
-  lua_package_path "$TEST_NGINX_LUA_PATH";
---- config
-location = /t {
-  content_by_lua_block {
-    local loader = require('apicast.configuration_loader.remote_v2')
-    local body = assert(loader:call("example.com"))
-    ngx.say(body)
-  }
-}
-
-location = /admin/api/account/proxy_configs/foobar.json {
-    echo '{}';
-}
---- request
-GET /t
---- expected_json
-{"services":[],"oidc":[]}
---- exit_code: 200
-
-=== TEST 3: retrieve config with liquid values
+=== TEST 2: retrieve config with liquid values
 should not fail
 --- main_config
 env THREESCALE_PORTAL_ENDPOINT=http://127.0.0.1:$TEST_NGINX_SERVER_PORT;

--- a/t/configuration-loading-filter-services-by-url.t
+++ b/t/configuration-loading-filter-services-by-url.t
@@ -1,0 +1,144 @@
+use Test::APIcast::Blackbox 'no_plan';
+
+repeat_each(1);
+run_tests();
+
+__DATA__
+
+=== TEST 1: multi service configuration limited with Regexp Filter
+--- env eval
+("APICAST_SERVICES_FILTER_BY_URL", "^on*")
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": 1,
+      "proxy": {
+        "hosts": [
+          "one"
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          {
+            "http_method": "GET",
+            "delta": 1,
+            "metric_system_name": "one",
+            "pattern": "/"
+          }
+        ]
+      },
+      "id": 42
+    },
+    {
+      "proxy": {
+        "hosts": [
+          "two"
+        ]
+      },
+      "id": 11
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block { ngx.exit(200) }
+  }
+--- upstream
+  location ~ / {
+     echo 'yay, api backend';
+  }
+--- pipelined_requests eval
+["GET /?user_key=1","GET /?user_key=2"]
+--- more_headers eval
+["Host: one", "Host: two"]
+--- response_body eval
+["yay, api backend\n", ""]
+--- error_code eval
+[200, 404]
+
+=== TEST 2: multi service configuration limited with Regexp Filter with paginated service list
+This test is configured to provide 3 pages of services. On each page, there is one service "one-*"
+which is valid according to the filter by url. The test will do one request to each valid service.
+--- env eval
+(
+  'APICAST_SERVICES_FILTER_BY_URL' => "^one*",
+  'APICAST_CONFIGURATION_LOADER' => 'lazy',
+  'THREESCALE_PORTAL_ENDPOINT' => "http://test:$ENV{TEST_NGINX_SERVER_PORT}"
+)
+--- upstream env
+location = /admin/api/services.json {
+  content_by_lua_block {
+    local args = ngx.req.get_uri_args(0)
+    local page = 1
+    if args.page then
+      page = tonumber(args.page)
+    end
+    local per_page = 500
+    if args.per_page then
+      per_page = tonumber(args.per_page)
+    end
+
+    local services_per_page = {}
+    for i = (page - 1)*per_page + 1,math.min(page*per_page, 1256)
+    do
+      table.insert(services_per_page, {service = { id = i }})
+    end
+
+    require('luassert').True(#services_per_page <= per_page)
+
+    local response = { services = services_per_page }
+    ngx.header.content_type = 'application/json;charset=utf-8'
+    ngx.say(require('cjson').encode(response))
+  }
+}
+
+location ~ /admin/api/services/\d+/proxy/configs/production/latest.json {
+  content_by_lua_block {
+    local proxy_config = {
+      content = { id = 1, backend_version = 1,
+        proxy = {
+          hosts = { 'two' },
+          api_backend = 'http://test:$TEST_NGINX_SERVER_PORT/api/',
+          backend = { endpoint = 'http://test:$TEST_NGINX_SERVER_PORT' },
+          proxy_rules = { { pattern = '/', http_method = 'GET', metric_system_name = 'test', delta = 1 } }
+        }
+      }
+    }
+
+    if( ngx.var.uri == '/admin/api/services/1/proxy/configs/production/latest.json' )
+    then
+      proxy_config.content.id = 1
+      proxy_config.content.proxy.hosts = { 'one-1' }
+    elseif( ngx.var.uri == '/admin/api/services/500/proxy/configs/production/latest.json'  )
+    then
+      proxy_config.content.id = 500
+      proxy_config.content.proxy.hosts = { 'one-500' }
+    elseif( ngx.var.uri == '/admin/api/services/1000/proxy/configs/production/latest.json'  )
+    then
+      proxy_config.content.id = 1000
+      proxy_config.content.proxy.hosts = { 'one-1000' }
+    end
+
+    local response = { proxy_config = proxy_config }
+    ngx.header.content_type = 'application/json;charset=utf-8'
+    ngx.say(require('cjson').encode(response))
+  }
+}
+
+location /api/ {
+  echo 'yay, api backend';
+}
+
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block { ngx.exit(200) }
+}
+
+--- pipelined_requests eval
+["GET /?user_key=1","GET /?user_key=1","GET /?user_key=1","GET /?user_key=2"]
+--- more_headers eval
+["Host: one-1","Host: one-500","Host: one-1000","Host: two"]
+--- response_body eval
+["yay, api backend\n","yay, api backend\n","yay, api backend\n",""]
+--- error_code eval
+[200, 200, 200, 404]

--- a/t/configuration-loading-filter-services-by-url.t
+++ b/t/configuration-loading-filter-services-by-url.t
@@ -115,6 +115,7 @@ location /api/ {
   echo 'yay, api backend';
 }
 
+--- timeout: 25s
 --- backend
 location /transactions/authrep.xml {
   content_by_lua_block { ngx.exit(200) }

--- a/t/configuration-loading-from-service-list.t
+++ b/t/configuration-loading-from-service-list.t
@@ -3,6 +3,7 @@ use Test::APIcast::Blackbox 'no_plan';
 our $private_key = `cat t/fixtures/rsa.pem`;
 our $public_key = `cat t/fixtures/rsa.pub`;
 
+repeat_each(1);
 run_tests();
 
 __DATA__
@@ -58,60 +59,7 @@ __DATA__
 --- error_code eval
 [200, 404]
 
-
-
-=== TEST 2: multi service configuration limited with Regexp Filter
---- env eval
-("APICAST_SERVICES_FILTER_BY_URL", "^on*")
---- configuration
-{
-  "services": [
-    {
-      "backend_version": 1,
-      "proxy": {
-        "hosts": [
-          "one"
-        ],
-        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
-        "proxy_rules": [
-          {
-            "http_method": "GET",
-            "delta": 1,
-            "metric_system_name": "one",
-            "pattern": "/"
-          }
-        ]
-      },
-      "id": 42
-    },
-    {
-      "proxy": {
-        "hosts": [
-          "two"
-        ]
-      },
-      "id": 11
-    }
-  ]
-}
---- backend
-  location /transactions/authrep.xml {
-    content_by_lua_block { ngx.exit(200) }
-  }
---- upstream
-  location ~ / {
-     echo 'yay, api backend';
-  }
---- pipelined_requests eval
-["GET /?user_key=1","GET /?user_key=2"]
---- more_headers eval
-["Host: one", "Host: two"]
---- response_body eval
-["yay, api backend\n", ""]
---- error_code eval
-[200, 404]
-
-=== TEST 3: multi service configuration limited with Regexp Filter and service list
+=== TEST 2: multi service configuration limited with Regexp Filter and service list
 --- env eval
 (
 "APICAST_SERVICES_FILTER_BY_URL", "^on*",
@@ -189,7 +137,7 @@ __DATA__
 [200, 200, 404]
 
 
-=== TEST 4: Verify that OIDC is working when filter services.
+=== TEST 3: Verify that OIDC is working when filter services.
 Related to issues THREESCALE-6042
 --- env eval
 (
@@ -281,3 +229,96 @@ my $jwt = encode_jwt(payload => {
 "Authorization: Bearer $jwt\r\nHost: one";
 --- no_error_log
 [error]
+
+=== TEST 4: load a config where only some of the services have an OIDC configuration
+This is a regression test. APIcast crashed when loading a config where only
+some of the services used OIDC.
+The reason is that we created an array of OIDC configs with
+size=number_of_services. Let's say we have 100 services and only the 50th has an
+OIDC config. In this case, we created this Lua table:
+{ [50] = oidc_config_here }.
+The problem is that cjson raises an error when trying to convert a sparse array
+like that into JSON. Using the default cjson configuration, the minimum number
+of elements to reproduce the error is 11. So in this test, we create 11 services
+and assign an OIDC config only to the last one. Check
+https://www.kyne.com.au/~mark/software/lua-cjson-manual.html#encode_sparse_array
+for more details.
+Now we assign to _false_ the elements of the array that do not have an OIDC
+config, so this test should not crash.
+--- env eval
+(
+  'THREESCALE_DEPLOYMENT_ENV' => 'production',
+  'APICAST_CONFIGURATION_LOADER' => 'lazy',
+  'APICAST_SERVICES_LIST' => '1,2,3,4,5,6,7,8,9,10,11',
+  'THREESCALE_PORTAL_ENDPOINT' => "http://test:$ENV{TEST_NGINX_SERVER_PORT}"
+)
+--- upstream env
+location ~ /admin/api/services/([0-9]|10)/proxy/configs/production/latest.json {
+echo '
+{
+  "proxy_config": {
+    "content": {
+      "id": 1,
+      "backend_version": 1,
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api/",
+        "backend": {
+          "endpoint": "http://test:$TEST_NGINX_SERVER_PORT"
+        },
+        "proxy_rules": [
+          {
+            "pattern": "/",
+            "http_method": "GET",
+            "metric_system_name": "test",
+            "delta": 1
+          }
+        ]
+      }
+    }
+  }
+}
+';
+}
+
+location = /admin/api/services/11/proxy/configs/production/latest.json {
+echo '{ "proxy_config": { "content": { "proxy": { "oidc_issuer_endpoint": "http://test:$TEST_NGINX_SERVER_PORT/issuer/endpoint" } } } }';
+}
+
+location = /issuer/endpoint/.well-known/openid-configuration {
+  content_by_lua_block {
+    local base = "http://" .. ngx.var.host .. ':' .. ngx.var.server_port
+    ngx.header.content_type = 'application/json;charset=utf-8'
+    ngx.say(require('cjson').encode {
+        issuer = 'https://example.com/auth/realms/apicast',
+        id_token_signing_alg_values_supported = { 'RS256' },
+        jwks_uri = base .. '/jwks',
+    })
+  }
+}
+
+location = /jwks {
+  content_by_lua_block {
+    ngx.header.content_type = 'application/json;charset=utf-8'
+    ngx.say([[
+        { "keys": [
+            { "kty":"RSA","kid":"somekid",
+              "n":"sKXP3pwND3rkQ1gx9nMb4By7bmWnHYo2kAAsFD5xq0IDn26zv64tjmuNBHpI6BmkLPk8mIo0B1E8MkxdKZeozQ","e":"AQAB" }
+        ] }
+    ]])
+  }
+}
+
+location /api/ {
+  echo 'yay, api backend';
+}
+
+--- backend
+location /transactions/authrep.xml {
+content_by_lua_block { ngx.exit(200) }
+}
+
+--- request
+GET /?user_key=uk
+--- error_code: 200
+--- response_body
+yay, api backend

--- a/t/configuration-loading-from-service-list.t
+++ b/t/configuration-loading-from-service-list.t
@@ -230,7 +230,7 @@ my $jwt = encode_jwt(payload => {
 --- no_error_log
 [error]
 
-=== TEST 4: servide list filter with paginated proxy config list
+=== TEST 4: service list filter with paginated proxy config list
 This test is configured to provide 3 pages of proxy configs. On each page, there is only one service
 which is valid according to the filter by service list. The test will do one request to each valid service.
 --- env eval
@@ -287,6 +287,7 @@ location /api/ {
   echo 'yay, api backend';
 }
 
+--- timeout: 25s
 --- backend
 location /transactions/authrep.xml {
   content_by_lua_block { ngx.exit(200) }

--- a/t/configuration-loading-lazy.t
+++ b/t/configuration-loading-lazy.t
@@ -216,6 +216,7 @@ location /api/ {
   echo 'yay, api backend';
 }
 
+--- timeout: 25s
 --- backend
 location /transactions/authrep.xml {
   content_by_lua_block { ngx.exit(200) }

--- a/t/configuration-loading-lazy.t
+++ b/t/configuration-loading-lazy.t
@@ -15,8 +15,8 @@ should just say service is not found
 --- upstream
 location /admin/api/account/proxy_configs/production.json {
   content_by_lua_block {
-    expected = "host=localhost&version=latest"
-    require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    local expected = { host = 'localhost', version = 'latest', page = '1', per_page = '500' }
+    require('luassert').same(expected, ngx.req.get_uri_args(0))
 
     ngx.say(require('cjson').encode({}))
   }
@@ -54,8 +54,8 @@ should correctly route the request
 --- upstream env
 location = /admin/api/account/proxy_configs/production.json {
   content_by_lua_block {
-    expected = "host=localhost&version=latest"
-    require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    local expected = { host = 'localhost', version = 'latest', page = '1', per_page = '500' }
+    require('luassert').same(expected, ngx.req.get_uri_args(0))
 
     local response = {
       proxy_configs = {
@@ -160,3 +160,72 @@ OIDC url is not valid, uri:
 --- no_error_log
 [error]
 
+=== TEST 6: Load paginated proxy config list
+This test is configured to provide 3 pages of proxy configs.
+The test will try requests with hostnames existing a different pages
+--- env eval
+(
+  'APICAST_CONFIGURATION_LOADER' => 'lazy',
+  'APICAST_SERVICE_CACHE_SIZE' => '2000',
+  'THREESCALE_PORTAL_ENDPOINT' => "http://test:$ENV{TEST_NGINX_SERVER_PORT}"
+)
+--- upstream env
+location /admin/api/account/proxy_configs/production.json {
+  content_by_lua_block {
+    local args = ngx.req.get_uri_args(0)
+    local page = 1
+    if args.page then
+      page = tonumber(args.page)
+    end
+    local per_page = 500
+    if args.per_page then
+      per_page = tonumber(args.per_page)
+    end
+
+    -- this test is designed for pages of 500 items
+    require('luassert').equals(500, per_page)
+    require('luassert').is_true(1 <= page and page < 4)
+
+    local function build_proxy_config(service_id, host)
+      return { proxy_config = {
+        content = { id = service_id, backend_version = 1,
+          proxy = {
+            hosts = { host },
+            api_backend = 'http://test:$TEST_NGINX_SERVER_PORT/api/',
+            backend = { endpoint = 'http://test:$TEST_NGINX_SERVER_PORT' },
+            proxy_rules = { { pattern = '/', http_method = 'GET', metric_system_name = 'test', delta = 1 } }
+          }
+        }
+      }}
+    end
+
+    local configs_per_page = {}
+
+    for i = (page - 1)*per_page + 1,math.min(page*per_page, 1256)
+    do
+      table.insert(configs_per_page, build_proxy_config(i, 'one-'..tostring(i)))
+    end
+
+    local response = { proxy_configs = configs_per_page }
+    ngx.header.content_type = 'application/json;charset=utf-8'
+    ngx.say(require('cjson').encode(response))
+  }
+}
+
+location /api/ {
+  echo 'yay, api backend';
+}
+
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block { ngx.exit(200) }
+}
+
+--- pipelined_requests eval
+["GET /?user_key=1","GET /?user_key=1","GET /?user_key=1"]
+--- more_headers eval
+["Host: one-1","Host: one-501","Host: one-1001"]
+--- response_body eval
+["yay, api backend\n","yay, api backend\n","yay, api backend\n"]
+--- error_code eval
+[200, 200, 200]

--- a/t/configuration-loading-with-oidc.t
+++ b/t/configuration-loading-with-oidc.t
@@ -29,8 +29,8 @@ config, so this test should not crash.
 --- upstream env
 location = /admin/api/account/proxy_configs/production.json {
   content_by_lua_block {
-    expected = "host=localhost&version=latest"
-    require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    local expected = { host = 'localhost', version = 'latest', page = '1', per_page = '500' }
+    require('luassert').same(expected, ngx.req.get_uri_args(0))
 
     local proxy_configs_list = {}
     for i = 1,10,1
@@ -40,6 +40,7 @@ location = /admin/api/account/proxy_configs/production.json {
           content = {
             id = i, backend_version =  1,
             proxy = {
+              hosts = { "localhost" },
               api_backend = 'http://test:$TEST_NGINX_SERVER_PORT/api/',
               backend = { endpoint = 'http://test:$TEST_NGINX_SERVER_PORT' },
               proxy_rules = { { pattern = '/', http_method = 'GET', metric_system_name = 'test', delta = 1 } }

--- a/t/configuration-loading-with-service-version.t
+++ b/t/configuration-loading-with-service-version.t
@@ -1,0 +1,145 @@
+use Test::APIcast::Blackbox 'no_plan';
+
+repeat_each(1);
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: load configuration with APICAST_SERVICE_${ID}_CONFIGURATION_VERSION
+--- env eval
+(
+  'APICAST_CONFIGURATION_LOADER' => 'lazy',
+  'THREESCALE_PORTAL_ENDPOINT' => "http://test:$ENV{TEST_NGINX_SERVER_PORT}",
+  'APICAST_SERVICE_2_CONFIGURATION_VERSION' => 42
+)
+--- upstream env
+    location = /admin/api/services.json {
+        echo '{ "services": [ { "service": { "id": 2 } } ] }';
+    }
+    location = /admin/api/services/2/proxy/configs/production/42.json {
+        echo '
+        {
+            "proxy_config": {
+                "content": {
+                    "id": 2,
+                    "backend_version": 1,
+                    "proxy": {
+                        "hosts": [ "localhost" ],
+                        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+                        "proxy_rules": [
+                            { "pattern": "/t", "http_method": "GET", "metric_system_name": "test","delta": 1 }
+                        ]
+                    }
+                }
+            }
+        }';
+    }
+
+    location /t {
+        echo "all ok";
+    }
+
+--- backend
+    location /transactions/authrep.xml {
+      content_by_lua_block {
+        ngx.exit(200)
+      }
+    }
+--- request
+GET /t?user_key=fake
+--- error_code: 200
+--- error_log
+using lazy configuration loader
+--- no_error_log
+[error]
+
+=== TEST 2: load configuration with APICAST_SERVICE_${ID}_CONFIGURATION_VERSION with paginated service list
+and paginated service list. This test is configured to provide 3 pages of services.
+On each page, there is one service for which the version will be overriden.
+The test will do one request to each valid service.
+--- env eval
+(
+  'APICAST_SERVICE_1_CONFIGURATION_VERSION' => 42,
+  'APICAST_SERVICE_500_CONFIGURATION_VERSION' => 42,
+  'APICAST_SERVICE_1000_CONFIGURATION_VERSION' => 42,
+  'APICAST_CONFIGURATION_LOADER' => 'lazy',
+  'THREESCALE_PORTAL_ENDPOINT' => "http://test:$ENV{TEST_NGINX_SERVER_PORT}"
+)
+--- upstream env
+location = /admin/api/services.json {
+  content_by_lua_block {
+    local args = ngx.req.get_uri_args(0)
+    local page = 1
+    if args.page then
+      page = tonumber(args.page)
+    end
+    local per_page = 500
+    if args.per_page then
+      per_page = tonumber(args.per_page)
+    end
+
+    local services_per_page = {}
+    for i = (page - 1)*per_page + 1,math.min(page*per_page, 1256)
+    do
+      table.insert(services_per_page, {service = { id = i }})
+    end
+
+    require('luassert').True(#services_per_page <= per_page)
+
+    local response = { services = services_per_page }
+    ngx.header.content_type = 'application/json;charset=utf-8'
+    ngx.say(require('cjson').encode(response))
+  }
+}
+
+location ~ /admin/api/services/\d+/proxy/configs/production/.*.json {
+  content_by_lua_block {
+    local proxy_config = {
+      content = { id = 1, backend_version = 1,
+        proxy = {
+          hosts = { 'other' },
+          api_backend = 'http://test:$TEST_NGINX_SERVER_PORT/api/',
+          backend = { endpoint = 'http://test:$TEST_NGINX_SERVER_PORT' },
+          proxy_rules = { { pattern = '/', http_method = 'GET', metric_system_name = 'test', delta = 1 } }
+        }
+      }
+    }
+
+    if( ngx.var.uri == '/admin/api/services/1/proxy/configs/production/42.json' )
+    then
+      proxy_config.content.id = 1
+      proxy_config.content.proxy.hosts = { 'one-1' }
+    elseif( ngx.var.uri == '/admin/api/services/500/proxy/configs/production/42.json'  )
+    then
+      proxy_config.content.id = 500
+      proxy_config.content.proxy.hosts = { 'one-500' }
+    elseif( ngx.var.uri == '/admin/api/services/1000/proxy/configs/production/42.json'  )
+    then
+      proxy_config.content.id = 1000
+      proxy_config.content.proxy.hosts = { 'one-1000' }
+    end
+
+    local response = { proxy_config = proxy_config }
+    ngx.header.content_type = 'application/json;charset=utf-8'
+    ngx.say(require('cjson').encode(response))
+  }
+}
+
+location /api/ {
+  echo 'yay, api backend';
+}
+
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block { ngx.exit(200) }
+}
+
+--- pipelined_requests eval
+["GET /?user_key=1","GET /?user_key=1","GET /?user_key=1","GET /?user_key=2"]
+--- more_headers eval
+["Host: one-1","Host: one-500","Host: one-1000","Host: two"]
+--- response_body eval
+["yay, api backend\n","yay, api backend\n","yay, api backend\n",""]
+--- error_code eval
+[200, 200, 200, 404]

--- a/t/configuration-loading-with-service-version.t
+++ b/t/configuration-loading-with-service-version.t
@@ -79,6 +79,10 @@ location = /admin/api/services.json {
       per_page = tonumber(args.per_page)
     end
 
+    -- this test is designed for pages of 500 items
+    require('luassert').equals(500, per_page)
+    require('luassert').is_true(1 <= page and page < 4)
+
     local services_per_page = {}
     for i = (page - 1)*per_page + 1,math.min(page*per_page, 1256)
     do
@@ -112,12 +116,12 @@ location ~ /admin/api/services/\d+/proxy/configs/production/.*.json {
       proxy_config.content.proxy.hosts = { 'one-1' }
     elseif( ngx.var.uri == '/admin/api/services/500/proxy/configs/production/42.json'  )
     then
-      proxy_config.content.id = 500
-      proxy_config.content.proxy.hosts = { 'one-500' }
+      proxy_config.content.id = 501
+      proxy_config.content.proxy.hosts = { 'one-501' }
     elseif( ngx.var.uri == '/admin/api/services/1000/proxy/configs/production/42.json'  )
     then
-      proxy_config.content.id = 1000
-      proxy_config.content.proxy.hosts = { 'one-1000' }
+      proxy_config.content.id = 1001
+      proxy_config.content.proxy.hosts = { 'one-1001' }
     end
 
     local response = { proxy_config = proxy_config }
@@ -138,8 +142,103 @@ location /transactions/authrep.xml {
 --- pipelined_requests eval
 ["GET /?user_key=1","GET /?user_key=1","GET /?user_key=1","GET /?user_key=2"]
 --- more_headers eval
-["Host: one-1","Host: one-500","Host: one-1000","Host: two"]
+["Host: one-1","Host: one-501","Host: one-1001","Host: two"]
 --- response_body eval
 ["yay, api backend\n","yay, api backend\n","yay, api backend\n",""]
 --- error_code eval
 [200, 200, 200, 404]
+
+=== TEST 3: load a config where only some of the services have an OIDC configuration
+This is a regression test. APIcast crashed when loading a config where only
+some of the services used OIDC.
+The reason is that we created an array of OIDC configs with
+size=number_of_services. Let's say we have 100 services and only the 50th has an
+OIDC config. In this case, we created this Lua table:
+{ [50] = oidc_config_here }.
+The problem is that cjson raises an error when trying to convert a sparse array
+like that into JSON. Using the default cjson configuration, the minimum number
+of elements to reproduce the error is 11. So in this test, we create 11 services
+and assign an OIDC config only to the last one. Check
+https://www.kyne.com.au/~mark/software/lua-cjson-manual.html#encode_sparse_array
+for more details.
+Now we assign to _false_ the elements of the array that do not have an OIDC
+config, so this test should not crash.
+--- env eval
+(
+  'THREESCALE_DEPLOYMENT_ENV' => 'production',
+  'APICAST_CONFIGURATION_LOADER' => 'lazy',
+  'APICAST_SERVICE_11_CONFIGURATION_VERSION' => 42,
+  'THREESCALE_PORTAL_ENDPOINT' => "http://test:$ENV{TEST_NGINX_SERVER_PORT}"
+)
+--- upstream env
+location = /admin/api/services.json {
+    echo '
+    {
+      "services":[
+        { "service": { "id":1 } }, { "service": { "id":2 } }, { "service": { "id":3 } },
+        { "service": { "id":4 } }, { "service": { "id":5 } }, { "service": { "id":6 } },
+        { "service": { "id":7 } }, { "service": { "id":8 } }, { "service": { "id":9 } },
+        { "service": { "id":10 } }, { "service": { "id":11 } }
+      ]
+    }';
+}
+
+location ~ /admin/api/services/([0-9]|10)/proxy/configs/production/latest.json {
+echo '
+{
+  "proxy_config": {
+    "content": { "id": 1, "backend_version": 1, "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/api/",
+        "backend": { "endpoint": "http://test:$TEST_NGINX_SERVER_PORT" },
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "test", "delta": 1 }
+        ]
+      }
+    }
+  }
+}
+';
+}
+
+location = /admin/api/services/11/proxy/configs/production/42.json {
+echo '{ "proxy_config": { "content": { "proxy": { "oidc_issuer_endpoint": "http://test:$TEST_NGINX_SERVER_PORT/issuer/endpoint" } } } }';
+}
+
+location = /issuer/endpoint/.well-known/openid-configuration {
+  content_by_lua_block {
+    local base = "http://" .. ngx.var.host .. ':' .. ngx.var.server_port
+    ngx.header.content_type = 'application/json;charset=utf-8'
+    ngx.say(require('cjson').encode {
+        issuer = 'https://example.com/auth/realms/apicast',
+        id_token_signing_alg_values_supported = { 'RS256' },
+        jwks_uri = base .. '/jwks',
+    })
+  }
+}
+
+location = /jwks {
+  content_by_lua_block {
+    ngx.header.content_type = 'application/json;charset=utf-8'
+    ngx.say([[
+        { "keys": [
+            { "kty":"RSA","kid":"somekid",
+              "n":"sKXP3pwND3rkQ1gx9nMb4By7bmWnHYo2kAAsFD5xq0IDn26zv64tjmuNBHpI6BmkLPk8mIo0B1E8MkxdKZeozQ","e":"AQAB" }
+        ] }
+    ]])
+  }
+}
+
+location /api/ {
+  echo 'yay, api backend';
+}
+
+--- backend
+location /transactions/authrep.xml {
+content_by_lua_block { ngx.exit(200) }
+}
+
+--- request
+GET /?user_key=uk
+--- error_code: 200
+--- response_body
+yay, api backend

--- a/t/configuration-loading-with-service-version.t
+++ b/t/configuration-loading-with-service-version.t
@@ -139,6 +139,7 @@ location /transactions/authrep.xml {
   content_by_lua_block { ngx.exit(200) }
 }
 
+--- timeout: 60s
 --- pipelined_requests eval
 ["GET /?user_key=1","GET /?user_key=1","GET /?user_key=1","GET /?user_key=2"]
 --- more_headers eval

--- a/t/http-proxy.t
+++ b/t/http-proxy.t
@@ -91,8 +91,11 @@ content_by_lua_block {
 }
 
 --- error_code: 200
---- error_log env
-proxy request: GET http://test.lvh.me:$TEST_NGINX_SERVER_PORT/admin/api/account/proxy_configs/production.json?version=latest HTTP/1.1
+--- error_log env eval
+[
+qr/proxy request\: GET http\:\/\/test.lvh.me\:$TEST_NGINX_SERVER_PORT\/admin\/api\/account\/proxy_configs\/production.json\?.* HTTP\/1.1/
+]
+
 --- no_error_log
 [error]
 
@@ -490,7 +493,7 @@ ETag: foobar
 [[
     qr{GET \/test\?user_key=test3 HTTP\/1\.1},
     qr{ETag\: foobar},
-    qr{Connection\: close}, 
+    qr{Connection\: close},
     qr{User\-Agent\: Test\:\:APIcast\:\:Blackbox},
     qr{Host\: test-upstream.lvh.me\:\d+}
 ]]
@@ -647,7 +650,7 @@ ETag: foobar
 [[
     qr{GET \/test\?user_key=test3 HTTP\/1\.1},
     qr{ETag\: foobar},
-    qr{Connection\: close}, 
+    qr{Connection\: close},
     qr{User\-Agent\: Test\:\:APIcast\:\:Blackbox},
     qr{Host\: test-upstream\.lvh\.me\:\d+}
 ]]
@@ -757,7 +760,7 @@ User-Agent: Test::APIcast::Blackbox
 --- expected_response_body_like_multiple eval
 [[
     qr{POST \/test\?user_key=test3 HTTP\/1\.1},
-    qr{Connection\: close}, 
+    qr{Connection\: close},
     qr{User\-Agent\: Test\:\:APIcast\:\:Blackbox},
     qr{Host\: test-upstream\.lvh\.me\:\d+},
     qr{Content\-Length\: 25},
@@ -1001,7 +1004,7 @@ ETag: foobar
 [[
     qr{GET \/test HTTP\/1\.1},
     qr{ETag\: foobar},
-    qr{Connection\: close}, 
+    qr{Connection\: close},
     qr{User\-Agent\: Test\:\:APIcast\:\:Blackbox},
     qr{Host\: test-upstream\.lvh\.me\:\d+}
 ]]
@@ -1124,7 +1127,7 @@ ETag: foobar
 [[
     qr{GET \/somepath\/test\?user_key=test3 HTTP\/1\.1},
     qr{ETag\: foobar},
-    qr{Connection\: close}, 
+    qr{Connection\: close},
     qr{User\-Agent\: Test\:\:APIcast\:\:Blackbox},
     qr{Host\: test-upstream.lvh.me\:\d+}
 ]]
@@ -1136,7 +1139,7 @@ proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
 --- user_files fixture=tls.pl eval
 
 
-=== TEST 22: https upstream API connection routes to the upstream (host + path) 
+=== TEST 22: https upstream API connection routes to the upstream (host + path)
 + request path with routing policy also enabled
 --- env eval
 (
@@ -1214,7 +1217,7 @@ ETag: foobar
 [[
     qr{GET \/somepath\/foo\/bar\?user_key=test3 HTTP\/1\.1},
     qr{ETag\: foobar},
-    qr{Connection\: close}, 
+    qr{Connection\: close},
     qr{User\-Agent\: Test\:\:APIcast\:\:Blackbox},
     qr{Host\: test-upstream.lvh.me\:\d+}
 ]]


### PR DESCRIPTION
### what
Load all services and proxy configuration pages

Fixes https://issues.redhat.com/browse/THREESCALE-8373

### Verification steps

* Create more than 500 services in a tenant
* Deploy APIcast using `THREESCALE_PORTAL_ENDPOINT=https://<token>@<provider domain>`
* Send a request to one of last services created
* Observe 200 OK response (also observe APIcast logs indicate that first 500 services were loaded in a first request and the remaining services in a second request)



