### PR TITLE
THREESCALE-7942 fix apicast bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - `APICAST_LOAD_SERVICES_WHEN_NEEDED` is dropped and the configuration is fetched "when needed" by default [PR #1352](https://github.com/3scale/APIcast/pull/1352) [THREESCALE-8508](https://issues.redhat.com/browse/THREESCALE-8508)
 
+### Fixed
+
+- Removes the warning message at the bootstrap [PR #1398](https://github.com/3scale/APIcast/pull/1398) [THREESCALE-7942](https://issues.redhat.com/browse/THREESCALE-7942)
+
 ## [3.13.2] 2023-02-21
 
 ### Fixed

--- a/gateway/bin/apicast
+++ b/gateway/bin/apicast
@@ -96,7 +96,6 @@ for my $inc ($apicast_src, 'src') {
     }
 }
 
-my $apicast_cli_file = apicast_cli();
 my @args = ('resty', @resty_args, apicast_cli(), @ARGV);
 
 exec '/usr/bin/env', @args;

--- a/gateway/bin/apicast
+++ b/gateway/bin/apicast
@@ -14,7 +14,6 @@ sub detect_lua_version {
 
 my $apicast_dir = $ENV{APICAST_DIR} || abs_path(dirname(abs_path(__FILE__)) . '/..');
 
-
 sub detect_apicast_paths {
     my $lua_modules = abs_path(dirname(abs_path(__FILE__)) . '/..');
     my $command = basename(__FILE__);
@@ -68,22 +67,14 @@ if ($rover && !$lua_path) {
     $lua_lib ||= ';';
 }
 
-
-
 $ENV{APICAST_DIR} = $apicast_conf;
 $ENV{LUA_PATH} = sprintf('%1$s/?.lua;', $apicast_src) . $lua_path . "/usr/local/openresty/lualib/?.lua;";
 $ENV{LUA_CPATH} = sprintf('%1$s/?.so;', $apicast_lib) . $lua_lib;
 $ENV{PWD} = $cwd;
 $ENV{ARGV0} = $0;
 
-sub lua_file {
-    my ($lua, $lua_file) = tempfile();
-
-    print { $lua } <DATA>;
-    close DATA;
-    close $lua;
-
-    return $lua_file;
+sub apicast_cli {
+    return abs_path(dirname(abs_path(__FILE__)) . '/apicast_cli.lua');
 }
 
 my @resty_args = ();
@@ -104,70 +95,8 @@ for my $inc ($apicast_src, 'src') {
         push @resty_args, '-I', $inc;
     }
 }
-my @args = ('resty', @resty_args, lua_file(), @ARGV);
+
+my $apicast_cli_file = apicast_cli();
+my @args = ('resty', @resty_args, apicast_cli(), @ARGV);
 
 exec '/usr/bin/env', @args;
-
-# This Lua helper is going to be executed by resty to detect if lua-rover is available.
-# And if so then run setup and lock down load paths to what is defined in the Roverfile + openresty libraries.
-__DATA__
-#!/usr/bin/env resty
-local ok, setup = pcall(require, 'rover.setup')
-local re = require('ngx.re')
-
--- detect the full path to resty binary this has been started with
-local function resty(code)
-    local cmd
-    do
-        local i = 0
-
-        while not cmd do
-            if not arg[i-1] then cmd = arg[i] end
-            i = i - 1
-        end
-    end
-
-    if not cmd then return nil, 'could not find resty' end
-
-    local handle = io.popen(([[/usr/bin/env -i %q -e %q]]):format(cmd, code))
-    local result = handle:read("*l")
-
-    handle:close()
-
-    return result
-end
-
--- get the default package.path and strip out paths for shared code
-local function default_package_path()
-    local sep = ';'
-    local filtered = {}
-    local LUA_DEFAULT_PATH = resty('print(package.path)')
-    local contains = function(str, pattern) return str:find(pattern, 1, true) end
-    local paths = re.split(LUA_DEFAULT_PATH or '', sep, 'oj')
-
-    for i=1,#paths do
-        local path = paths[i]
-
-        if not contains(path, '/site/') and
-           not contains(path, '/share/') and
-           path:find('^/') then
-            table.insert(filtered, path)
-        end
-    end
-
-    return table.concat(filtered, sep)
-end
-
-if ok then
-    setup()
-    -- Use not only rover paths but also code shipped with OpenResty.
-    -- Rover sets it up to Roverfile defined dependencies only.
-    -- But APIcast needs to access libraries distributed with OpenResty.
-    package.path = package.path ..';' .. default_package_path()
-    -- Load APIcast and dependencies
-    require('apicast.executor')
-else
-    package.path = './src/?.lua;' .. package.path
-end
-
-require('apicast.cli')(arg)

--- a/gateway/bin/apicast_cli.lua
+++ b/gateway/bin/apicast_cli.lua
@@ -1,0 +1,47 @@
+#!/usr/bin/env resty
+-- This Lua helper is going to be executed by resty to detect if lua-rover is available.
+-- And if so then run setup and lock down load paths to what is defined in the Roverfile + openresty libraries.
+local ok, setup = pcall(require, 'rover.setup')
+local re = require('ngx.re')
+
+local function default_resty_path()
+    local handle = io.popen([[/usr/bin/env -i resty -e 'print(package.path)']])
+    local result = handle:read("*l")
+    handle:close()
+    return result
+end
+
+-- get the default package.path and strip out paths for shared code
+local function default_package_path()
+    local sep = ';'
+    local filtered = {}
+    local LUA_DEFAULT_PATH = default_resty_path()
+    local contains = function(str, pattern) return str:find(pattern, 1, true) end
+    local paths = re.split(LUA_DEFAULT_PATH or '', sep, 'oj')
+
+    for i=1,#paths do
+        local path = paths[i]
+
+        if not contains(path, '/site/') and
+           not contains(path, '/share/') and
+           path:find('^/') then
+            table.insert(filtered, path)
+        end
+    end
+
+    return table.concat(filtered, sep)
+end
+
+if ok then
+    setup()
+    -- Use not only rover paths but also code shipped with OpenResty.
+    -- Rover sets it up to Roverfile defined dependencies only.
+    -- But APIcast needs to access libraries distributed with OpenResty.
+    package.path = package.path ..';' .. default_package_path()
+    -- Load APIcast and dependencies
+    require('apicast.executor')
+else
+    package.path = './src/?.lua;' .. package.path
+end
+
+require('apicast.cli')(arg)


### PR DESCRIPTION
### what

removes the warning message at the start of APIcast POD
like this one:
```
env: '/tmp/FXal6CekIq': Permission denied
```

### verification steps

* start development mode
```
make development
make dependencies
```
* Run APIcast
```
$ cat <<EOF >config.json
{
   "services": [
      {
         "proxy": {
             "hosts": ["one"],
             "proxy_rules": [],
             "api_backend": "https://echo-api.3scale.net",
             "policy_chain": []
         }
      }
   ]
}
EOF

APICAST_LOG_LEVEL=warn APICAST_WORKERS=1 THREESCALE_CONFIG_FILE=config.json BACKEND_ENDPOINT_OVERRIDE=http://localhost:8081 ./bin/apicast
```

* Check the error `env: '/tmp/FXal6CekIq': Permission denied` does not exist