### PR TITLE
Fix Transfer-Encoding header not removed for buffered requests

### DIFF
--- a/gateway/src/apicast/http_proxy.lua
+++ b/gateway/src/apicast/http_proxy.lua
@@ -118,6 +118,11 @@ local function forward_https_request(proxy_uri, uri, skip_https_connect)
         end
     end
 
+    -- The whole request is buffered in the memory so remove the Transfer-Encoding: chunked
+    if request.headers["Transfer-Encoding"] == "chunked" then
+        request.headers["Transfer-Encoding"] = nil
+    end
+
     local httpc, err = http_proxy.new(request, skip_https_connect)
 
     if not httpc then

--- a/t/http-proxy.t
+++ b/t/http-proxy.t
@@ -661,7 +661,7 @@ proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
 [error]
 --- user_files fixture=tls.pl eval
 
-=== TEST 13: Upstream Policy connection uses proxy
+=== TEST 13: Upstream Policy connection uses proxy with POST
 --- env eval
 ("http_proxy" => $ENV{TEST_NGINX_HTTP_PROXY})
 --- configuration
@@ -1221,6 +1221,359 @@ ETag: foobar
     qr{User\-Agent\: Test\:\:APIcast\:\:Blackbox},
     qr{Host\: test-upstream.lvh.me\:\d+}
 ]]
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- no_error_log
+[error]
+--- user_files fixture=tls.pl eval
+
+
+=== TEST 23: Upstream API with HTTP POST chunked request, HTTP_PROXY and HTTP api_backend
+--- env eval
+(
+    "http_proxy" => $ENV{TEST_NGINX_HTTP_PROXY},
+    'BACKEND_ENDPOINT_OVERRIDE' => "http://test_backend.lvh.me:$ENV{TEST_NGINX_SERVER_PORT}"
+)
+--- configuration
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT",
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+server_name test_backend.lvh.me;
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+server_name test-upstream.lvh.me;
+  location /test {
+    access_by_lua_block {
+        assert = require('luassert')
+        local content_length = ngx.req.get_headers()["Content-Length"]
+        local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+        assert.equal('12', content_length)
+        assert.falsy(encoding)
+    }
+    echo_read_request_body;
+    echo $request_body;
+  }
+--- raw_request eval
+"POST /test?user_key=value HTTP/1.1\r
+Host: localhost\r
+Connection: close\r
+Transfer-Encoding: chunked\r
+\r
+5\r
+hello\r
+1\r
+,\r
+1\r
+ \r
+5\r
+world\r
+0\r
+\r
+"
+--- response_body
+hello, world
+--- error_code: 200
+--- error_log env
+proxy request: POST http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/test?user_key=value HTTP/1.1
+--- no_error_log
+[error]
+
+
+=== TEST 24: Upstream API with HTTPS POST chunked request, HTTPS_PROXY and HTTPS api_backend
+--- env random_port eval
+(
+  'https_proxy' => $ENV{TEST_NGINX_HTTPS_PROXY},
+  'BACKEND_ENDPOINT_OVERRIDE' => "https://test-backend.lvh.me:$ENV{TEST_NGINX_RANDOM_PORT}"
+)
+--- configuration random_port env
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT",
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend env
+  server_name test-backend.lvh.me;
+  listen $TEST_NGINX_RANDOM_PORT ssl;
+  ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+  ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream env
+server_name test-upstream.lvh.me;
+listen $TEST_NGINX_RANDOM_PORT ssl;
+
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+location /test {
+    access_by_lua_block {
+      assert = require('luassert')
+      local content_length = ngx.req.get_headers()["Content-Length"]
+      local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+      assert.equal('12', content_length)
+      assert.falsy(encoding)
+    }
+    echo_read_request_body;
+    echo $request_body;
+}
+--- raw_request eval
+"POST https://localhost/test?user_key=test3 HTTP/1.1\r
+Host: localhost\r
+Connection: close\r
+Transfer-Encoding: chunked\r
+\r
+5\r
+hello\r
+1\r
+,\r
+1\r
+ \r
+5\r
+world\r
+0\r
+\r
+"
+--- response_body
+hello, world
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- no_error_log
+[error]
+--- user_files fixture=tls.pl eval
+
+
+=== TEST 25: Upstream Policy connection uses proxy with POST chunked request
+--- env random_port eval
+("http_proxy" => $ENV{TEST_NGINX_HTTP_PROXY})
+--- configuration
+{
+  "services": [
+    {
+      "proxy": {
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/test", "url": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+server_name test-upstream.lvh.me;
+  location /test {
+    access_by_lua_block {
+      assert = require('luassert')
+      local content_length = ngx.req.get_headers()["Content-Length"]
+      local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+      assert.equal('12', content_length)
+      assert.falsy(encoding)
+    }
+    echo_read_request_body;
+    echo $request_body;
+  }
+--- raw_request eval
+"POST https://localhost/test?user_key=value HTTP/1.1\r
+Host: localhost\r
+Connection: close\r
+Transfer-Encoding: chunked\r
+\r
+5\r
+hello\r
+1\r
+,\r
+1\r
+ \r
+5\r
+world\r
+0\r
+\r
+"
+--- response_body
+hello, world
+--- error_code: 200
+--- error_log env
+proxy request: POST http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/test?user_key=value HTTP/1.1
+--- no_error_log
+[error]
+
+
+=== TEST 26: Upstream Policy connection uses proxy for https with POST chunked request
+--- env eval
+("https_proxy" => $ENV{TEST_NGINX_HTTPS_PROXY})
+--- configuration random_port env
+{
+  "services": [
+    {
+      "proxy": {
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/test", "url": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream env
+server_name test-upstream.lvh.me;
+listen $TEST_NGINX_RANDOM_PORT ssl;
+
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+location /test {
+    access_by_lua_block {
+      assert = require('luassert')
+      local content_length = ngx.req.get_headers()["Content-Length"]
+      local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+      assert.equal('12', content_length)
+      assert.falsy(encoding)
+    }
+    echo_read_request_body;
+    echo $request_body;
+}
+--- raw_request eval
+"POST https://localhost/test?user_key=value HTTP/1.1\r
+Host: localhost\r
+Connection: close\r
+Transfer-Encoding: chunked\r
+\r
+5\r
+hello\r
+1\r
+,\r
+1\r
+ \r
+5\r
+world\r
+0\r
+\r
+"
+--- response_body
+hello, world
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- no_error_log
+[error]
+--- user_files fixture=tls.pl eval
+
+
+=== TEST 27: Upstream policy with HTTPS POST request, HTTPS_PROXY and HTTPS backend
+--- env random_port eval
+(
+  'https_proxy' => $ENV{TEST_NGINX_HTTPS_PROXY},
+  'BACKEND_ENDPOINT_OVERRIDE' => "https://test-backend.lvh.me:$ENV{TEST_NGINX_RANDOM_PORT}"
+)
+--- configuration random_port env
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT",
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/test", "url": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT" } ]
+              }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend env
+  server_name test-backend.lvh.me;
+  listen $TEST_NGINX_RANDOM_PORT ssl;
+  ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+  ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream env
+server_name test-upstream.lvh.me;
+listen $TEST_NGINX_RANDOM_PORT ssl;
+
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+location /test {
+    access_by_lua_block {
+      assert = require('luassert')
+      local content_length = ngx.req.get_headers()["Content-Length"]
+      local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+      assert.equal('12', content_length)
+      assert.falsy(encoding)
+    }
+    echo_read_request_body;
+    echo $request_body;
+}
+--- raw_request eval
+"POST https://localhost/test?user_key=value HTTP/1.1\r
+Host: localhost\r
+Connection: close\r
+Transfer-Encoding: chunked\r
+\r
+5\r
+hello\r
+1\r
+,\r
+1\r
+ \r
+5\r
+world\r
+0\r
+\r
+"
+--- response_body
+hello, world
 --- error_code: 200
 --- error_log env
 proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1


### PR DESCRIPTION
What

by default, APICast buffers the entire request before sending it upstream, however, if proxies are involved and the request is sent with a "Transfer-Encoding: chunked" header, the API will forward the request with the full buffered request body and "Transfer-Encoding: chunked" header and thus upset the upstream server.

This PR fixes https://issues.redhat.com/browse/THREESCALE-9542 by removing the "Transfer-Encoding: chunked". 
