### PR TITLE
[THREESCALE-9542] Part 2: Add support to proxy request with Transfer-Encoding: chunked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed CVE-2023-44487 (HTTP/2 Rapid Reset) [PR #1417](https://github.com/3scale/apicast/pull/1417) [THREESCALE-10224](https://issues.redhat.com/browse/THREESCALE-10224)
 
+- Fixed issue where the proxy policy could not handle requests with "Transfer-Encoding: chunked" header [PR #1403](https://github.com/3scale/APIcast/pull/1403) [THREESCALE-9542](https://issues.redhat.com/browse/THREESCALE-9542)
+
 ### Added
 
 - Detect number of CPU shares when running on Cgroups V2 [PR #1410](https://github.com/3scale/apicast/pull/1410) [THREESCALE-10167](https://issues.redhat.com/browse/THREESCALE-10167)

--- a/gateway/src/apicast/http_proxy.lua
+++ b/gateway/src/apicast/http_proxy.lua
@@ -170,7 +170,7 @@ local function forward_https_request(proxy_uri, uri, proxy_opts)
                 -- set by openresty based on the size of the buffer. However, when the body is rendered
                 -- to a file, we will need to calculate and manually set the Content-Length header based
                 -- on the file size
-                local contentLength, err = file_size(temp_file_path)
+                local contentLength, err = file_size(temp_file_path)()
                 if err then
                     ngx.log(ngx.ERR, "HTTPS proxy: Failed to set content length, err: ", err)
                     ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)

--- a/gateway/src/apicast/policy/request_unbuffered/README.md
+++ b/gateway/src/apicast/policy/request_unbuffered/README.md
@@ -12,3 +12,8 @@ This policy allows to disable request buffering
 }
 ```
 
+## Caveats
+
+- Because APIcast allows defining mapping rules based on request content, POST requests with
+  `Content-type: application/x-www-form-urlencoded` will always be buffered regardless of the
+  `request_unbuffered` policy is enabled or not.

--- a/gateway/src/apicast/policy/request_unbuffered/README.md
+++ b/gateway/src/apicast/policy/request_unbuffered/README.md
@@ -5,15 +5,13 @@
 When enable this policy will dymanically sets the [`proxy_request_buffering: off`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_request_buffering
 ) directive per service.
 
-
 ## Technical details
 
-By default, NGINX reads the entire request body into memory (or buffers large requests into disk) before proxying it to the upstream server. However, reading bodies can become expensive, especially when requests with large payloads are sent.
+By default, NGINX reads the entire request body into memory or buffers large requests to disk before forwarding them to the upstream server. Reading bodies can become expensive, especially when sending requests containing large payloads.
 
-For example, when the client sends 10GB, NGINX will buffer the entire 10GB to disk before sending anything to
-the upstream server.
+For example, when the client sends 10GB, NGINX will buffer the entire 10GB to disk before sending anything to the upstream server.
 
-When `proxy_request_buffering` is in the chain, request buffering will be disabled and the request body will be sent to the proxied server immediately as it received. This can help minimize time spent sending data to a service and disk I/O for requests with big body. However, there are caveats and corner cases applied, [**Caveats**](#caveats)
+When the `request_unbuffered` is in the chain, request buffering is disabled, sending the request body to the proxied server immediately upon receiving it. This can help minimize time spent sending data to a service and disk I/O for requests with big body. However, there are caveats and corner cases applied, [**Caveats**](#caveats)
 
 The policy also provides a consistent behavior across multiple scenarios like:
 
@@ -30,10 +28,15 @@ The policy also provides a consistent behavior across multiple scenarios like:
 
 ## Why don't we also support disable response buffering?
 
-The response buffering is enabled by default in NGINX (the [`proxy_buffering: on`]() directive). It does
-this to shield the backend against slow clients ([slowloris attack](https://en.wikipedia.org/wiki/Slowloris_(computer_security))).
+The response buffering is enabled by default in NGINX (the [`proxy_buffering: on`]() directive). It does this to shield the backend against slow clients ([slowloris attack](https://en.wikipedia.org/wiki/Slowloris_(computer_security))).
 
-If the `proxy_buffering` is disabled, the upstream server will be forced to keep the connection open until all data has been received by the client. Thereforce, NGINX [advises](https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#proxy_buffering-off) against disabling `proxy_buffering` as it will potentially waste upstream server resources.
+If the `proxy_buffering` is disabled, the upstream server keeps the connection open until all data is received by the client. NGINX [advises](https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#proxy_buffering-off) against disabling `proxy_buffering` as it will potentially waste upstream server resources.
+
+## Why does upstream receive a "Content-Length" header when the original request is sent with "Transfer-Encoding: chunked"
+
+For a request with "small" body that fits into [`client_body_buffer_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size) and with header "Transfer-Encoding: chunked", NGINX will always read and know the length of the body. Then it will send the request to upstream with the "Content-Length" header.
+
+If a client uses chunked transfer encoding with HTTP/1.0, NGINX will always buffer the request body
 
 ## Example configuration
 
@@ -89,11 +92,6 @@ Use with Camel Proxy policy
 
 ## Caveats
 
-- Because APIcast allows defining mapping rules based on request content, ie `POST /some_path?a_param={a_value}`
-  will match a request like `POST "http://apicast_host:8080/some_path"` with a form URL-encoded body like: `a_param=abc`
-  , requests with `Content-type: application/x-www-form-urlencoded` will always be buffered regardless of the
+- APIcast allows defining of mapping rules based on request content. For example, `POST /some_path?a_param={a_value}` will match a request like `POST "http://apicast_host:8080/some_path"` with a form URL-encoded body like: `a_param=abc`, requests with `Content-type: application/x-www-form-urlencoded` will always be buffered regardless of the
   `request_unbuffered` policy is enabled or not.
-- For a request with "small" body that fits into [`client_body_buffer_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size) and with header "Transfer-Encoding: chunked", NGINX will always read and know the length of the body.
-  Then it will send the request to upstream with the "Content-Length" header.
-- If a client uses chunked transfer encoding with HTTP/1.0, NGINX will always buffer the request body
 - Disable request buffering could potentially expose the backend to [slowloris attack](https://en.wikipedia.org/wiki/Slowloris_(computer_security)). Therefore, we recommend to only use this policy when needed.

--- a/gateway/src/apicast/policy/request_unbuffered/README.md
+++ b/gateway/src/apicast/policy/request_unbuffered/README.md
@@ -1,19 +1,99 @@
 # APICast Request Unbuffered
 
-This policy allows to disable request buffering
+## Description
+
+When enable this policy will dymanically sets the [`proxy_request_buffering: off`](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_request_buffering
+) directive per service.
+
+
+## Technical details
+
+By default, NGINX reads the entire request body into memory (or buffers large requests into disk) before proxying it to the upstream server. However, reading bodies can become expensive, especially when requests with large payloads are sent.
+
+For example, when the client sends 10GB, NGINX will buffer the entire 10GB to disk before sending anything to
+the upstream server.
+
+When `proxy_request_buffering` is in the chain, request buffering will be disabled and the request body will be sent to the proxied server immediately as it received. This can help minimize time spent sending data to a service and disk I/O for requests with big body. However, there are caveats and corner cases applied, [**Caveats**](#caveats)
+
+The policy also provides a consistent behavior across multiple scenarios like:
+
+```
+- APIcast <> upstream HTTP 1.1 plain
+- APIcast <> upstream TLS
+- APIcast <> HTTP Proxy (env var) <> upstream HTTP 1.1 plain
+- APIcast <> HTTP Proxy (policy) <> upstream HTTP 1.1 plain
+- APIcast <> HTTP Proxy (camel proxy) <> upstream HTTP 1.1 plain
+- APIcast <> HTTP Proxy (env var) <> upstream TLS
+- APIcast <> HTTP Proxy (policy) <> upstream TLS
+- APIcast <> HTTP Proxy (camel proxy) <> upstream TLS
+```
+
+## Why don't we also support disable response buffering?
+
+The response buffering is enabled by default in NGINX (the [`proxy_buffering: on`]() directive). It does
+this to shield the backend against slow clients ([slowloris attack](https://en.wikipedia.org/wiki/Slowloris_(computer_security))).
+
+If the `proxy_buffering` is disabled, the upstream server will be forced to keep the connection open until all data has been received by the client. Thereforce, NGINX [advises](https://www.nginx.com/blog/avoiding-top-10-nginx-configuration-mistakes/#proxy_buffering-off) against disabling `proxy_buffering` as it will potentially waste upstream server resources.
 
 ## Example configuration
 
 ```
-{
-    "name": "request_unbuffered",
-    "version": "builtin",
-    "configuration": {}
-}
+"policy_chain": [
+    {
+        "name": "request_unbuffered",
+        "version": "builtin",
+    },
+    {
+      "name": "apicast.policy.apicast"
+    }
+]
+```
+
+Use with Proxy policy
+
+```
+"policy_chain": [
+    {
+        "name": "request_unbuffered",
+        "version": "builtin",
+    },
+    {
+      "name": "apicast.policy.http_proxy",
+      "configuration": {
+          "all_proxy": "http://foo:bar@192.168.15.103:8888/",
+          "https_proxy": "http://192.168.15.103:8888/",
+          "http_proxy": "http://192.168.15.103:8888/"
+      }
+    }
+]
+```
+
+Use with Camel Proxy policy
+
+```
+"policy_chain": [
+    {
+        "name": "request_unbuffered",
+        "version": "builtin",
+    },
+    {
+      "name": "apicast.policy.camel",
+      "configuration": {
+          "http_proxy": "http://192.168.15.103:8080/",
+          "https_proxy": "http://192.168.15.103:8443/",
+          "all_proxy": "http://192.168.15.103:8080/"
+      }
+    }
+]
 ```
 
 ## Caveats
 
-- Because APIcast allows defining mapping rules based on request content, POST requests with
-  `Content-type: application/x-www-form-urlencoded` will always be buffered regardless of the
+- Because APIcast allows defining mapping rules based on request content, ie `POST /some_path?a_param={a_value}`
+  will match a request like `POST "http://apicast_host:8080/some_path"` with a form URL-encoded body like: `a_param=abc`
+  , requests with `Content-type: application/x-www-form-urlencoded` will always be buffered regardless of the
   `request_unbuffered` policy is enabled or not.
+- For a request with "small" body that fits into [`client_body_buffer_size`](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size) and with header "Transfer-Encoding: chunked", NGINX will always read and know the length of the body.
+  Then it will send the request to upstream with the "Content-Length" header.
+- If a client uses chunked transfer encoding with HTTP/1.0, NGINX will always buffer the request body
+- Disable request buffering could potentially expose the backend to [slowloris attack](https://en.wikipedia.org/wiki/Slowloris_(computer_security)). Therefore, we recommend to only use this policy when needed.

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -241,6 +241,7 @@ function _M:call(context)
           self:set_skip_https_connect_on_proxy();
         end
 
+        self.request_unbuffered = context.request_unbuffered
         http_proxy.request(self, proxy_uri)
     else
         local err = self:rewrite_request()

--- a/gateway/src/resty/file.lua
+++ b/gateway/src/resty/file.lua
@@ -28,4 +28,20 @@ function _M.file_reader(filename)
     end)
 end
 
+function _M.file_size(filename)
+  local handle, err = open(filename)
+
+  if err then
+    return nil, err
+  end
+
+  local current = handle:seek()
+  local size = handle:seek("end")
+
+  handle:seek("set", current)
+  handle:close()
+
+  return size
+end
+
 return _M

--- a/gateway/src/resty/file.lua
+++ b/gateway/src/resty/file.lua
@@ -1,4 +1,5 @@
 local co_yield = coroutine._yield
+local co_wrap = coroutine._wrap
 local open = io.open
 
 local co_wrap_iter = require("resty.coroutines").co_wrap_iter
@@ -29,19 +30,21 @@ function _M.file_reader(filename)
 end
 
 function _M.file_size(filename)
-  local handle, err = open(filename)
+    return co_wrap(function()
+        local handle, err = open(filename)
 
-  if err then
-    return nil, err
-  end
+        if err then
+          return nil, err
+        end
 
-  local current = handle:seek()
-  local size = handle:seek("end")
+        local current = handle:seek()
+        local size = handle:seek("end")
 
-  handle:seek("set", current)
-  handle:close()
+        handle:seek("set", current)
+        handle:close()
 
-  return size
+        return size
+    end)
 end
 
 return _M

--- a/gateway/src/resty/http/request_reader.lua
+++ b/gateway/src/resty/http/request_reader.lua
@@ -1,0 +1,47 @@
+local httpc = require "resty.resolver.http"
+
+local _M = {
+}
+
+local cr_lf = "\r\n"
+
+-- chunked_reader return a body reader that translates the data read from
+-- lua-resty-http client_body_reader to HTTP "chunked" format before returning it
+--
+-- The chunked reader return nil when the final 0-length chunk is read
+local function chunked_reader(sock, chunksize)
+    chunksize = chunksize or 65536
+    local eof = false
+    local reader = httpc:get_client_body_reader(chunksize, sock)
+    if not reader then
+        return nil
+    end
+
+    return function()
+        if eof then
+            return nil
+        end
+
+        local buffer, err = reader()
+        if err then
+            return nil, err
+        end
+        if buffer then
+            local chunk = string.format("%x\r\n", #buffer) .. buffer .. cr_lf
+            return chunk
+        else
+            eof = true
+            return "0\r\n\r\n"
+        end
+    end
+end
+
+function _M.get_client_body_reader(sock, chunksize, is_chunked)
+    if is_chunked then
+        return chunked_reader(sock, chunksize)
+    else
+        return httpc:get_client_body_reader(chunksize, sock)
+    end
+end
+
+return _M

--- a/gateway/src/resty/http/request_reader.lua
+++ b/gateway/src/resty/http/request_reader.lua
@@ -1,9 +1,27 @@
 local httpc = require "resty.resolver.http"
+local ngx_req = ngx.req
 
 local _M = {
 }
 
 local cr_lf = "\r\n"
+
+local function test_expect(sock)
+  local expect = ngx_req.get_headers()["Expect"]
+
+  if expect == "" or ngx_req.http_version == 1.0 then
+    return true
+  end
+
+  if expect and expect:lower() == "100-continue" then
+    local _, err = sock:send("HTTP/1.1 100 Continue\r\n\r\n")
+    if err then
+        ngx.log(ngx.ERR, "failed to handle expect header, err: ", err)
+        return false, err
+    end
+  end
+  return true
+end
 
 -- chunked_reader return a body reader that translates the data read from
 -- lua-resty-http client_body_reader to HTTP "chunked" format before returning it
@@ -15,6 +33,14 @@ local function chunked_reader(sock, chunksize)
     local reader = httpc:get_client_body_reader(chunksize, sock)
     if not reader then
         return nil
+    end
+
+    -- If Expect: 100-continue is sent upstream, lua-resty-http will only call
+    -- _send_body after receiving "100 Continue". So it's safe to process the
+    -- Expect header and send "100 Continue" downstream here.
+    local ok, err = test_expect(sock)
+    if not ok then
+      return nil, err
     end
 
     return function()

--- a/gateway/src/resty/http/response_writer.lua
+++ b/gateway/src/resty/http/response_writer.lua
@@ -1,0 +1,58 @@
+local _M = {
+}
+
+local cr_lf = "\r\n"
+
+local function send(socket, data)
+    if not data or data == '' then
+        ngx.log(ngx.DEBUG, 'skipping sending nil')
+        return
+    end
+
+    return socket:send(data)
+end
+
+-- write_response writes response body reader to sock in the HTTP/1.x server response format,
+-- The connection is closed if send() fails or when returning a non-zero
+function _M.send_response(sock, response, chunksize)
+    local bytes, err
+    chunksize = chunksize or 65536
+
+    if not response then
+        ngx.log(ngx.ERR, "no response provided")
+        return
+    end
+
+    if not sock then
+        return nil, "socket not initialized yet"
+    end
+
+    -- Status line
+    local status  = "HTTP/1.1 " .. response.status .. " " .. response.reason .. cr_lf
+    bytes, err = send(sock, status)
+    if not bytes then
+        return nil, "failed to send status line, err: " .. (err or "unknown")
+    end
+
+    -- Write body
+    local reader = response.body_reader
+    repeat
+        local chunk, read_err
+
+        chunk, read_err = reader(chunksize)
+        if read_err then
+            return nil, "failed to read response body, err: " .. (err or "unknown")
+        end
+
+        if chunk then
+            bytes, err = send(sock, chunk)
+            if not bytes then
+                return nil, "failed to send response body, err: " .. (err or "unknown")
+            end
+        end
+    until not chunk
+
+    return true, nil
+end
+
+return _M

--- a/t/apicast-policy-camel.t
+++ b/t/apicast-policy-camel.t
@@ -3,6 +3,16 @@ use Test::APIcast::Blackbox 'no_plan';
 
 require("http_proxy.pl");
 
+sub large_body {
+  my $res = "";
+  for (my $i=0; $i <= 1024; $i++) {
+    $res = $res . "1111111 1111111 1111111 1111111\n";
+  }
+  return $res;
+}
+
+$ENV{'LARGE_BODY'} = large_body();
+
 repeat_each(1);
 
 run_tests();
@@ -742,3 +752,473 @@ EOF
 --- no_error_log
 [error]
 --- user_files fixture=tls.pl eval
+
+
+
+=== TEST 11: http_proxy with request_unbuffered policy
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "request_unbuffered"
+          },
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.camel",
+            "configuration": {
+                "http_proxy": "http://127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+  server_name test-upstream.lvh.me;
+  location / {
+    echo_read_request_body;
+    echo_request_body;
+  }
+--- request eval
+"POST /?user_key= \n" . $ENV{LARGE_BODY}
+--- response_body eval chomp
+$ENV{LARGE_BODY}
+--- error_code: 200
+--- error_log env
+using proxy: http://127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT
+--- no_error_log
+[error]
+--- grep_error_log eval
+qr/a client request body is buffered to a temporary file/
+--- grep_error_log_out
+a client request body is buffered to a temporary file
+
+
+
+=== TEST 12: http_proxy with request_unbuffered policy and chunked body
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "request_unbuffered"
+          },
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.camel",
+            "configuration": {
+                "http_proxy": "http://127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+  server_name test-upstream.lvh.me;
+  location / {
+    access_by_lua_block {
+      assert = require('luassert')
+      local content_length = ngx.req.get_headers()["Content-Length"]
+      local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+      assert.equal('chunked', encoding)
+      assert.falsy(content_length)
+    }
+    echo_read_request_body;
+    echo_request_body;
+  }
+--- more_headers
+Transfer-Encoding: chunked
+--- request eval
+"POST /?user_key=value
+".
+sprintf("%x\r\n", length $ENV{"LARGE_BODY"}).
+$ENV{LARGE_BODY}
+."\r
+0\r
+\r
+"
+--- response_body eval
+$ENV{LARGE_BODY}
+--- error_code: 200
+--- error_log env
+using proxy: http://127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT
+--- no_error_log
+[error]
+--- grep_error_log eval
+qr/a client request body is buffered to a temporary file/
+--- grep_error_log_out
+a client request body is buffered to a temporary file
+
+
+
+=== TEST 13: all_proxy with request_unbuffered policy
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "request_unbuffered"
+          },
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.camel",
+            "configuration": {
+                "all_proxy": "http://127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+  server_name test-upstream.lvh.me;
+  location / {
+    echo_read_request_body;
+    echo_request_body;
+  }
+--- request eval
+"POST /?user_key= \n" . $ENV{LARGE_BODY}
+--- response_body eval chomp
+$ENV{LARGE_BODY}
+--- error_code: 200
+--- error_log env
+using proxy: http://127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT
+--- no_error_log
+[error]
+--- grep_error_log eval
+qr/a client request body is buffered to a temporary file/
+--- grep_error_log_out
+a client request body is buffered to a temporary file
+
+
+
+=== TEST 14: all_proxy with request_unbuffered policy and chunked body
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "request_unbuffered"
+          },
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.camel",
+            "configuration": {
+                "all_proxy": "http://127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+  server_name test-upstream.lvh.me;
+  location / {
+    access_by_lua_block {
+      assert = require('luassert')
+      local content_length = ngx.req.get_headers()["Content-Length"]
+      local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+      assert.equal('chunked', encoding)
+      assert.falsy(content_length)
+    }
+    echo_read_request_body;
+    echo_request_body;
+  }
+--- more_headers
+Transfer-Encoding: chunked
+--- request eval
+"POST /?user_key=value
+".
+sprintf("%x\r\n", length $ENV{"LARGE_BODY"}).
+$ENV{LARGE_BODY}
+."\r
+0\r
+\r
+"
+--- response_body eval
+$ENV{LARGE_BODY}
+--- error_code: 200
+--- error_log env
+using proxy: http://127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT
+--- no_error_log
+[error]
+--- grep_error_log eval
+qr/a client request body is buffered to a temporary file/
+--- grep_error_log_out
+a client request body is buffered to a temporary file
+
+
+
+=== TEST 15: https_proxy with request_unbuffered policy, only upstream and proxy_pass will buffer
+the request
+--- init eval
+$Test::Nginx::Util::PROXY_SSL_PORT = Test::APIcast::get_random_port();
+$Test::Nginx::Util::ENDPOINT_SSL_PORT = Test::APIcast::get_random_port();
+--- configuration random_port env eval
+<<EOF
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://127.0.0.1:$Test::Nginx::Util::ENDPOINT_SSL_PORT",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "request_unbuffered"
+          },
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.camel",
+            "configuration": {
+                "https_proxy": "http://127.0.0.1:$Test::Nginx::Util::PROXY_SSL_PORT"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+EOF
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream eval
+<<EOF
+  # Endpoint config
+  listen $Test::Nginx::Util::ENDPOINT_SSL_PORT ssl;
+
+  ssl_certificate $Test::Nginx::Util::ServRoot/html/server.crt;
+  ssl_certificate_key $Test::Nginx::Util::ServRoot/html/server.key;
+
+  server_name _ default_server;
+
+  location / {
+    echo_read_request_body;
+    echo_request_body;
+  }
+}
+server {
+  # Proxy config
+  listen $Test::Nginx::Util::PROXY_SSL_PORT ssl;
+
+  ssl_certificate $Test::Nginx::Util::ServRoot/html/server.crt;
+  ssl_certificate_key $Test::Nginx::Util::ServRoot/html/server.key;
+
+
+  server_name _ default_server;
+
+  location ~ /.* {
+    proxy_http_version 1.1;
+    proxy_pass https://\$http_host;
+  }
+EOF
+--- request eval
+"POST /?user_key= \n" . $ENV{LARGE_BODY}
+--- response_body eval chomp
+$ENV{LARGE_BODY}
+--- error_code: 200
+--- user_files fixture=tls.pl eval
+--- error_log eval
+<<EOF
+using proxy: http://127.0.0.1:$Test::Nginx::Util::PROXY_SSL_PORT,
+EOF
+--- no_error_log
+[error]
+--- grep_error_log eval
+qr/a client request body is buffered to a temporary file/
+--- grep_error_log_out
+a client request body is buffered to a temporary file
+a client request body is buffered to a temporary file
+
+
+
+=== TEST 16: https_proxy with request_unbuffered policy and chunked body, only upstream and proxy_pass will buffer
+the request
+--- init eval
+$Test::Nginx::Util::PROXY_SSL_PORT = Test::APIcast::get_random_port();
+$Test::Nginx::Util::ENDPOINT_SSL_PORT = Test::APIcast::get_random_port();
+--- configuration random_port env eval
+<<EOF
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://127.0.0.1:$Test::Nginx::Util::ENDPOINT_SSL_PORT",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "request_unbuffered"
+          },
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.camel",
+            "configuration": {
+                "https_proxy": "http://127.0.0.1:$Test::Nginx::Util::PROXY_SSL_PORT"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+EOF
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream eval
+<<EOF
+  # Endpoint config
+  listen $Test::Nginx::Util::ENDPOINT_SSL_PORT ssl;
+
+  ssl_certificate $Test::Nginx::Util::ServRoot/html/server.crt;
+  ssl_certificate_key $Test::Nginx::Util::ServRoot/html/server.key;
+
+  server_name _ default_server;
+
+  location / {
+    echo_read_request_body;
+    echo_request_body;
+  }
+}
+server {
+  # Proxy config
+  listen $Test::Nginx::Util::PROXY_SSL_PORT ssl;
+
+  ssl_certificate $Test::Nginx::Util::ServRoot/html/server.crt;
+  ssl_certificate_key $Test::Nginx::Util::ServRoot/html/server.key;
+
+
+  server_name _ default_server;
+
+  location ~ /.* {
+    access_by_lua_block {
+      assert = require('luassert')
+      local content_length = ngx.req.get_headers()["Content-Length"]
+      local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+      assert.equal('chunked', encoding)
+      assert.falsy(content_length)
+    }
+    proxy_http_version 1.1;
+    proxy_pass https://\$http_host;
+  }
+EOF
+--- more_headers
+Transfer-Encoding: chunked
+--- request eval
+"POST /?user_key=value
+".
+sprintf("%x\r\n", length $ENV{"LARGE_BODY"}).
+$ENV{LARGE_BODY}
+."\r
+0\r
+\r
+"
+--- response_body eval
+$ENV{LARGE_BODY}
+--- error_code: 200
+--- user_files fixture=tls.pl eval
+--- error_log eval
+<<EOF
+using proxy: http://127.0.0.1:$Test::Nginx::Util::PROXY_SSL_PORT,
+EOF
+--- no_error_log
+[error]
+--- grep_error_log eval
+qr/a client request body is buffered to a temporary file/
+--- grep_error_log_out
+a client request body is buffered to a temporary file
+a client request body is buffered to a temporary file

--- a/t/http-proxy.t
+++ b/t/http-proxy.t
@@ -1320,3 +1320,478 @@ got header line: Proxy-Authorization: Basic Zm9vOmJhcg==
 --- no_error_log
 [error]
 --- user_files fixture=tls.pl eval
+
+
+
+=== TEST 25: Upstream API with HTTP POST chunked request, HTTP_PROXY and HTTP api_backend
+--- env eval
+(
+    "http_proxy" => $ENV{TEST_NGINX_HTTP_PROXY},
+    'BACKEND_ENDPOINT_OVERRIDE' => "http://test_backend.lvh.me:$ENV{TEST_NGINX_SERVER_PORT}"
+)
+--- configuration
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT",
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+server_name test_backend.lvh.me;
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+server_name test-upstream.lvh.me;
+  location /test {
+    access_by_lua_block {
+        assert = require('luassert')
+        local content_length = ngx.req.get_headers()["Content-Length"]
+        local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+        assert.equal('12', content_length)
+        assert.falsy(encoding)
+    }
+    echo_read_request_body;
+    echo $request_body;
+  }
+--- more_headers
+Transfer-Encoding: chunked
+--- request eval
+"POST /test?user_key=value
+7\r
+hello, \r
+5\r
+world\r
+0\r
+\r
+"
+--- response_body
+hello, world
+--- error_code: 200
+--- error_log env
+proxy request: POST http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/test?user_key=value HTTP/1.1
+--- no_error_log
+[error]
+
+
+
+=== TEST 26: Upstream API with HTTPS POST chunked request, HTTPS_PROXY and HTTPS api_backend
+--- env random_port eval
+(
+  'https_proxy' => $ENV{TEST_NGINX_HTTPS_PROXY},
+  'BACKEND_ENDPOINT_OVERRIDE' => "https://test-backend.lvh.me:$ENV{TEST_NGINX_RANDOM_PORT}"
+)
+--- configuration random_port env
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT",
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend env
+  server_name test-backend.lvh.me;
+  listen $TEST_NGINX_RANDOM_PORT ssl;
+  ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+  ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream env
+server_name test-upstream.lvh.me;
+listen $TEST_NGINX_RANDOM_PORT ssl;
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+location /test {
+    access_by_lua_block {
+      assert = require('luassert')
+      local content_length = ngx.req.get_headers()["Content-Length"]
+      local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+      assert.equal('12', content_length)
+      assert.falsy(encoding)
+    }
+    echo_read_request_body;
+    echo $request_body;
+}
+--- more_headers
+Transfer-Encoding: chunked
+--- request eval
+"POST /test?user_key=value
+7\r
+hello, \r
+5\r
+world\r
+0\r
+\r
+"
+--- response_body
+hello, world
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- no_error_log
+[error]
+--- user_files fixture=tls.pl eval
+
+
+
+=== TEST 27: Upstream Policy connection uses proxy with POST chunked request
+--- env random_port eval
+("http_proxy" => $ENV{TEST_NGINX_HTTP_PROXY})
+--- configuration
+{
+  "services": [
+    {
+      "proxy": {
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/test", "url": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+server_name test-upstream.lvh.me;
+  location /test {
+    access_by_lua_block {
+      assert = require('luassert')
+      local content_length = ngx.req.get_headers()["Content-Length"]
+      local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+      assert.equal('12', content_length)
+      assert.falsy(encoding)
+    }
+    echo_read_request_body;
+    echo $request_body;
+  }
+--- more_headers
+Transfer-Encoding: chunked
+--- request eval
+"POST /test?user_key=value
+7\r
+hello, \r
+5\r
+world\r
+0\r
+\r
+"
+--- response_body
+hello, world
+--- error_code: 200
+--- error_log env
+proxy request: POST http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/test?user_key=value HTTP/1.1
+--- no_error_log
+[error]
+
+
+
+=== TEST 28: Upstream Policy connection uses proxy for https with POST chunked request
+--- env eval
+("https_proxy" => $ENV{TEST_NGINX_HTTPS_PROXY})
+--- configuration random_port env
+{
+  "services": [
+    {
+      "proxy": {
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/test", "url": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT" } ]
+              }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream env
+server_name test-upstream.lvh.me;
+listen $TEST_NGINX_RANDOM_PORT ssl;
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+location /test {
+    access_by_lua_block {
+      assert = require('luassert')
+      local content_length = ngx.req.get_headers()["Content-Length"]
+      local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+      assert.equal('12', content_length)
+      assert.falsy(encoding)
+    }
+    echo_read_request_body;
+    echo $request_body;
+}
+--- more_headers
+Transfer-Encoding: chunked
+--- request eval
+"POST /test?user_key=value
+7\r
+hello, \r
+5\r
+world\r
+0\r
+\r
+"
+--- response_body
+hello, world
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- no_error_log
+[error]
+--- user_files fixture=tls.pl eval
+
+
+
+=== TEST 29: Upstream policy with HTTPS POST chunked request, HTTPS_PROXY and HTTPS backend
+--- env random_port eval
+(
+  'https_proxy' => $ENV{TEST_NGINX_HTTPS_PROXY},
+  'BACKEND_ENDPOINT_OVERRIDE' => "https://test-backend.lvh.me:$ENV{TEST_NGINX_RANDOM_PORT}"
+)
+--- configuration random_port env
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT",
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/test", "url": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT" } ]
+              }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend env
+  server_name test-backend.lvh.me;
+  listen $TEST_NGINX_RANDOM_PORT ssl;
+  ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+  ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream env
+server_name test-upstream.lvh.me;
+listen $TEST_NGINX_RANDOM_PORT ssl;
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+location /test {
+    access_by_lua_block {
+      assert = require('luassert')
+      local content_length = ngx.req.get_headers()["Content-Length"]
+      local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+      assert.equal('12', content_length)
+      assert.falsy(encoding)
+    }
+    echo_read_request_body;
+    echo $request_body;
+}
+--- more_headers
+Transfer-Encoding: chunked
+--- request eval
+"POST /test?user_key=value
+7\r
+hello, \r
+5\r
+world\r
+0\r
+\r
+"
+--- response_body
+hello, world
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- no_error_log
+[error]
+--- user_files fixture=tls.pl eval
+
+
+
+=== TEST 30: Upstream policy with HTTPS POST chunked request, HTTPS_PROXY and HTTPS backend and lower
+case header
+--- env random_port eval
+(
+  'https_proxy' => $ENV{TEST_NGINX_HTTPS_PROXY},
+  'BACKEND_ENDPOINT_OVERRIDE' => "https://test-backend.lvh.me:$ENV{TEST_NGINX_RANDOM_PORT}"
+)
+--- configuration random_port env
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT",
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.upstream",
+            "configuration":
+              {
+                "rules": [ { "regex": "/test", "url": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT" } ]
+              }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend env
+  server_name test-backend.lvh.me;
+  listen $TEST_NGINX_RANDOM_PORT ssl;
+  ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+  ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream env
+server_name test-upstream.lvh.me;
+listen $TEST_NGINX_RANDOM_PORT ssl;
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+location /test {
+    access_by_lua_block {
+      assert = require('luassert')
+      local content_length = ngx.req.get_headers()["Content-Length"]
+      local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+      assert.equal('12', content_length)
+      assert.falsy(encoding)
+    }
+    echo_read_request_body;
+    echo $request_body;
+}
+--- more_headers
+transfer-encoding: chunked
+--- request eval
+"POST /test?user_key=value
+7\r
+hello, \r
+5\r
+world\r
+0\r
+\r
+"
+--- response_body
+hello, world
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- no_error_log
+[error]
+--- user_files fixture=tls.pl eval
+
+
+
+=== TEST 31: POST chunked request with random chunk size, HTTPS_PROXY and HTTPS api_backend
+this will also test the case when the request body is big and saved to a temp file
+--- env random_port eval
+(
+  'https_proxy' => $ENV{TEST_NGINX_HTTPS_PROXY},
+  'BACKEND_ENDPOINT_OVERRIDE' => "https://test-backend.lvh.me:$ENV{TEST_NGINX_RANDOM_PORT}"
+)
+--- configuration random_port env
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend env
+  server_name test-backend.lvh.me;
+  listen $TEST_NGINX_RANDOM_PORT ssl;
+  ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+  ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream env
+server_name test-upstream.lvh.me;
+listen $TEST_NGINX_RANDOM_PORT ssl;
+
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+location / {
+    echo_read_request_body;
+    echo_request_body;
+}
+
+--- more_headers
+Transfer-Encoding: chunked
+--- request eval
+$::data = '';
+my $count = (int rand 32766) + 1;
+for (my $i = 0; $i < $count; $i++) {
+    my $c = chr int rand 128;
+    $::data .= $c;
+}
+my $s = "POST /test?user_key=value
+".
+sprintf("%x\r\n", length $::data).
+$::data
+."\r
+0\r
+\r
+";
+open my $out, '>/tmp/out.txt' or die $!;
+print $out $s;
+close $out;
+$s
+--- response_body eval
+$::data
+--- error_log env
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- no_error_log
+[error]
+--- user_files fixture=tls.pl eval


### PR DESCRIPTION
### What:
Fix  https://issues.redhat.com/browse/THREESCALE-9542

This PR adds support to proxy the request with "Transfer-Encoding: chunked" when using with the proxy server.

### Note to reviewers

Please just review the last 2 commits. I will rebase once part 1 merged

### Verification steps:

* Checkout this branch

* Make runtime-image IMAGE_NAME=apicast-test
```shell
make runtime-image IMAGE_NAME=apicast-test
```

* Then run the gateway with the built image

```diff
diff --git a/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json b/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json
index 5227c5aa..24c45338 100644
--- a/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json
+++ b/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json
@@ -44,6 +44,11 @@
           "host": "backend"
         },
         "policy_chain": [
+          {
+              "name": "request_unbuffered",
+              "version": "builtin",
+              "configuration": {}
+          },
           {
             "name": "apicast.policy.http_proxy",
             "configuration": {
```

```shell
cd dev-environments/https-proxy-upstream-tlsv1.3
make certs
make gateway IMAGE_NAME=apicast-test
```

* Send chunked request with one chunk body

```shell
curl --resolve post.example.com:8080:127.0.0.1 -v -H "Transfer-Encoding: chunked"   -H "Content-Type: application/json"  -d @my-data.json "http://post.example.com:8080/?user_key=123"
```

The request should return 200 OK.  Note that upstream echo API is reporting that the request included `Transfer-Encoding: chunked` header and the expected body.

<details>

```shell
 ▲  curl --resolve post.example.com:8080:127.0.0.1 -v -H "Transfer-Encoding: chunked"   -H "Content-Type: application/json"  -d 'hello, world' "http://post.example.com:8080/?user_key=123"
* Added post.example.com:8080:127.0.0.1 to DNS cache
* Hostname post.example.com was found in DNS cache
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to post.example.com (127.0.0.1) port 8080 (#0)
> POST /?user_key=123 HTTP/1.1
> Host: post.example.com:8080
> User-Agent: curl/7.61.1
> Accept: */*
> Transfer-Encoding: chunked
> Content-Type: application/json
>
> c
* upload completely sent off: 19 out of 12 bytes
< HTTP/1.1 200 OK
< {
<   "args": {
<     "user_key": "123"
<   },
<   "data": "hello, world",
<   "files": {},
<   "form": {},
<   "headers": {
<     "Accept": "*/*",
<     "Content-Type": "application/json",
<     "Host": "example.com",
<     "Transfer-Encoding": "chunked",
<     "User-Agent": "curl/7.61.1"
<   },
<   "json": null,
<   "origin": "172.25.0.2",
<   "url": "http://example.com/post?user_key=123"
< }
* Connection #0 to host post.example.com left intact
```

</details>

* Send chunked request with few chunks in the body delayed in time. Python3 is required.

First get the APICast IPAddress

```
 ▲ docker inspect https-proxy-upstream-tlsv13-gateway-run-d76ff72726ec | grep IPAddress
```

```python
❯ cat <<EOF >chunked-request.py
import http.client
import time

def gen():
    yield bytes('hi', "utf-8")
    time.sleep(2)
    yield bytes('there', "utf-8")
    time.sleep(2)
    yield bytes('bye', "utf-8")

http.client.HTTPConnection.debuglevel = 1
conn = http.client.HTTPConnection('127.0.0.1', 8080)

headers = {'Content-type': 'application/octet-stream', 'Host': 'post.example.com'}

conn.request('POST', '/?user_key=foo', gen(), headers)

response = conn.getresponse()
print(response.read().decode())
EOF
```

Replace `127.0.0.1` with the IP of APIcast gateway above

```shell
> python3 chunked-request.py
send: b'POST /?user_key=foo HTTP/1.1\r\nAccept-Encoding: identity\r\nTransfer-Encoding: chunked\r\nContent-type: application/octet-stream\r\nHost: post.example.com\r\n\r\n'
send: b'2\r\nhi\r\n'                                                                                                                                                        
send: b'5\r\nthere\r\n'                                                                                                                                                     
send: b'3\r\nbye\r\n'                                                                                                                                                       
send: b'0\r\n\r\n'                                                                                                                                                          
reply: 'HTTP/1.1 200 OK\r\n'                                                                                                                                                
header: Access-Control-Allow-Credentials: true                                                                                                                              
header: Access-Control-Allow-Origin: *                                                                                                                                      
header: Date: Tue, 09 Jan 2024 03:40:18 GMT                                                                                                                                 
header: Content-Type: application/json                                                                                                                                      
header: Server: gunicorn/19.9.0                                                                                                                                             
{
  "args": {
    "user_key": "foo"
  }, 
  "data": "hitherebye", 
  "files": {}, 
  "form": {}, 
  "headers": {
    "Accept-Encoding": "identity", 
    "Content-Type": "application/octet-stream", 
    "Host": "example.com", 
    "Transfer-Encoding": "chunked",
    "User-Agent": "lua-resty-http/0.14 (Lua) ngx_lua/10019"
  }, 
  "json": null, 
  "origin": "172.18.0.4"
  "url": "http://example.com/post?user_key=foo"
}
```
* Note that the upstream service got transfer encoding chunked request and chunked encoding of the request body with the length bytes preceding each chunk.

<details>

```shell
> 2024/01/09 03:40:14.000960414  length=203 from=0 to=202 
POST /post?user_key=foo HTTP/1.1\r                        
User-Agent: lua-resty-http/0.14 (Lua) ngx_lua/10019\r     
Transfer-Encoding: chunked\r                              
Host: example.com\r                                       
Accept-Encoding: identity\r                               
Content-type: application/octet-stream\r                  
\r                                                        
> 2024/01/09 03:40:14.000960570  length=7 from=203 to=209 
2\r
hi\r
> 2024/01/09 03:40:16.000952052  length=10 from=210 to=219
5\r
there\r
> 2024/01/09 03:40:18.000954073  length=8 from=220 to=227
3\r
bye\r
> 2024/01/09 03:40:18.000954120  length=5 from=228 to=232
0\r
\r
< 2024/01/09 03:40:18.000954722  length=653 from=0 to=652
HTTP/1.1 200 OK\r
Server: gunicorn/19.9.0\r
Date: Tue, 09 Jan 2024 03:40:18 GMT\r
Connection: keep-alive\r
Content-Type: application/json\r
Content-Length: 423\r
Access-Control-Allow-Origin: *\r
Access-Control-Allow-Credentials: true\r
\r
{
  "args": {
    "user_key": "foo"
  }, 
  "data": "hitherebye", 
  "files": {}, 
  "form": {}, 
  "headers": {
    "Accept-Encoding": "identity", 
    "Content-Type": "application/octet-stream", 
    "Host": "example.com", 
    "Transfer-Encoding": "chunked", 
    "User-Agent": "lua-resty-http/0.14 (Lua) ngx_lua/10019"
  }, 
  "json": null, 
  "origin": "172.18.0.4", 
  "url": "http://example.com/post?user_key=foo"
}
```
</details>

* Send chunked request with expect 100-continue header.
```python
❯ cat <<EOF >chunked-request.py
import http.client
import time

def gen():
    yield bytes('hi', "utf-8")
    time.sleep(2)
    yield bytes('there', "utf-8")
    time.sleep(2)
    yield bytes('bye', "utf-8")

http.client.HTTPConnection.debuglevel = 1
conn = http.client.HTTPConnection('127.0.0.1', 8080)

headers = {'Content-type': 'application/octet-stream', 'Host': 'post.example.com', 'Expect': '100-continue'}

conn.request('POST', '/?user_key=foo', gen(), headers)

response = conn.getresponse()
print(response.read().decode())
EOF
```

* Note that the upstream service got transfer encoding chunked request and return 100 Continue
```
▲ python3 ./chunked-request.py

send: b'POST /?user_key=foo HTTP/1.1\r\nAccept-Encoding: identity\r\nTransfer-Encoding: chunked\r\nContent-type: application/octet-stream\r\nHost: post.example.com\r\nExpect: 100-continue\r\n\r\n'
send: b'2\r\nhi\r\n'                          
send: b'5\r\nthere\r\n'                       
send: b'3\r\nbye\r\n'                         
send: b'0\r\n\r\n'                            
reply: 'HTTP/1.1 100 Continue\r\n'            
headers: [b'\r\n']                            
reply: 'HTTP/1.1 200 OK\r\n'                  
header: Access-Control-Allow-Credentials: true
header: Access-Control-Allow-Origin: *        
header: Date: Tue, 09 Jan 2024 03:47:02 GMT   
header: Content-Type: application/json        
header: Server: gunicorn/19.9.0
{                                                          
  "args": {                                                
    "user_key": "foo"                                      
  },                                                       
  "data": "hitherebye",                                    
  "files": {},                                             
  "form": {},                                              
  "headers": {                                             
    "Accept-Encoding": "identity",                         
    "Content-Type": "application/octet-stream",            
    "Expect": "100-continue",                              
    "Host": "example.com",                                 
    "Transfer-Encoding": "chunked",                        
    "User-Agent": "lua-resty-http/0.14 (Lua) ngx_lua/10019"
  },                                                       
  "json": null,                                            
  "origin": "172.18.0.4",                                  
  "url": "http://example.com/post?user_key=foo"            
}
```