### PR TITLE
[THREESCALE-9542] Part 1: buffering policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Detect number of CPU shares when running on Cgroups V2 [PR #1410](https://github.com/3scale/apicast/pull/1410) [THREESCALE-10167](https://issues.redhat.com/browse/THREESCALE-10167)
-### Added
 
-* Add support to use Basic Authentication with the forward proxy. [PR #1409](https://github.com/3scale/APIcast/pull/1409)
+- Add support to use Basic Authentication with the forward proxy. [PR #1409](https://github.com/3scale/APIcast/pull/1409)
+
+- Added request unbuffered policy [PR #1408](https://github.com/3scale/APIcast/pull/1408) [THREESCALE-9542](https://issues.redhat.com/browse/THREESCALE-9542)
 
 ## [3.14.0] 2023-07-25
 

--- a/gateway/conf.d/apicast.conf
+++ b/gateway/conf.d/apicast.conf
@@ -78,6 +78,23 @@ location @upstream {
     require('resty.ctx').apply()
   }
 
+  proxy_request_buffering on;
+  #{% include "conf.d/upstream_shared.conf" %}
+
+  # these are duplicated so when request is redirected here those phases are executed
+  post_action @out_of_band_authrep_action;
+  body_filter_by_lua_block { require('apicast.executor'):body_filter() }
+  header_filter_by_lua_block { require('apicast.executor'):header_filter() }
+}
+
+location @upstream_request_unbuffered {
+  internal;
+
+  rewrite_by_lua_block {
+    require('resty.ctx').apply()
+  }
+
+  proxy_request_buffering off;
   #{% include "conf.d/upstream_shared.conf" %}
 
   # these are duplicated so when request is redirected here those phases are executed

--- a/gateway/conf.d/apicast.conf
+++ b/gateway/conf.d/apicast.conf
@@ -78,71 +78,8 @@ location @upstream {
     require('resty.ctx').apply()
   }
 
-  #{% capture proxy_cache_valid %}
-  #{#} proxy_cache $cache_zone;
-  #{#} proxy_cache_key $scheme$request_method$proxy_host$request_uri$service_id;
-  #{#} proxy_no_cache $cache_request;
-  #{#} proxy_cache_valid {{ env.APICAST_CACHE_STATUS_CODES | default: '200 302'}} {{ env.APICAST_CACHE_MAX_TIME | default: '1m' }};
-  #{% endcapture %}
-  #{{ proxy_cache_valid | replace: "#{#}", "" }}
-  #
+  #{% include "conf.d/upstream_shared.conf" %}
 
-  #{% if opentelemetry != empty %}
-  #   {% capture opentelemetry_propagate_directive %}
-  #{#} opentelemetry_propagate;
-  #   {% endcapture %}
-  #   {{ opentelemetry_propagate_directive | replace: "#{#}", "" }}
-  #{% endif %}
-
-  proxy_pass $proxy_pass;
-
-  proxy_http_version 1.1;
-  proxy_set_header X-Real-IP  $remote_addr;
-  proxy_set_header Host $http_host;
-  proxy_set_header X-3scale-proxy-secret-token $secret_token;
-  proxy_set_header X-3scale-debug "";
-  proxy_set_header Connection $upstream_connection_header;
-  proxy_set_header Upgrade $upstream_upgrade_header;
-
-  # This is a bit tricky. It uses liquid to set a SSL client certificate. In
-  # NGINX, all this is not executed as it is commented with '#'. However, in
-  # Liquid, all this will be evaluated. As a result, the following directives
-  # are set optionally: proxy_ssl_certificate, proxy_ssl_certificate_key,
-  # proxy_ssl_session_reuse, and proxy_ssl_password_file.
-
-  # {% if proxy_ssl_certificate != empty and proxy_ssl_certificate_key != empty %}
-  #   {% capture proxy_ssl %}
-  #{#}   proxy_ssl_certificate {{ proxy_ssl_certificate }};
-  #{#}   proxy_ssl_certificate_key {{ proxy_ssl_certificate_key }};
-  #   {% endcapture %}
-  #   {{ proxy_ssl | replace: "#{#}", "" }}
-  #
-  #   {% if proxy_ssl_password_file != empty %}
-  #     {% capture proxy_ssl %}
-  #{#}   proxy_ssl_password_file {{ proxy_ssl_password_file }};
-  #     {% endcapture %}
-  #   {{ proxy_ssl | replace: "#{#}", "" }}
-  #   {% endif %}
-  #
-  #   {% if proxy_ssl_session_reuse != empty %}
-  #     {% capture proxy_ssl %}
-  #{#}   proxy_ssl_session_reuse {{ proxy_ssl_session_reuse }};
-  #     {% endcapture %}
-  #   {{ proxy_ssl | replace: "#{#}", "" }}
-  #   {% endif %}
-  # {% endif %}
-
-  # When 'upstream_retry_cases' is empty, apply the same default as NGINX.
-  # If the proxy_next_upstream directive is not declared, the retry policy
-  # will never retry.
-  # {% if upstream_retry_cases != empty %}
-  #   {% capture proxy_next_upstream %}
-  #{#}  proxy_next_upstream {{ upstream_retry_cases }};
-  #   {% endcapture %}
-  #   {{ proxy_next_upstream | replace: "#{#}", "" }}
-  # {% else %}
-  #   proxy_next_upstream error timeout;
-  # {% endif %}
   # these are duplicated so when request is redirected here those phases are executed
   post_action @out_of_band_authrep_action;
   body_filter_by_lua_block { require('apicast.executor'):body_filter() }

--- a/gateway/conf.d/upstream_shared.conf
+++ b/gateway/conf.d/upstream_shared.conf
@@ -1,0 +1,66 @@
+#{% capture proxy_cache_valid %}
+#{#} proxy_cache $cache_zone;
+#{#} proxy_cache_key $scheme$request_method$proxy_host$request_uri$service_id;
+#{#} proxy_no_cache $cache_request;
+#{#} proxy_cache_valid {{ env.APICAST_CACHE_STATUS_CODES | default: '200 302'}} {{ env.APICAST_CACHE_MAX_TIME | default: '1m' }};
+#{% endcapture %}
+#{{ proxy_cache_valid | replace: "#{#}", "" }}
+#
+
+#{% if opentelemetry != empty %}
+#   {% capture opentelemetry_propagate_directive %}
+#{#} opentelemetry_propagate;
+#   {% endcapture %}
+#   {{ opentelemetry_propagate_directive | replace: "#{#}", "" }}
+#{% endif %}
+
+proxy_pass $proxy_pass;
+
+proxy_http_version 1.1;
+
+proxy_set_header X-Real-IP  $remote_addr;
+proxy_set_header Host $http_host;
+proxy_set_header X-3scale-proxy-secret-token $secret_token;
+proxy_set_header X-3scale-debug "";
+proxy_set_header Connection $upstream_connection_header;
+proxy_set_header Upgrade $upstream_upgrade_header;
+
+# This is a bit tricky. It uses liquid to set a SSL client certificate. In
+# NGINX, all this is not executed as it is commented with '#'. However, in
+# Liquid, all this will be evaluated. As a result, the following directives
+# are set optionally: proxy_ssl_certificate, proxy_ssl_certificate_key,
+# proxy_ssl_session_reuse, and proxy_ssl_password_file.
+
+# {% if proxy_ssl_certificate != empty and proxy_ssl_certificate_key != empty %}
+#   {% capture proxy_ssl %}
+#{#}   proxy_ssl_certificate {{ proxy_ssl_certificate }};
+#{#}   proxy_ssl_certificate_key {{ proxy_ssl_certificate_key }};
+#   {% endcapture %}
+#   {{ proxy_ssl | replace: "#{#}", "" }}
+#
+#   {% if proxy_ssl_password_file != empty %}
+#     {% capture proxy_ssl %}
+#{#}   proxy_ssl_password_file {{ proxy_ssl_password_file }};
+#     {% endcapture %}
+#   {{ proxy_ssl | replace: "#{#}", "" }}
+#   {% endif %}
+#
+#   {% if proxy_ssl_session_reuse != empty %}
+#     {% capture proxy_ssl %}
+#{#}   proxy_ssl_session_reuse {{ proxy_ssl_session_reuse }};
+#     {% endcapture %}
+#   {{ proxy_ssl | replace: "#{#}", "" }}
+#   {% endif %}
+# {% endif %}
+
+# When 'upstream_retry_cases' is empty, apply the same default as NGINX.
+# If the proxy_next_upstream directive is not declared, the retry policy
+# will never retry.
+# {% if upstream_retry_cases != empty %}
+#   {% capture proxy_next_upstream %}
+#{#}  proxy_next_upstream {{ upstream_retry_cases }};
+#   {% endcapture %}
+#   {{ proxy_next_upstream | replace: "#{#}", "" }}
+# {% else %}
+#   proxy_next_upstream error timeout;
+# {% endif %}

--- a/gateway/src/apicast/policy/request_unbuffered/README.md
+++ b/gateway/src/apicast/policy/request_unbuffered/README.md
@@ -1,0 +1,14 @@
+# APICast Request Unbuffered
+
+This policy allows to disable request buffering
+
+## Example configuration
+
+```
+{
+    "name": "request_unbuffered",
+    "version": "builtin",
+    "configuration": {}
+}
+```
+

--- a/gateway/src/apicast/policy/request_unbuffered/apicast-policy.json
+++ b/gateway/src/apicast/policy/request_unbuffered/apicast-policy.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "Request Unbuffered",
+  "summary": "Disable request buffering",
+  "description": [
+      "Disable request buffering. This is useful when proxying big payloads with HTTP/1.1 chunked encoding"
+  ],
+  "version": "builtin",
+  "configuration": {
+    "type": "object",
+    "properties": {}
+  }
+}

--- a/gateway/src/apicast/policy/request_unbuffered/init.lua
+++ b/gateway/src/apicast/policy/request_unbuffered/init.lua
@@ -1,0 +1,1 @@
+return require('request_unbuffered')

--- a/gateway/src/apicast/policy/request_unbuffered/request_unbuffered.lua
+++ b/gateway/src/apicast/policy/request_unbuffered/request_unbuffered.lua
@@ -1,0 +1,22 @@
+-- Request Unbuffered policy
+-- This policy will disable request buffering
+
+local policy = require('apicast.policy')
+local _M = policy.new('request_unbuffered')
+
+local new = _M.new
+
+--- Initialize a buffering
+-- @tparam[opt] table config Policy configuration.
+function _M.new(config)
+  local self = new(config)
+  return self
+end
+
+function _M:export()
+  return {
+    request_unbuffered = true,
+  }
+end
+
+return _M

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -210,6 +210,15 @@ function _M:set_keepalive_key(context)
   end
 end
 
+local function get_upstream_location_name(context)
+    if context.upstream_location_name then
+        return context.upstream_location_name
+    end
+    if context.request_unbuffered then
+        return "@upstream_request_unbuffered"
+    end
+end
+
 --- Execute the upstream.
 --- @tparam table context any table (policy context, ngx.ctx) to store the upstream for later use by balancer
 function _M:call(context)
@@ -242,9 +251,9 @@ function _M:call(context)
 
     self:set_keepalive_key(context or {})
     if not self.servers then self:resolve() end
-    if context.upstream_location_name then
-        self.location_name = context.upstream_location_name
-    end
+
+    local upstream_location_name = get_upstream_location_name(context)
+    self:update_location(upstream_location_name)
     context[self.upstream_name] = self
 
     return exec(self)

--- a/spec/upstream_spec.lua
+++ b/spec/upstream_spec.lua
@@ -217,6 +217,22 @@ describe('Upstream', function()
             assert.spy(ngx.exec).was_called_with(upstream.location_name)
         end)
 
+        it('executes the upstream location when request_unbuffered provided in the context', function()
+            local contexts = {
+                ["buffered_request"] = {ctx={}, upstream_location="@upstream"},
+                ["unbuffered_request"] = {ctx={request_unbuffered=true}, upstream_location="@upstream_request_unbuffered"},
+                ["upstream_location and buffered_request"] = {ctx={upstream_location_name="@grpc", request_unbuffered=true}, upstream_location="@grpc"},
+                ["upstream_location and unbuffered_request"] = {ctx={upstream_location_name="@grpc"}, upstream_location="@grpc"},
+            }
+
+            for _, value in pairs(contexts) do
+                local upstream = Upstream.new('http://localhost')
+                upstream:call(value.ctx)
+
+                assert.spy(ngx.exec).was_called_with(value.upstream_location)
+            end
+        end)
+
         it('skips executing the upstream location when missing', function()
             local upstream = Upstream.new('http://localhost')
             upstream.location_name = nil

--- a/t/apicast-policy-request-unbuffered.t
+++ b/t/apicast-policy-request-unbuffered.t
@@ -1,0 +1,210 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+sub large_body {
+  my $res = "";
+  for (my $i=0; $i <= 1024; $i++) {
+    $res = $res . "1111111 1111111 1111111 1111111\n";
+  }
+  return $res;
+}
+
+$ENV{'LARGE_BODY'} = large_body();
+
+require("policies.pl");
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: request_unbuffered policy with big file
+--- configuration
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "request_unbuffered",
+            "version": "builtin",
+            "configuration": {}
+          },
+          {
+            "name": "apicast",
+            "version": "builtin",
+            "configuration": {}
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+--- upstream
+server_name test-upstream.lvh.me;
+  location / {
+    echo_read_request_body;
+    echo_request_body;
+  }
+--- request eval
+"POST /?user_key= \n" . $ENV{LARGE_BODY}
+--- response_body eval chomp
+$ENV{LARGE_BODY}
+--- error_code: 200
+--- grep_error_log
+a client request body is buffered to a temporary file
+--- grep_error_log_out
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: with small chunked request
+--- configuration
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "request_unbuffered",
+            "version": "builtin",
+            "configuration": {}
+          },
+          {
+            "name": "apicast",
+            "version": "builtin",
+            "configuration": {}
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+--- upstream
+server_name test-upstream.lvh.me;
+  location / {
+    access_by_lua_block {
+      assert = require('luassert')
+      ngx.say("yay, api backend")
+
+      -- Nginx will read the entire body in one chunk, the upstream request will not be chunked
+      -- and Content-Length header will be added.
+      local content_length = ngx.req.get_headers()["Content-Length"]
+      local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+      assert.equal('12', content_length)
+      assert.falsy(encoding, "chunked")
+    }
+  }
+--- more_headers
+Transfer-Encoding: chunked
+--- request eval
+"POST /test?user_key=value
+7\r
+hello, \r
+5\r
+world\r
+0\r
+\r
+"
+--- error_code: 200
+--- no_error_log
+[error]
+
+
+
+=== TEST 3: With big chunked request
+--- configuration
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "POST", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "request_unbuffered",
+            "version": "builtin",
+            "configuration": {}
+          },
+          {
+            "name": "apicast",
+            "version": "builtin",
+            "configuration": {}
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+location /transactions/authrep.xml {
+  content_by_lua_block {
+    ngx.exit(200)
+  }
+}
+--- upstream
+server_name test-upstream.lvh.me;
+  location / {
+    access_by_lua_block {
+      assert = require('luassert')
+      local content_length = ngx.req.get_headers()["Content-Length"]
+      local encoding = ngx.req.get_headers()["Transfer-Encoding"]
+      assert.equal('chunked', encoding)
+      assert.falsy(content_length)
+    }
+    echo_read_request_body;
+    echo_request_body;
+  }
+--- more_headers
+Transfer-Encoding: chunked
+--- request eval
+$::data = '';
+for (my $i = 0; $i < 16384; $i++) {
+    my $c = chr int rand 128;
+    $::data .= $c;
+}
+my $s = "POST https://localhost/test?user_key=value
+".
+sprintf("%x\r\n", length $::data).
+$::data
+."\r
+0\r
+\r
+";
+open my $out, '>/tmp/out.txt' or die $!;
+print $out $s;
+close $out;
+$s
+--- response_body eval
+$::data
+--- error_code: 200
+--- grep_error_log
+a client request body is buffered to a temporary file
+--- grep_error_log_out
+--- no_error_log
+[error]

--- a/t/apicast-policy-request-unbuffered.t
+++ b/t/apicast-policy-request-unbuffered.t
@@ -61,9 +61,10 @@ server_name test-upstream.lvh.me;
 --- response_body eval chomp
 $ENV{LARGE_BODY}
 --- error_code: 200
---- grep_error_log
-a client request body is buffered to a temporary file
+--- grep_error_log eval
+qr/a client request body is buffered to a temporary file/
 --- grep_error_log_out
+a client request body is buffered to a temporary file
 --- no_error_log
 [error]
 
@@ -107,7 +108,6 @@ server_name test-upstream.lvh.me;
   location / {
     access_by_lua_block {
       assert = require('luassert')
-      ngx.say("yay, api backend")
 
       -- Nginx will read the entire body in one chunk, the upstream request will not be chunked
       -- and Content-Length header will be added.
@@ -116,6 +116,8 @@ server_name test-upstream.lvh.me;
       assert.equal('12', content_length)
       assert.falsy(encoding, "chunked")
     }
+    echo_read_request_body;
+    echo_request_body;
   }
 --- more_headers
 Transfer-Encoding: chunked
@@ -128,6 +130,8 @@ world\r
 0\r
 \r
 "
+--- response_body chomp
+hello, world
 --- error_code: 200
 --- no_error_log
 [error]
@@ -203,8 +207,9 @@ $s
 --- response_body eval
 $::data
 --- error_code: 200
---- grep_error_log
-a client request body is buffered to a temporary file
+--- grep_error_log eval
+qr/a client request body is buffered to a temporary file/
 --- grep_error_log_out
+a client request body is buffered to a temporary file
 --- no_error_log
 [error]


### PR DESCRIPTION
### What

As part of https://issues.redhat.com/browse/THREESCALE-9542, this PR adds a new buffering policy which enable users to disable request buffering for use cases which call for it (namely, large payloads using HTTP 1.1 chunked encoding).
(Note: currently only support use case with no proxy between APIcast and upstream).

By default that the request buffer is true (which is the same as before). Users can now turn the request buffering off per service.

When request buffering is disabled, nginx will forward request body to upstream ASAP. 

### Verification steps

* Expose port 8080 from dev image docker-compose-devel.yml

```                                                                    
version: '2.2'                                                               
services:                                                                    
   ....   
    expose:                                                                  
      - "8080" 
    ports:                                                                   
      - "8080:8080" 
  redis:                                                                     
    image: redis                                                             
```

* Generate a APICast configuration file

```
▲ ~ cat <<EOF >apicast-config-buffering.json
{
  "services": [
    {
      "id": "1",
      "backend_version": "1",
      "proxy": {
        "hosts": ["one"],
        "api_backend": "https://postman-echo.com/post",
        "backend": {
          "endpoint": "http://127.0.0.1:8081",
          "host": "backend"
        },
        "policy_chain": [
          {
            "name": "apicast.policy.buffering",
            "configuration": {
              "request_buffering": false
            }
          },
          {
            "name": "apicast.policy.apicast"
          }
        ],
        "proxy_rules": [
          {
            "http_method": "POST",
            "pattern": "/",
            "metric_system_name": "hits",
            "delta": 1,
            "parameters": [],
            "querystring_parameters": {}
          }
        ]
      }
    }
  ]
}
EOF
```

* Start APICast
```
▲ ~ make development

bash-4.4$ APICAST_LOG_LEVEL=info \
     APICAST_WORKERS=1 \
     APICAST_CONFIGURATION_LOADER=lazy \
     APICAST_CONFIGURATION_CACHE=0 \
     APICAST_CACHE_MAX_TIME=60m \
     THREESCALE_DEPLOYMENT_ENV=staging \
     THREESCALE_CONFIG_FILE=apicast-config-buffering.json \
     ./bin/apicast
```

* On another terminal window, get APIcast IP
```
▲ ~ docker ps
CONTAINER ID   IMAGE                                               COMMAND                  CREATED        STATUS          PORTS      NAMES
b296d42cd090   quay.io/3scale/apicast-ci:openresty-1.19.3-pr1379   "cat"                    40 hours ago   Up 42 minutes   8080/tcp   apicast_build_0-development-1
66b01064a328   redis                                               "docker-entrypoint.s…"   40 hours ago   Up 42 minutes   6379/tcp   apicast_build_0-redis-1

▲ ~ APICAST_IP=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' apicast_build_0-development-1)
```

* Send a chunked request to APICast

```
▲ ~ curl -X POST -H "Host: one" -H "Transfer-Encoding: chunked" -d "hello world" http://${APICAST_IP}:8080?user_key= -v

Note: Unnecessary use of -X or --request, POST is already inferred.
* Rebuilt URL to: http://172.18.0.3:8080/?user_key=
*   Trying 172.18.0.3...
* TCP_NODELAY set
* Connected to 172.18.0.3 (172.18.0.3) port 8080 (#0)
> POST /?user_key= HTTP/1.1
> Host: one
> User-Agent: curl/7.61.1
> Accept: */*
> Transfer-Encoding: chunked
> Content-Type: application/x-www-form-urlencoded
>
> b
* upload completely sent off: 18 out of 11 bytes
< HTTP/1.1 200 OK
< Server: openresty
< Date: Fri, 29 Sep 2023 04:56:52 GMT
< Content-Type: application/json; charset=utf-8
< Content-Length: 519
< Connection: keep-alive
< ETag: W/"207-E3Zw8GywynTtA+pWygta+QpX/iE"
< set-cookie: sails.sid=s%3AHNaAy70f4ZxTdqL0JbduWyqKyDpKLvkd.amZZvuEujjMHLdAH88d1WQC%2BIHLlgIC4UFvtt4X6EwE; Path=/; HttpOnly
<
{
  "args": {
    "user_key": ""
  },
  "data": "",
  "files": {},
  "form": {
    "hello world": ""
  },
  "headers": {
    "x-forwarded-proto": "https",
    "x-forwarded-port": "443",
    "host": "postman-echo.com",
    "x-amzn-trace-id": "Root=1-65165913-499dff523f8d21ae49c82810",
    "content-length": "11",
    "user-agent": "curl/7.61.1",
    "accept": "*/*",
    "content-type": "application/x-www-form-urlencoded"
  },
  "json": {
    "hello world": ""
  },
  "url": "https://postman-echo.com/post?user_key="
* Connection #0 to host 172.18.0.3 left intact
}%
```

The upstream return `200` with `Content-Length` header

* Generate a big enough file

```
▲ ~ fallocate -l 1k bigfile
```

* Send another request with the file just created.
```
▲ ~ curl -X POST -H "Host: one" -H "Transfer-Encoding: chunked" -F file=@bigfile http://${APICAST_IP}:8080\?user_key\= -v

Note: Unnecessary use of -X or --request, POST is already inferred.
* Rebuilt URL to: http://172.18.0.3:8080/?user_key=
*   Trying 172.18.0.3...
* TCP_NODELAY set
* Connected to 172.18.0.3 (172.18.0.3) port 8080 (#0)
> POST /?user_key= HTTP/1.1
> Host: one
> User-Agent: curl/7.61.1
> Accept: */*
> Transfer-Encoding: chunked
> Content-Type: multipart/form-data; boundary=------------------------75222875ca38fe83
> Expect: 100-continue
>
< HTTP/1.1 100 Continue
* Signaling end of chunked upload via terminating chunk.
< HTTP/1.1 200 OK
< Server: openresty
< Date: Fri, 29 Sep 2023 05:36:30 GMT
< Content-Type: application/json; charset=utf-8
< Content-Length: 1398679
< Connection: keep-alive
< ETag: W/"155797-TOcX0o2gapOIAVRTgw4rQelFlTk"
< set-cookie: sails.sid=s%3A2aN1_2w7ZtrrN0vfAxb3vnS_YZbijWNm.Dn29qUNy274GfKY1L%2BV1VfuAMxfzDaq7Ua2xbMs600M; Path=/; HttpOnly
<
{
  "args": {
    "user_key": ""
  },
  "data": {},
  "files": {
    "filename": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
...
=="
  },
  "form": {},
  "headers": {
    "x-forwarded-proto": "https",
    "x-forwarded-port": "443",
    "host": "postman-echo.com",
    "x-amzn-trace-id": "Root=1-6516625b-4f7d069c20a9c6584473507c",
    "transfer-encoding": "chunked",
    "user-agent": "curl/7.61.1",
    "accept": "*/*",
    "content-type": "multipart/form-data; boundary=------------------------75222875ca38fe83"
  },
  "json": null,
  "url": "https://postman-echo.com/post?user_key="
* Connection #0 to host 172.18.0.3 left intact
}%
```

This time we can see that upstream return `200` with `"transfer-encoding": "chunked"` header

