### PR TITLE
[THREESCALE-4393] Add support to use Basic Authentication with the forward proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Detect number of CPU shares when running on Cgroups V2 [PR #1410](https://github.com/3scale/apicast/pull/1410) [THREESCALE-10167](https://issues.redhat.com/browse/THREESCALE-10167)
+### Added
+
+* Add support to use Basic Authentication with the forward proxy. [PR #1409](https://github.com/3scale/APIcast/pull/1409)
 
 ## [3.14.0] 2023-07-25
 

--- a/gateway/src/apicast/http_proxy.lua
+++ b/gateway/src/apicast/http_proxy.lua
@@ -167,7 +167,10 @@ function _M.request(upstream, proxy_uri)
         -- Only set "Proxy-Authorization" when sending HTTP request. When sent over HTTPS,
         -- the `Proxy-Authorization` header must be sent in the CONNECT request as the proxy has
         -- no visibility into the tunneled request.
-        if not ngx.var.http_proxy_authorization and proxy_auth then
+        --
+        -- Also DO NOT set the header if using the camel proxy to avoid unintended leak of
+        -- Proxy-Authorization header in requests
+        if not ngx.var.http_proxy_authorization and proxy_auth and not upstream.skip_https_connect then
             ngx.req.set_header("Proxy-Authorization", proxy_auth)
         end
 

--- a/gateway/src/apicast/http_proxy.lua
+++ b/gateway/src/apicast/http_proxy.lua
@@ -157,7 +157,7 @@ end
 function _M.request(upstream, proxy_uri)
     local uri = upstream.uri
 
-    if not ngx.var.proxy_authorization then
+    if not ngx.var.http_proxy_authorization then
         if proxy_uri.user or proxy_uri.password then
             local proxy_auth = "Basic " .. ngx.encode_base64(concat({ proxy_uri.user or '', proxy_uri.password or '' }, ':'))
             ngx.req.set_header("Proxy-Authorization", proxy_auth)

--- a/gateway/src/apicast/policy/http_proxy/Readme.md
+++ b/gateway/src/apicast/policy/http_proxy/Readme.md
@@ -54,8 +54,8 @@ The policy expect the URLS following the `http://[<username>[:<passwd>]@]<host>[
       "name": "apicast.policy.http_proxy",
       "configuration": {
           "all_proxy": "http://foo:bar@192.168.15.103:8888/",
-          "https_proxy": "https://foo:bar@192.168.15.103:8888/",
-          "http_proxy": "https://foo:bar@192.168.15.103:8888/"
+          "https_proxy": "http://foo:bar@192.168.15.103:8888/",
+          "http_proxy": "http://foo:bar@192.168.15.103:8888/"
       }
     }
 ]

--- a/gateway/src/apicast/policy/http_proxy/Readme.md
+++ b/gateway/src/apicast/policy/http_proxy/Readme.md
@@ -43,6 +43,8 @@ used.
 
 ## Configuration
 
+The policy expect the URLS following the `http://[<username>[:<passwd>]@]<host>[:<port>]` format, e.g.:
+
 ```
 "policy_chain": [
     {
@@ -51,15 +53,17 @@ used.
     {
       "name": "apicast.policy.http_proxy",
       "configuration": {
-          "all_proxy": "http://192.168.15.103:8888/",
-          "https_proxy": "https://192.168.15.103:8888/",
-          "http_proxy": "https://192.168.15.103:8888/"
+          "all_proxy": "http://foo:bar@192.168.15.103:8888/",
+          "https_proxy": "https://foo:bar@192.168.15.103:8888/",
+          "http_proxy": "https://foo:bar@192.168.15.103:8888/"
       }
     }
 ]
 ```
 
-- If http_proxy or https_proxy is not defined the all_proxy will be taken. 
+- If http_proxy or https_proxy is not defined the all_proxy will be taken.
+- The policy supports for proxy authentication via the `<username>` and `<passwd>` options.
+- The `<username>` and `<passwd>` are optional, all other components are required.
 
 ## Caveats
 
@@ -67,7 +71,7 @@ used.
   always send to the proxy. 
 - In case of HTTP_PROXY, HTTPS_PROXY or ALL_PROXY parameters are defined, this
   policy will overwrite those values. 
-- Proxy connection does not support authentication.
+- 3scale currently does not support connecting to an HTTP proxy via TLS. For this reason, the scheme of the HTTPS_PROXY value is restricted to http.
 
 
 ## Example Use case

--- a/gateway/src/resty/http/proxy.lua
+++ b/gateway/src/resty/http/proxy.lua
@@ -61,7 +61,7 @@ local function _connect_proxy_https(httpc, request, host, port)
         path = format('%s:%s', host, port or default_port(uri)),
         headers = {
             ['Host'] = request.headers.host or format('%s:%s', uri.host, default_port(uri)),
-            ['Proxy-Authorization'] = request.headers["Proxy-Authorization"] or ''
+            ['Proxy-Authorization'] = request.proxy_auth or ''
         }
     })
     if not res then return nil, err end

--- a/t/apicast-policy-http-proxy.t
+++ b/t/apicast-policy-http-proxy.t
@@ -244,13 +244,11 @@ server_name test-upstream.lvh.me;
 GET /?user_key=value
 --- error_code: 200
 --- error_log env
-proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
---- error_log env
 using proxy: http://foo:bar@127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT
 
 
 === TEST 5: using all_proxy with Basic Auth
---- configuration
+--- configuration random_port env
 {
   "services": [
     {
@@ -296,8 +294,6 @@ server_name test-upstream.lvh.me;
 --- request
 GET /?user_key=value
 --- error_code: 200
---- error_log env
-proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
 --- error_log env
 using proxy: http://foo:bar@127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT
 
@@ -347,16 +343,16 @@ location /test {
     echo_end;
 
     access_by_lua_block {
-      assert = require('luassert')
+      local assert = require('luassert')
       local proxy_auth = ngx.req.get_headers()['Proxy-Authorization']
-      assert.equals(proxy_auth, "Basic Zm9vOmJhcg==")
+      assert.falsy(proxy_auth)
     }
 }
 --- request
 GET /test?user_key=test3
 --- error_code: 200
---- error_log env
-proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
 --- user_files fixture=tls.pl eval
 --- error_log env
 using proxy: http://foo:bar@127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+got header line: Proxy-Authorization: Basic Zm9vOmJhcg==

--- a/t/apicast-policy-http-proxy.t
+++ b/t/apicast-policy-http-proxy.t
@@ -234,17 +234,14 @@ using proxy: $TEST_NGINX_HTTPS_PROXY
 --- upstream
 server_name test-upstream.lvh.me;
   location / {
-    access_by_lua_block {
-      local assert = require('luassert')
-      local proxy_auth = ngx.req.get_headers()['Proxy-Authorization']
-      assert.equals(proxy_auth, "Basic Zm9vOmJhcg==")
-    }
+    echo 'yay, api backend!';
   }
 --- request
 GET /?user_key=value
 --- error_code: 200
 --- error_log env
 using proxy: http://foo:bar@127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT
+proxy http request - got header line: Proxy-Authorization: Basic Zm9vOmJhcg==
 
 
 === TEST 5: using all_proxy with Basic Auth

--- a/t/apicast-policy-http-proxy.t
+++ b/t/apicast-policy-http-proxy.t
@@ -194,3 +194,169 @@ proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
 --- user_files fixture=tls.pl eval
 --- error_log env
 using proxy: $TEST_NGINX_HTTPS_PROXY
+
+
+=== TEST 4: using HTTP proxy with Basic Auth
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.http_proxy",
+            "configuration": {
+                "http_proxy": "http://foo:bar@127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+server_name test-upstream.lvh.me;
+  location / {
+    access_by_lua_block {
+      local assert = require('luassert')
+      local proxy_auth = ngx.req.get_headers()['Proxy-Authorization']
+      assert.equals(proxy_auth, "Basic Zm9vOmJhcg==")
+    }
+  }
+--- request
+GET /?user_key=value
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- error_log env
+using proxy: http://foo:bar@127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT
+
+
+=== TEST 5: using all_proxy with Basic Auth
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.http_proxy",
+            "configuration": {
+                "all_proxy": "http://foo:bar@127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+server_name test-upstream.lvh.me;
+  location / {
+    access_by_lua_block {
+      local assert = require('luassert')
+      local proxy_auth = ngx.req.get_headers()['Proxy-Authorization']
+      assert.equals(proxy_auth, "Basic Zm9vOmJhcg==")
+    }
+  }
+--- request
+GET /?user_key=value
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- error_log env
+using proxy: http://foo:bar@127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT
+
+
+=== TEST 6: using HTTPS proxy with Basic Auth
+--- configuration random_port env
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT",
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "apicast.policy.http_proxy",
+            "configuration": {
+                "https_proxy": "http://foo:bar@127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream env
+server_name test-upstream.lvh.me;
+listen $TEST_NGINX_RANDOM_PORT ssl;
+
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+location /test {
+    echo_foreach_split '\r\n' $echo_client_request_headers;
+    echo $echo_it;
+    echo_end;
+
+    access_by_lua_block {
+      assert = require('luassert')
+      local proxy_auth = ngx.req.get_headers()['Proxy-Authorization']
+      assert.equals(proxy_auth, "Basic Zm9vOmJhcg==")
+    }
+}
+--- request
+GET /test?user_key=test3
+--- error_code: 200
+--- error_log env
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+--- user_files fixture=tls.pl eval
+--- error_log env
+using proxy: http://foo:bar@127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT

--- a/t/fixtures/proxy.lua
+++ b/t/fixtures/proxy.lua
@@ -113,6 +113,7 @@ local function forward_http_stream(sock, upstream)
         send(upstream, header_line)
 
         local header = re_match(header_line, [[(?<name>[^:\s]+):\s*(?<value>.+)\r\n$]])
+        ngx.log(ngx.DEBUG, 'proxy http request - got header line: ', header_line)
 
         if header and str_lower(header.name) == 'content-length' then
             body_length = tonumber(header.value)

--- a/t/http-proxy.t
+++ b/t/http-proxy.t
@@ -1227,3 +1227,99 @@ proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
 --- no_error_log
 [error]
 --- user_files fixture=tls.pl eval
+
+
+=== TEST 23: upstream API connection uses http proxy with BasicAuth
+--- env eval
+(
+  "http_proxy" => "http://foo:bar\@127.0.0.1:$ENV{TEST_NGINX_HTTP_PROXY_PORT}",
+  'BACKEND_ENDPOINT_OVERRIDE' => "http://test_backend.lvh.me:$ENV{TEST_NGINX_SERVER_PORT}"
+)
+--- configuration
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+server_name test_backend.lvh.me;
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+server_name test-upstream.lvh.me;
+  location / {
+    access_by_lua_block {
+      local assert = require('luassert')
+      local proxy_auth = ngx.req.get_headers()['Proxy-Authorization']
+      assert.equals(proxy_auth, "Basic Zm9vOmJhcg==")
+    }
+  }
+--- request
+GET /?user_key=value
+--- error_code: 200
+--- error_log env
+using proxy: http://foo:bar@127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT
+--- no_error_log
+[error]
+
+
+=== TEST 24: upstream API connection uses proxy for https with BasicAuth
+--- env eval
+(
+  "https_proxy" => "http://foo:bar\@127.0.0.1:$ENV{TEST_NGINX_HTTP_PROXY_PORT}",
+  'BACKEND_ENDPOINT_OVERRIDE' => "http://test_backend.lvh.me:$ENV{TEST_NGINX_SERVER_PORT}"
+)
+--- configuration random_port env
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+server_name test_backend.lvh.me;
+
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream env
+server_name test-upstream.lvh.me;
+
+listen $TEST_NGINX_RANDOM_PORT ssl;
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+location / {
+    echo_foreach_split '\r\n' $echo_client_request_headers;
+    echo $echo_it;
+    echo_end;
+}
+--- request
+GET /test?user_key=test3
+--- error_code: 200
+--- error_log env
+using proxy: http://foo:bar@127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+got header line: Proxy-Authorization: Basic Zm9vOmJhcg==
+--- no_error_log
+[error]
+--- user_files fixture=tls.pl eval

--- a/t/http-proxy.t
+++ b/t/http-proxy.t
@@ -1259,17 +1259,14 @@ server_name test_backend.lvh.me;
 --- upstream
 server_name test-upstream.lvh.me;
   location / {
-    access_by_lua_block {
-      local assert = require('luassert')
-      local proxy_auth = ngx.req.get_headers()['Proxy-Authorization']
-      assert.equals(proxy_auth, "Basic Zm9vOmJhcg==")
-    }
+    echo 'yay, api backend!';
   }
 --- request
 GET /?user_key=value
 --- error_code: 200
 --- error_log env
 using proxy: http://foo:bar@127.0.0.1:$TEST_NGINX_HTTP_PROXY_PORT
+proxy http request - got header line: Proxy-Authorization: Basic Zm9vOmJhcg==
 --- no_error_log
 [error]
 


### PR DESCRIPTION
What

Fixes https://issues.redhat.com/browse/THREESCALE-4393

This PR support the use of Basic Auth with forward proxy in the following scenarios:
* `APIcast <> forward HTTP proxy with Basic Auth <> HTTP upstream`
* `APIcast <> forward HTTP proxy with Basic Auth <> HTTPS upstream`

## Verification steps 

* Add the following line to `examples/forward-proxy/tinyproxy.conf`

```
BasicAuth foo bar
```

### APIcast <> forward HTTP proxy with Basic Auth <> HTTP upstream

* Update `examples/forward-proxy/apicast-config.json` with the following:

```
{                                                             
    "services": [                                             
        {                                                     
            "backend_version": "1",                           
            "proxy": {                                        
                "hosts": ["one"],                             
                "api_backend": "http://postman-echo.com",       
                "backend": {                                  
                    "endpoint": "http://127.0.0.1:8081",      
                    "host": "backend"                         
                },                                            
                "policy_chain": [                             
                    {                                         
                        "name": "apicast.policy.apicast"      
                    },                                        
                    {                                         
                        "name": "apicast.policy.http_proxy",  
                        "configuration": {                    
                            "http_proxy": "http://foo:bar@proxy:443/"
                        }                                     
                    }                                         
                ],                                            
                "proxy_rules": [                              
                    {                                         
                        "http_method": "GET",                 
                        "pattern": "/",                       
                        "metric_system_name": "hits",         
                        "delta": 1,                           
                        "parameters": [],                     
                        "querystring_parameters": {}          
                    }                                         
                ]                                             
            }                                                 
        }                                                     
    ]                                                         
}                                                             
```

* run `docker-compose.forward-proxy.yml`

```
make forward-proxy-gateway
```

* Get APIcast IP

```
❯ docker ps
CONTAINER ID   IMAGE                   COMMAND                  CREATED          STATUS         PORTS                NAMES
bab24ff74d69   apicast-test            "container-entrypoin…"   9 seconds ago    Up 9 seconds   8080/tcp, 8090/tcp   apicast_build_0-gateway-run-a32123385dce
dec323e010f9   nginx:1.23.4            "/docker-entrypoint.…"   10 seconds ago   Up 9 seconds   80/tcp, 443/tcp      apicast_build_0-upstream-1
a0b1ffe5b514   apicast_build_0-proxy   "/usr/bin/tinyproxy …"   10 seconds ago   Up 9 seconds   0/tcp                apicast_build_0-proxy-1

❯ APICAST_IP=$(docker inspect apicast_build_0-gateway-run-a32123385dce | yq e -P '.[0].NetworkSettings.Networks.apicast_build_0_default.IPAddress' -)
```

* Send request to APICast

```
❯ curl -v -H "Host: one" http://${APICAST_IP}:8080/get?user_key=foo
*   Trying 127.0.0.1...                                                                                                         
* TCP_NODELAY set                                                                                                               
* Connected to localhost (127.0.0.1) port 8080 (#0)                                                                             
> GET /get?user_key= HTTP/1.1                                                                                                   
> Host: one                                                                                                                     
> User-Agent: curl/7.61.1                                                                                                       
> Accept: */*                                                                                                                   
>                                                                                                                               
< HTTP/1.1 200 OK                                                                                                               
< Server: openresty                                                                                                             
< Date: Thu, 31 Aug 2023 06:12:41 GMT                                                                                           
< Content-Type: application/json; charset=utf-8                                                                                 
< Content-Length: 370                                                                                                           
< Connection: keep-alive                                                                                                        
< Via: 1.1 tinyproxy (tinyproxy/1.11.1)                                                                                         
< ETag: W/"172-1BPDY6s8yDG5TJHwqYbKsiphJMI"                                                                                     
< set-cookie: sails.sid=s%3AnwD0yJG_9FLjXIev7zU9n_6U3CFFN5KD.QOtPZ4Jy84tU46c8%2FiYS%2FCsaolhffNCqFLeGPbcH%2FcM; Path=/; HttpOnly
<                                                                                                                               
{                                                                                                                               
  "args": {                                                                                                                     
    "user_key": ""                                                                                                              
  },                                                                                                                            
  "headers": {                                                                                                                  
    "x-forwarded-proto": "http",                                                                                                
    "x-forwarded-port": "80",                                                                                                   
    "host": "postman-echo.com",                                                                                                 
    "x-amzn-trace-id": "Root=1-64f02f59-455a8e1e1cf53ad137ba4e7a",                                                              
    "via": "1.1 tinyproxy (tinyproxy/1.11.1)",                                                                                  
    "user-agent": "curl/7.61.1",                                                                                                
    "accept": "*/*"                                                                                                             
  },                                                                                                                            
  "url": "http://postman-echo.com/get?user_key="                                                                                
* Connection #0 to host localhost left intact                                                                                   
                                                                                                 
```

We can see that the the request is going through the proxy

### APIcast <> forward HTTP proxy with Basic Auth <> HTTPS upstream

* Update `examples/forward-proxy/apicast-config.json` with the following:

```
{                                                             
    "services": [                                             
        {                                                     
            "backend_version": "1",                           
            "proxy": {                                        
                "hosts": ["one"],                             
                "api_backend": "https://postman-echo.com",       
                "backend": {                                  
                    "endpoint": "http://127.0.0.1:8081",      
                    "host": "backend"                         
                },                                            
                "policy_chain": [                             
                    {                                         
                        "name": "apicast.policy.apicast"      
                    },                                        
                    {                                         
                        "name": "apicast.policy.http_proxy",  
                        "configuration": {                    
                            "https_proxy": "http://foo:bar@proxy:443/"
                        }                                     
                    }                                         
                ],                                            
                "proxy_rules": [                              
                    {                                         
                        "http_method": "GET",                 
                        "pattern": "/",                       
                        "metric_system_name": "hits",         
                        "delta": 1,                           
                        "parameters": [],                     
                        "querystring_parameters": {}          
                    }                                         
                ]                                             
            }                                                 
        }                                                     
    ]                                                         
}                                                             
```

* run `docker-compose.forward-proxy.yml`

```
make forward-proxy-gateway
```

* Get APIcast IP

```
❯ docker ps
CONTAINER ID   IMAGE                   COMMAND                  CREATED          STATUS         PORTS                NAMES
f0b18fa16dda   apicast-test            "container-entrypoin…"   9 seconds ago    Up 9 seconds   8080/tcp, 8090/tcp   apicast_build_0-gateway-run-a32123385dce
7b3107db8aa4   nginx:1.23.4            "/docker-entrypoint.…"   10 seconds ago   Up 9 seconds   80/tcp, 443/tcp      apicast_build_0-upstream-1
f0b18fa16dda   apicast_build_0-proxy   "/usr/bin/tinyproxy …"   10 seconds ago   Up 9 seconds   0/tcp                apicast_build_0-proxy-1

❯ APICAST_IP=$(docker inspect apicast_build_0-gateway-run-a32123385dce | yq e -P '.[0].NetworkSettings.Networks.apicast_build_0_default.IPAddress' -)
```

* Send request to APICast

```
❯ curl -v -H "Host: one" http://${APICAST_IP}:8080/get?user_key=foo
*   Trying 127.0.0.1...                                                                                                            
* TCP_NODELAY set                                                                                                                  
* Connected to localhost (127.0.0.1) port 8080 (#0)                                                                                
> GET /get?user_key= HTTP/1.1                                                                                                      
> Host: one                                                                                                                        
> User-Agent: curl/7.61.1                                                                                                          
> Accept: */*                                                                                                                      
>                                                                                                                                  
< HTTP/1.1 200 OK                                                                                                                  
< Server: openresty                                                                                                                
< Content-Type: application/json; charset=utf-8                                                                                    
< Transfer-Encoding: chunked                                                                                                       
< Connection: keep-alive                                                                                                           
< set-cookie: sails.sid=s%3ALAz2UZyLXVxBZ8VY2XjC90y0N54Mk_JV.xJ0meVF%2F1%2FEP1m7BY0SZ9jNQ%2FLaIl3jaoHHsxH%2FPIhQ; Path=/; HttpOnly 
< Date: Thu, 31 Aug 2023 06:11:54 GMT                                                                                              
< ETag: W/"146-Gpco5rr4Zu8qMK21l8EJcRbPeqI"                                                                                        
<                                                                                                                                  
{                                                                                                                                  
  "args": {                                                                                                                        
    "user_key": ""                                                                                                                 
  },                                                                                                                               
  "headers": {                                                                                                                     
    "x-forwarded-proto": "https",                                                                                                  
    "x-forwarded-port": "443",                                                                                                     
    "host": "postman-echo.com",                                                                                                    
    "x-amzn-trace-id": "Root=1-64f02f2a-2403dd5e6c8931eb1878f63e",                                                                 
    "user-agent": "curl/7.61.1",                                                                                                   
    "accept": "*/*"                                                                                                                
  },                                                                                                                               
  "url": "https://postman-echo.com/get?user_key="                                                                                  
* Connection #0 to host localhost left intact                                                                                      

```

We can see that the the request is going through the proxy
