### PR TITLE
JWT claim check policy: uri was not escape correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed token instrospection field removed [PR #1438](https://github.com/3scale/APIcast/pull/1438) [THREESCALE-10591](https://issues.redhat.com/browse/THREESCALE-10591)
 
+- Fixed issue with URL was not correctly escaped when using the JWT claim check policy [THREESCALE-10308](https://issues.redhat.com/browse/THREESCALE-10308) [PR #1428](https://github.com/3scale/APIcast/pull/1428)
+
 ### Added
 
 - Detect number of CPU shares when running on Cgroups V2 [PR #1410](https://github.com/3scale/apicast/pull/1410) [THREESCALE-10167](https://issues.redhat.com/browse/THREESCALE-10167)


### PR DESCRIPTION
### What:

Fix [THREESCALE-10308](https://issues.redhat.com/browse/THREESCALE-10308)

The uri was not escaped correctly with JWT claim check policy so the mapping rule will not work as expected.

For example: Mapping rule: `/api/{id}/whatever` is supposed to match `/api/  123/whatever` and perform the JWT token check but due to the special character (space) the request will not match on resource and APIcast  
skips the JWT token check.

### Comparison the behavior before and after this PR

* Mapping rule with capture group

Mapping rule:  `/foo{id}/bar`

Request | Direct to APICast | JWT Claim Check policy | PR#1428
-- | -- | -- | --
GET /foo/bar | False | False | False
GET /foo1/bar | True | True | True
GET /foo%201/bar | True | False | True

* Mapping rule with % character

Mapping rule:  `/foo%20/bar`

Request | Direct to APICast | JWT Claim Check policy | PR#1428
-- | -- | -- | --
GET /foo/bar | False | False | False
GET /foo1/bar | False | False | False
GET /foo%20/bar | True | False | True

* Normal mapping rule

Mapping rule:  `/foo/bar`

Request | Direct to APICast | JWT Claim Check policy | PR#1428
-- | -- | -- | --
GET /foo/bar | True | True | True
GET /foo1/bar | False | False | False
GET /foo%20/bar | False | False | False

With:

`True`   : mapping rules match<br>
`False` : mapping rules do not match</p>

                          
### Verification steps

* Setup Keycloak instance, realms, clients and users
* Install 3scale
    * [Integrating 3scale with Red Hat Single Sign-On as the OpenID Connect identity provider](https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.13/html/administering_the_api_gateway/integrating-threescale-with-an-openid-connect-identity-provider#integrating-threescale-with-rhsso-as-the-openid-connect-identity-provider_oidc)
* Configure a single Product A with an OpenID Provider + realm A and with the following mapping rule
```
/groups/{groupid}/foo$
```
* Configure a JWT Claim check policy with the following:
```
{                                                                           
  "name": "apicast.policy.jwt_claim_check",                                 
  "configuration": {                                                         
    "rules" : [{                                                             
        "operations": [                                                     
            {"op": "matches", "jwt_claim": "{{roles | join: '|'}}", "jwt_claim_type": "liquid",
            "value": "invalid"}                               
        ],                                                                   
        "combine_op": "and",                                                 
        "methods": ["GET"],                                                 
        "resource": "/groups/{groupid}/foo$"           
    }]                                                                       
  }
},     
```
* Start dev environment                                                
```
make development
make dependencies
```
* Run apicast locally
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=debug APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=lazy APICAST_CONFIGURATION_CACHE=0 THREESCALE_PORTAL_ENDPOINT=https://token@3scale-admin.example.com ./bin/apicast
```
* Generate token from a realm A
* Run query with the valid jwt
```
# capture apicast IP
APICAST_IP=$(docker inspect apicast_build_0-development-1 | yq e -P '.[0].NetworkSettings.Networks.apicast_build_0_default.IPAddress' -)

curl -v -k -H "Host: example.com:443" -H "Accept: application/json" -H "Authorization: Bearer ${ACCESS_TOKEN}" "http://${APICAST_IP}:8080/groups/%201/foo"
```

* The response should be HTTP/1.1 403 Forbidden
```
< HTTP/1.1 403 Forbidden                     
< Server: openresty                          
< Date: Tue, 28 Nov 2023 02:44:27 GMT        
< Content-Type: text/plain                   
< Transfer-Encoding: chunked                 
< Connection: keep-alive                     
<                                            
Request blocked due to JWT claim policy      
* Connection #0 to host 127.0.0.1 left intact
```