### PR TITLE
[WIP] THREESCALE-10164 Including the env var LARGE_CLIENT_HEADER_BUFFERS

### DIFF
--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -478,6 +478,13 @@ connections.
 By default Gateway does not enable it, and the keepalive timeout on nginx is set
 to [75 seconds](http://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_timeout)
 
+### `LARGE_CLIENT_HEADER_BUFFERS`
+
+**Default:** 4 8k
+**Value:** string
+
+Sets the maximum number and size of buffers used for reading large client request header. A request line cannot exceed the size of one buffer, or the 414 (Request-URI Too Large) error is returned to the client. A request header field cannot exceed the size of one buffer as well, or the 400 (Bad Request) error is returned to the client. Buffers are allocated only on demand. By default, the buffer size is equal to [8K](http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers) bytes. If after the end of request processing a connection is transitioned into the keep-alive state, these buffers are released.
+
 
 ### `APICAST_CACHE_STATUS_CODES`
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -483,7 +483,7 @@ to [75 seconds](http://nginx.org/en/docs/http/ngx_http_core_module.html#keepaliv
 **Default:** 4 8k
 **Value:** string
 
-Sets the maximum number and size of buffers used for reading large client request header. A request line cannot exceed the size of one buffer, or the 414 (Request-URI Too Large) error is returned to the client. A request header field cannot exceed the size of one buffer as well, or the 400 (Bad Request) error is returned to the client. Buffers are allocated only on demand. By default, the buffer size is equal to [8K](http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers) bytes. If after the end of request processing a connection is transitioned into the keep-alive state, these buffers are released.
+This environment variable sets the maximum number and size of buffers for reading large client request headers. A request line cannot exceed the size of one buffer, or the client receives a 414 (Request-URI Too Large) error. A request header field cannot exceed the size of one buffer or the client receives a 400 (Bad Request) error. Buffers are allocated only when necessary, with a default size of [8K](http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers) bytes. After processing a request, if the connection transitions into the keep-alive state, these buffers are released.
 
 
 ### `APICAST_CACHE_STATUS_CODES`

--- a/gateway/src/apicast/cli/environment.lua
+++ b/gateway/src/apicast/cli/environment.lua
@@ -129,6 +129,7 @@ _M.default_environment = 'production'
 -- @tfield ?string opentelemetry_config_file opentelemetry config file to load
 -- @tfield ?string upstream_retry_cases error cases where the call to the upstream should be retried
 --         follows the same format as https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream
+-- @tfield ?string large_client_header_buffers sets the maximum number and size of buffers used for reading large client request header
 -- @tfield ?policy_chain policy_chain @{policy_chain} instance
 -- @tfield ?{string,...} nameservers list of nameservers
 -- @tfield ?string package.path path to load Lua files
@@ -149,6 +150,7 @@ _M.default_config = {
     opentelemetry_config_file = env_value_ref('OPENTELEMETRY_CONFIG'),
     upstream_retry_cases = env_value_ref('APICAST_UPSTREAM_RETRY_CASES'),
     http_keepalive_timeout = env_value_ref('HTTP_KEEPALIVE_TIMEOUT'),
+    large_client_header_buffers = env_value_ref('LARGE_CLIENT_HEADER_BUFFERS'),
     policy_chain = require('apicast.policy_chain').default(),
     nameservers = parse_nameservers(),
     worker_processes = cpus() or 'auto',


### PR DESCRIPTION
Include `LARGE_CLIENT_HEADER_BUFFERS` var to my first contribution on APICast.

Fixes https://issues.redhat.com/browse/THREESCALE-10164