### PR TITLE
resolver.t conversion to APIcast::Blackbox

### DIFF
--- a/gateway/http.d/init.conf
+++ b/gateway/http.d/init.conf
@@ -58,7 +58,7 @@ init_by_lua_block {
       end
     end
 
-    require('resty.resolver').init()
+    -- require('resty.resolver').init()
 
     require('apicast.loader')
 

--- a/gateway/src/apicast/cli/environment.lua
+++ b/gateway/src/apicast/cli/environment.lua
@@ -28,7 +28,7 @@ local function parse_nameservers()
     local resolver = require('resty.resolver')
     local nameservers = {}
 
-    for _,nameserver in ipairs(resolver.init_nameservers()) do
+    for _,nameserver in ipairs(resolver.init_nameservers(resty_env.value('TEST_NGINX_RESOLV_CONF'))) do
         -- resty.resolver returns nameservers as tables with __tostring metamethod
         -- unfortunately those objects can't be joined with table.concat
         -- and have to be converted to strings first


### PR DESCRIPTION
This pull request is an almost complete one, but needs some discussion because:

- The variable name that specify a custom `resolv.conf` is `TEST_NGINX_RESOLV_CONF` and this will appear in code outside the tests (`gateway/http.d/init.conf` or `gateway/src/apicast/cli/environment.lua`);
- One of the `resty.resolver` calls is just commented inside `gateway/http.d/init.conf`.