### PR TITLE
configuration-loading-boot-without-config.t conversion Blackbox

### DIFF
--- a/t/configuration-loading-boot-without-config.t
+++ b/t/configuration-loading-boot-without-config.t
@@ -1,13 +1,8 @@
 use lib 't';
-use Test::APIcast 'no_plan';
+use Test::APIcast::Blackbox 'no_plan';
 
-$ENV{TEST_NGINX_HTTP_CONFIG} = "$Test::APIcast::path/http.d/init.conf";
-$ENV{APICAST_CONFIGURATION_LOADER} = 'boot';
-
-env_to_nginx(
-    'APICAST_CONFIGURATION_LOADER',
-    'TEST_NGINX_APICAST_PATH',
-    'THREESCALE_CONFIG_FILE'
+env_to_apicast(
+    'APICAST_CONFIGURATION_LOADER' => 'boot'
 );
 
 log_level('emerg');
@@ -17,12 +12,6 @@ __DATA__
 
 === TEST 1: require configuration on boot
 should exit with error if there is no configuration
---- http_config
-  include $TEST_NGINX_HTTP_CONFIG;
-  lua_package_path "$TEST_NGINX_LUA_PATH";
---- config
 --- must_die
---- request
-GET
 --- error_log
 failed to load configuration, exiting


### PR DESCRIPTION
Since the `Test::APIcast::Blackbox` loads the configuration trough `--- configuration` block all the stuff inside the script is no longer necessary, the simple absence of that block already causes the necessary effect.