### PR TITLE
THREESCALE-10582 fix integration of upstream connection policy with camel policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Docker compose up instead of docker compose run [PR #1442](https://github.com/3scale/APIcast/pull/1442)
 
+- Fix integration of upstream connection policy with camel policy [THREESCALE-10582](https://issues.redhat.com/browse/THREESCALE-10582) [PR #1443](https://github.com/3scale/APIcast/pull/1443)
+
 ### Added
 
 - Detect number of CPU shares when running on Cgroups V2 [PR #1410](https://github.com/3scale/apicast/pull/1410) [THREESCALE-10167](https://issues.redhat.com/browse/THREESCALE-10167)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Docker compose up instead of docker compose run [PR #1442](https://github.com/3scale/APIcast/pull/1442)
 
-- Fix integration of upstream connection policy with camel policy [THREESCALE-10582](https://issues.redhat.com/browse/THREESCALE-10582) [PR #1443](https://github.com/3scale/APIcast/pull/1443)
+- Fix integration of upstream connection policy with camel policy [PR #1443](https://github.com/3scale/APIcast/pull/1443) [THREESCALE-10582](https://issues.redhat.com/browse/THREESCALE-10582)
 
 ### Added
 

--- a/gateway/src/apicast/http_proxy.lua
+++ b/gateway/src/apicast/http_proxy.lua
@@ -146,7 +146,8 @@ local function forward_https_request(proxy_uri, uri, proxy_opts)
         path = format('%s%s%s', ngx.var.uri, ngx.var.is_args, ngx.var.query_string or ''),
         body = body,
         proxy_uri = proxy_uri,
-        proxy_auth = opts.proxy_auth
+        proxy_auth = opts.proxy_auth,
+        upstream_connection_opts = opts.upstream_connection_opts
     }
 
     local httpc, err = http_proxy.new(request, opts.skip_https_connect)
@@ -226,7 +227,8 @@ function _M.request(upstream, proxy_uri)
         local proxy_opts = {
             proxy_auth = proxy_auth,
             skip_https_connect = upstream.skip_https_connect,
-            request_unbuffered = upstream.request_unbuffered
+            request_unbuffered = upstream.request_unbuffered,
+            upstream_connection_opts = upstream.upstream_connection_opts
         }
 
         forward_https_request(proxy_uri, uri, proxy_opts)

--- a/gateway/src/apicast/http_proxy.lua
+++ b/gateway/src/apicast/http_proxy.lua
@@ -27,7 +27,6 @@ local DEFAULT_CHUNKSIZE = 32 * 1024
 
 function _M.reset()
     _M.resolver = resty_resolver
-    _M.http_backend = require('resty.http_ng.backend.resty')
     _M.dns_resolution = 'apicast' -- can be set to 'proxy' to let proxy do the name resolution
 
     return _M
@@ -147,10 +146,11 @@ local function forward_https_request(proxy_uri, uri, proxy_opts)
         body = body,
         proxy_uri = proxy_uri,
         proxy_auth = opts.proxy_auth,
-        upstream_connection_opts = opts.upstream_connection_opts
+        upstream_connection_opts = opts.upstream_connection_opts,
+        skip_https_connect = opts.skip_https_connect
     }
 
-    local httpc, err = http_proxy.new(request, opts.skip_https_connect)
+    local httpc, err = http_proxy.new(request)
 
     if not httpc then
         ngx.log(ngx.ERR, 'could not connect to proxy: ',  proxy_uri, ' err: ', err)

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -232,6 +232,7 @@ function _M:call(context)
         end
 
         self.request_unbuffered = context.request_unbuffered
+        self.upstream_connection_opts = context.upstream_connection_opts
         http_proxy.request(self, proxy_uri)
     else
         local err = self:rewrite_request()

--- a/gateway/src/resty/balancer.lua
+++ b/gateway/src/resty/balancer.lua
@@ -146,6 +146,8 @@ function _M:set_timeouts(connect_timeout, send_timeout, read_timeout)
 
   -- If one of the values is nil, the default applies:
   -- https://github.com/openresty/lua-resty-core/blob/master/lib/ngx/balancer.md#set_timeouts
+  ngx.log(ngx.DEBUG, 'setting timeouts (secs), connect_timeout: ', connect_timeout,
+    ' send_timeout: ', send_timeout, ' read_timeout: ', read_timeout)
   return ngx_balancer.set_timeouts(connect_timeout, send_timeout, read_timeout)
 end
 

--- a/gateway/src/resty/http/proxy.lua
+++ b/gateway/src/resty/http/proxy.lua
@@ -77,11 +77,12 @@ local function _connect_proxy_https(httpc, request, host, port)
     return httpc
 end
 
-local function connect_proxy(httpc, request, skip_https_connect)
+local function connect_proxy(httpc, request)
     -- target server requires hostname not IP and DNS resolution is left to the proxy itself as specified in the RFC #7231
     -- https://httpwg.org/specs/rfc7231.html#CONNECT
     local uri = request.uri
     local proxy_uri = request.proxy
+    local skip_https_connect = request.skip_https_connect
 
     if proxy_uri.scheme ~= 'http' then
         return nil, 'proxy connection supports only http'
@@ -131,7 +132,7 @@ local function find_proxy_url(request)
     return request.proxy_uri or _M.find(uri)
 end
 
-local function connect(request, skip_https_connect)
+local function connect(request)
     request = request or { }
     local opts = { timeouts = request.upstream_connection_opts }
     local httpc = http.new(opts)
@@ -141,7 +142,7 @@ local function connect(request, skip_https_connect)
     request.proxy = proxy_uri
 
     if proxy_uri then
-        return connect_proxy(httpc, request, skip_https_connect)
+        return connect_proxy(httpc, request)
     else
         return connect_direct(httpc, request)
     end

--- a/gateway/src/resty/http/proxy.lua
+++ b/gateway/src/resty/http/proxy.lua
@@ -132,7 +132,9 @@ local function find_proxy_url(request)
 end
 
 local function connect(request, skip_https_connect)
-    local httpc = http.new()
+    request = request or { }
+    local opts = { timeouts = request.upstream_connection_opts }
+    local httpc = http.new(opts)
     local proxy_uri = find_proxy_url(request)
 
     request.ssl_verify = request.options and request.options.ssl and request.options.ssl.verify

--- a/gateway/src/resty/resolver/http.lua
+++ b/gateway/src/resty/resolver/http.lua
@@ -8,8 +8,14 @@ local _M = setmetatable({}, { __index = resty_http })
 
 local mt = { __index = _M }
 
-function _M.new()
+function _M.new(opts)
+  opts = opts or { }
   local http = resty_http:new()
+
+  local timeouts = opts.timeouts
+  if timeouts then
+    http:set_timeouts(timeouts.connect_timeout, timeouts.send_timeout, timeouts.read_timeout)
+  end
 
   http.resolver = resty_resolver:instance()
   http.balancer = round_robin.new()

--- a/gateway/src/resty/resolver/http.lua
+++ b/gateway/src/resty/resolver/http.lua
@@ -8,22 +8,8 @@ local _M = setmetatable({}, { __index = resty_http })
 
 local mt = { __index = _M }
 
-function _M.new(opts)
-  opts = opts or { }
+function _M.new()
   local http = resty_http:new()
-
-  local timeouts = opts.timeouts
-  if timeouts then
-    ngx.log(ngx.DEBUG, 'setting timeouts (secs), connect_timeout: ', timeouts.connect_timeout,
-      ' send_timeout: ', timeouts.send_timeout, ' read_timeout: ', timeouts.read_timeout)
-    -- lua-resty-http uses nginx API for lua sockets
-    -- in milliseconds
-    -- https://github.com/openresty/lua-nginx-module?tab=readme-ov-file#tcpsocksettimeouts
-    local connect_timeout = timeouts.connect_timeout and timeouts.connect_timeout * 1000
-    local send_timeout = timeouts.send_timeout and timeouts.send_timeout * 1000
-    local read_timeout = timeouts.read_timeout and timeouts.read_timeout * 1000
-    http:set_timeouts(connect_timeout, send_timeout, read_timeout)
-  end
 
   http.resolver = resty_resolver:instance()
   http.balancer = round_robin.new()

--- a/gateway/src/resty/resolver/http.lua
+++ b/gateway/src/resty/resolver/http.lua
@@ -14,7 +14,15 @@ function _M.new(opts)
 
   local timeouts = opts.timeouts
   if timeouts then
-    http:set_timeouts(timeouts.connect_timeout, timeouts.send_timeout, timeouts.read_timeout)
+    ngx.log(ngx.DEBUG, 'setting timeouts (secs), connect_timeout: ', timeouts.connect_timeout,
+      ' send_timeout: ', timeouts.send_timeout, ' read_timeout: ', timeouts.read_timeout)
+    -- lua-resty-http uses nginx API for lua sockets
+    -- in milliseconds
+    -- https://github.com/openresty/lua-nginx-module?tab=readme-ov-file#tcpsocksettimeouts
+    local connect_timeout = timeouts.connect_timeout and timeouts.connect_timeout * 1000
+    local send_timeout = timeouts.send_timeout and timeouts.send_timeout * 1000
+    local read_timeout = timeouts.read_timeout and timeouts.read_timeout * 1000
+    http:set_timeouts(connect_timeout, send_timeout, read_timeout)
   end
 
   http.resolver = resty_resolver:instance()

--- a/spec/http_proxy_spec.lua
+++ b/spec/http_proxy_spec.lua
@@ -1,0 +1,52 @@
+
+describe('http_proxy', function()
+  describe('.request', function()
+    local function stub_ngx_request()
+      ngx.var = { }
+
+      stub(ngx, 'exit')
+      stub(ngx.req, 'get_headers', function() return { } end)
+      stub(ngx.req, 'get_method', function() return 'GET' end)
+    end
+
+    local function stub_resty_http_proxy()
+      local httpc = {
+      }
+
+      local response = {}
+      stub(httpc, 'request', function() return response end)
+      stub(httpc, 'proxy_response')
+      stub(httpc, 'set_keepalive')
+
+      local resty_http_proxy = require 'resty.http.proxy'
+      stub(resty_http_proxy, 'new', function() return httpc end)
+    end
+
+    before_each(function()
+      stub_ngx_request()
+      stub_resty_http_proxy()
+    end)
+
+    describe('on https backend', function()
+      local upstream = {
+        uri = {
+          scheme = 'https'
+        },
+        request_unbuffered = false,
+        skip_https_connect = false
+      }
+      local proxy_uri = {
+      }
+
+      before_each(function()
+        stub(upstream, 'rewrite_request')
+      end)
+
+      it('terminates phase', function()
+        local http_proxy = require('apicast.http_proxy')
+        http_proxy.request(upstream, proxy_uri)
+        assert.spy(ngx.exit).was_called_with(ngx.OK)
+      end)
+    end)
+  end)
+end)

--- a/spec/resty/http/proxy_spec.lua
+++ b/spec/resty/http/proxy_spec.lua
@@ -47,16 +47,37 @@ describe('resty.http.proxy', function()
     end)
 
     context('.new', function()
-        it('connects to the #http_proxy', function()
-            _M:reset({ http_proxy = 'http://127.0.0.1:1984' })
+      before_each(function()
+        _M:reset({ http_proxy = 'http://127.0.0.1:1984' })
+      end)
 
-            local request = { url = 'http://upstream:8091/request', method = 'GET' }
-            local proxy = assert(_M.new(request))
+      it('connects to the #http_proxy', function()
+          local request = { url = 'http://upstream:8091/request', method = 'GET' }
+          local proxy = assert(_M.new(request))
 
-            local res = assert(proxy:request(request))
+          local res = assert(proxy:request(request))
 
-            assert.same(200, res.status)
-            assert.match('GET http://upstream:8091/request HTTP/1.1', res:read_body())
-        end)
+          assert.same(200, res.status)
+          assert.match('GET http://upstream:8091/request HTTP/1.1', res:read_body())
+      end)
+
+      it('connects to the #http_proxy with timeouts', function()
+          local request = {
+            url = 'http://upstream:8091/request',
+            method = 'GET',
+            upstream_connection_opts = {
+              connect_timeout = 1,
+              send_timeout = 1,
+              read_timeout = 1
+            }
+          }
+
+          local proxy = assert(_M.new(request))
+
+          local res = assert(proxy:request(request))
+
+          assert.same(200, res.status)
+          assert.match('GET http://upstream:8091/request HTTP/1.1', res:read_body())
+      end)
     end)
 end)

--- a/t/apicast-policy-camel.t
+++ b/t/apicast-policy-camel.t
@@ -19,7 +19,7 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: API backend connection uses http proxy 
+=== TEST 1: API backend connection uses http proxy
 --- configuration
 {
   "services": [

--- a/t/apicast-policy-http-proxy.t
+++ b/t/apicast-policy-http-proxy.t
@@ -202,10 +202,8 @@ ETag: foobar
 --- error_code: 200
 --- error_log env
 proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
---- user_files fixture=tls.pl eval
---- error_log env
 using proxy: $TEST_NGINX_HTTPS_PROXY
-
+--- user_files fixture=tls.pl eval
 
 === TEST 4: using HTTP proxy with Basic Auth
 --- configuration

--- a/t/apicast-policy-upstream-connection.t
+++ b/t/apicast-policy-upstream-connection.t
@@ -144,3 +144,84 @@ proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
 using proxy: $TEST_NGINX_HTTPS_PROXY
 proxy_response(): timeout
 --- user_files fixture=tls.pl eval
+
+=== TEST 3: Set timeouts using HTTPS proxy for backend using HTTPS_PROXY env var
+In this test we set some timeouts to 1s. To force a read timeout, the upstream
+returns part of the response, then waits 3s (more than the timeout defined),
+and after that, it returns the rest of the response. Backend is configured with https_proxy
+This test uses the "ignore_response" section, because we know that the response
+is not going to be complete and that makes the Test::Nginx framework raise an
+error. With "ignore_response" that error is ignored.
+--- env eval
+(
+  "https_proxy" => $ENV{TEST_NGINX_HTTPS_PROXY},
+)
+--- configuration random_port env
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT",
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.upstream_connection",
+            "configuration": {
+              "connect_timeout": 1,
+              "send_timeout": 1,
+              "read_timeout": 1
+            }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream env
+server_name test-upstream.lvh.me;
+listen $TEST_NGINX_RANDOM_PORT ssl;
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+location /test {
+    content_by_lua_block {
+      ngx.say("first part")
+      ngx.flush(true)
+      ngx.sleep(3)
+      ngx.say("yay, second part")
+    }
+
+    access_by_lua_block {
+      assert = require('luassert')
+      assert.equal('https', ngx.var.scheme)
+      assert.equal('$TEST_NGINX_RANDOM_PORT', ngx.var.server_port)
+      assert.equal('test-upstream.lvh.me', ngx.var.ssl_server_name)
+
+      local host = ngx.req.get_headers()["Host"]
+      local result = string.match(host, "^test%-upstream%.lvh%.me:")
+      assert.equals(result, "test-upstream.lvh.me:")
+    }
+}
+
+--- request
+GET /test?user_key=test3
+--- more_headers
+User-Agent: Test::APIcast::Blackbox
+ETag: foobar
+--- error_log env
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+using proxy: $TEST_NGINX_HTTPS_PROXY
+proxy_response(): timeout
+--- user_files fixture=tls.pl eval

--- a/t/apicast-policy-upstream-connection.t
+++ b/t/apicast-policy-upstream-connection.t
@@ -225,3 +225,86 @@ proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
 using proxy: $TEST_NGINX_HTTPS_PROXY
 proxy_response(): timeout
 --- user_files fixture=tls.pl eval
+
+=== TEST 4: Set timeouts using HTTPS Camel proxy for backend
+In this test we set some timeouts to 1s. To force a read timeout, the upstream
+returns part of the response, then waits 3s (more than the timeout defined),
+and after that, it returns the rest of the response. Backend is configured with https_proxy
+This test uses the "ignore_response" section, because we know that the response
+is not going to be complete and that makes the Test::Nginx framework raise an
+error. With "ignore_response" that error is ignored.
+--- configuration random_port env
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT",
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.upstream_connection",
+            "configuration": {
+              "connect_timeout": 1,
+              "send_timeout": 1,
+              "read_timeout": 1
+            }
+          },
+          {
+            "name": "apicast.policy.camel",
+            "configuration": {
+                "https_proxy": "$TEST_NGINX_HTTPS_PROXY"
+            }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream env
+server_name test-upstream.lvh.me;
+listen $TEST_NGINX_RANDOM_PORT ssl;
+
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+location /test {
+    content_by_lua_block {
+      ngx.say("first part")
+      ngx.flush(true)
+      ngx.sleep(3)
+      ngx.say("yay, second part")
+    }
+
+    access_by_lua_block {
+      assert = require('luassert')
+      assert.equal('https', ngx.var.scheme)
+      assert.equal('$TEST_NGINX_RANDOM_PORT', ngx.var.server_port)
+      assert.equal('test-upstream.lvh.me', ngx.var.ssl_server_name)
+
+      local host = ngx.req.get_headers()["Host"]
+      local result = string.match(host, "^test%-upstream%.lvh%.me:")
+      assert.equals(result, "test-upstream.lvh.me:")
+    }
+}
+--- request
+GET /test?user_key=test3
+--- ignore_response
+--- more_headers
+User-Agent: Test::APIcast::Blackbox
+ETag: foobar
+--- error_log env
+using proxy: $TEST_NGINX_HTTPS_PROXY
+err: timeout
+--- user_files fixture=tls.pl eval

--- a/t/apicast-policy-upstream-connection.t
+++ b/t/apicast-policy-upstream-connection.t
@@ -1,6 +1,8 @@
 use lib 't';
 use Test::APIcast::Blackbox 'no_plan';
 
+require("http_proxy.pl");
+
 run_tests();
 
 __DATA__
@@ -59,3 +61,88 @@ GET /
 --- error_log
 upstream timed out
 --- error_code:
+
+=== TEST 2: Set timeouts using HTTPS proxy for backend
+In this test we set some timeouts to 1s. To force a read timeout, the upstream
+returns part of the response, then waits 3s (more than the timeout defined),
+and after that, it returns the rest of the response. Backend is configured with https_proxy
+This test uses the "ignore_response" section, because we know that the response
+is not going to be complete and that makes the Test::Nginx framework raise an
+error. With "ignore_response" that error is ignored.
+--- configuration random_port env
+{
+  "services": [
+    {
+      "backend_version":  1,
+      "proxy": {
+        "api_backend": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT",
+        "proxy_rules": [
+          { "pattern": "/test", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.upstream_connection",
+            "configuration": {
+              "connect_timeout": 1,
+              "send_timeout": 1,
+              "read_timeout": 1
+            }
+          },
+          {
+            "name": "apicast.policy.http_proxy",
+            "configuration": {
+                "https_proxy": "$TEST_NGINX_HTTPS_PROXY"
+            }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream env
+server_name test-upstream.lvh.me;
+listen $TEST_NGINX_RANDOM_PORT ssl;
+
+ssl_certificate $TEST_NGINX_SERVER_ROOT/html/server.crt;
+ssl_certificate_key $TEST_NGINX_SERVER_ROOT/html/server.key;
+
+location /test {
+    content_by_lua_block {
+      ngx.say("first part")
+      ngx.flush(true)
+      ngx.sleep(3)
+      ngx.say("yay, second part")
+    }
+
+    access_by_lua_block {
+      assert = require('luassert')
+      assert.equal('https', ngx.var.scheme)
+      assert.equal('$TEST_NGINX_RANDOM_PORT', ngx.var.server_port)
+      assert.equal('test-upstream.lvh.me', ngx.var.ssl_server_name)
+
+      local host = ngx.req.get_headers()["Host"]
+      local result = string.match(host, "^test%-upstream%.lvh%.me:")
+      assert.equals(result, "test-upstream.lvh.me:")
+    }
+}
+--- request
+GET /test?user_key=test3
+--- ignore_response
+--- more_headers
+User-Agent: Test::APIcast::Blackbox
+ETag: foobar
+--- error_code:
+--- error_log env
+proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
+using proxy: $TEST_NGINX_HTTPS_PROXY
+proxy_response(): timeout
+--- user_files fixture=tls.pl eval

--- a/t/apicast-policy-upstream-connection.t
+++ b/t/apicast-policy-upstream-connection.t
@@ -60,7 +60,6 @@ GET /
 --- ignore_response
 --- error_log
 upstream timed out
---- error_code:
 
 === TEST 2: Set timeouts using HTTPS proxy for backend
 In this test we set some timeouts to 1s. To force a read timeout, the upstream
@@ -140,7 +139,6 @@ GET /test?user_key=test3
 --- more_headers
 User-Agent: Test::APIcast::Blackbox
 ETag: foobar
---- error_code:
 --- error_log env
 proxy request: CONNECT test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT HTTP/1.1
 using proxy: $TEST_NGINX_HTTPS_PROXY


### PR DESCRIPTION
### What

Fixes: https://issues.redhat.com/browse/THREESCALE-10582

Upstream timeouts don't work with Camel Service. Actually upstream connection policy is not working when `https_proxy` is being used (either with env vars or policy).

This PR fixes the integration of upstream connection with any use case for `https_proxy`. 

It was considered adding connection options to the proxy policy and camel policy. Mainly because "Upstream connection" policy is referring to "upstream", which can be confusing when a proxy is being used, as the connection to upstream backend is no longer made by APIcast. Instead, APIcast creates a connection to the proxy. So the Upstream connection opts should, ideally, only apply to connections to backend "upstream". 

We decided to apply upstream connection policy to any "upstream" connection the APIcast make initiate, either a proxy or a actual upstream backend. That way, implementation wise it is easier. No need to add extended connection parameters to the proxy policies. Furthermore, if users are using Upstream connection policy together with `http_proxy`, the configuration still applies. With a new connection parameters in the proxy policies, this last use case would be broken. Additionally, if connection opts are added to the policies as optional params, we would need to add new env vars as well for the use case where proxies are configured via env vars. Too complex just to stick "upstream" concept to the actual backend (`api_backend` in the service configuration). Instead, upstram connection policy applies to any "upstream" connection APIcast does, regardless of being it a proxy or backend upstream. 

### Verification Steps 

#### Upstream connection integration with `https_proxy` camel proxy 

* Build docker image from this git branch

```shell
make runtime-image IMAGE_NAME=apicast-test
```

* Camel proxy dev environment setup

```shell
cd dev-environments/camel-proxy
make certs
```


* Testing `https_proxy` use case: APIcast --> camel proxy --> upstream (TLS)

This env uses as `api_backend` the real env `https://echo-api.3scale.net:443`. My roundtrip latency is ~400ms. 

```
❯ curl -i -w "tcp:%{time_total}\n" https://echo-api.3scale.net:443 2>/dev/null
HTTP/1.1 200 OK
content-type: application/json
x-3scale-echo-api: echo-api/1.0.3
vary: Origin
x-content-type-options: nosniff
content-length: 524
x-envoy-upstream-service-time: 0
date: Mon, 05 Feb 2024 14:50:56 GMT
server: envoy

{
  "method": "GET",
  "path": "/",
  "args": "",
  "body": "",
  "headers": {
    "HTTP_VERSION": "HTTP/1.1",
    "HTTP_HOST": "echo-api.3scale.net",
    "HTTP_USER_AGENT": "curl/7.81.0",
    "HTTP_ACCEPT": "*/*",
    "HTTP_X_FORWARDED_FOR": "81.61.128.254",
    "HTTP_X_FORWARDED_PROTO": "https",
    "HTTP_X_ENVOY_EXTERNAL_ADDRESS": "81.61.128.254",
    "HTTP_X_REQUEST_ID": "a78c1edb-b0bf-42a2-8c44-e1ae9d4dba49",
    "HTTP_X_ENVOY_EXPECTED_RQ_TIMEOUT_MS": "15000"
  },
  "uuid": "b48cdf4d-1419-4aaf-871e-10cd9c67f68e"
}tcp:0.398028
``` 
Let's start with timeouts set to 1 sec and the request should be accepted.
```patch
patch <<EOF
diff --git a/dev-environments/camel-proxy/apicast-config.json b/dev-environments/camel-proxy/apicast-config.json
index 91201afa..8f92f029 100644
--- a/dev-environments/camel-proxy/apicast-config.json
+++ b/dev-environments/camel-proxy/apicast-config.json
@@ -44,6 +44,14 @@
           "host": "backend"
         },
         "policy_chain": [
+          {
+            "name": "apicast.policy.upstream_connection",
+            "configuration": {
+              "connect_timeout": 1,
+              "send_timeout": 1,
+              "read_timeout": 1
+            }
+          },
           {
             "name": "apicast.policy.camel",
             "configuration": {
EOF
```

Run environment

```shell
make gateway IMAGE_NAME=apicast-test
```

The request should be accepted (`200 OK`), as the connection timeouts should not be exceeded. 

```sh
curl --resolve https-proxy.example.com:8080:127.0.0.1 -v "http://https-proxy.example.com:8080/?user_key=123"
```

Now, let's lower the timeouts threshold to something like 100ms that should be exceeded because the upstream is far away.

Stop the gateway
```
CTRL-C
```
Restore `apicast-config.json` file
```
git checkout apicast-config.json
```

Apply 100ms timeouts

```patch
patch <<EOF
diff --git a/dev-environments/camel-proxy/apicast-config.json b/dev-environments/camel-proxy/apicast-config.json
index 91201afa..8f92f029 100644
--- a/dev-environments/camel-proxy/apicast-config.json
+++ b/dev-environments/camel-proxy/apicast-config.json
@@ -44,6 +44,14 @@
           "host": "backend"
         },
         "policy_chain": [
+          {
+            "name": "apicast.policy.upstream_connection",
+            "configuration": {
+              "connect_timeout": 0.1,
+              "send_timeout": 0.1,
+              "read_timeout": 0.1
+            }
+          },
           {
             "name": "apicast.policy.camel",
             "configuration": {
EOF
```

Run environment

```shell
make gateway IMAGE_NAME=apicast-test
```

The request should fail (`502 Bad Gateway`), as the connection timeouts should be exceeded.

```sh
curl --resolve https-proxy.example.com:8080:127.0.0.1 -v "http://https-proxy.example.com:8080/?user_key=123"
```

The logs should show the following line

```
[error] 19#19: *2 lua tcp socket read timed out
```

Clean the env before starting next step

```
make clean
```

#### Upstream connection integration with `https_proxy` with proxy policy (tinyproxy)

* Build docker image from this git branch

```shell
cd ${APICAST_PROJECT} && git checkout THREESCALE-10582-upstream-policy-with-camel-policy

make runtime-image IMAGE_NAME=apicast-test
```

* `https_proxy` dev environment setup

```shell
cd dev-environments/https-proxy-upstream-tlsv1.3
make certs
```
* Testing `https_proxy` use case: APIcast --> tiny  proxy --> upstream (TLS)

Timeouts set to 0.1 sec
```patch
patch <<EOF
diff --git a/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json b/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json
index 5227c5aa..34a2ed23 100644
--- a/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json
+++ b/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json
@@ -11,6 +11,14 @@
           "host": "backend"
         },
         "policy_chain": [
+          {
+            "name": "apicast.policy.upstream_connection",
+            "configuration": {
+              "connect_timeout": 0.1,
+              "send_timeout": 0.1,
+              "read_timeout": 0.1
+            }
+          },
           {
             "name": "apicast.policy.http_proxy",
             "configuration": {
EOF
```
Run environment

```shell
make gateway IMAGE_NAME=apicast-test
```
The request should be accepted (200 OK), as the connection timeouts should not be exceeded.
```sh                                                                                        
curl --resolve get.example.com:8080:127.0.0.1 -i "http://get.example.com:8080/?user_key=123" 
```                                                                         

Now, let's simulate some network latency using  docker containers with Traffic control. We will add 200ms of latency to the container running `socat` between the proxy and the backend upstream. It is called `example.com` service.

Stop the gateway
```
CTRL-C
```

We are going to modify network-related stuff, so the NET_ADMIN capability is needed.
```patch
patch <<EOF
diff --git a/dev-environments/https-proxy-upstream-tlsv1.3/docker-compose.yml b/dev-environments/https-proxy-upstream-tlsv1.3/docker-compose.yml
index 9fa735f7..0f802e8b 100644
--- a/dev-environments/https-proxy-upstream-tlsv1.3/docker-compose.yml
+++ b/dev-environments/https-proxy-upstream-tlsv1.3/docker-compose.yml
@@ -39,6 +39,8 @@ services:
     restart: unless-stopped
     volumes:
       - ./cert/example.com.pem:/etc/pki/example.com.pem
+    cap_add:
+      - NET_ADMIN
   two.upstream:
     image: kennethreitz/httpbin
     expose:
EOF
```

Run environment with the new config

```shell
make gateway IMAGE_NAME=apicast-test
```

install the `tc` (traffic control) command

```
docker compose exec example.com apk add iproute2-tc
```

Add 200ms latency to the outbound traffic of `example.com` service.
```
docker compose exec example.com tc qdisc add dev eth0 root netem delay 200ms
```
The request should be rejected (`503 Service Temporarily Unavailable`), as the connection timeouts should not be exceeded.
```sh                                                                                        
curl --resolve get.example.com:8080:127.0.0.1 -i "http://get.example.com:8080/?user_key=123" 
```      
The logs should show the following line

```
[error] 19#19: *2 lua tcp socket read timed out
```
                 


