### PR TITLE
[THREESCALE-10164] Add support to set large_client_header_buffers directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Bump penlight to 1.31.1 [PR #1447](https://github.com/3scale/APIcast/pull/1447)
 
+- Added `APICAST_CLIENT_REQUEST_HEADER_BUFFERS` variable to allow configure of the NGINX `client_request_header_buffers` directive: [PR #1446](https://github.com/3scale/APIcast/pull/1446), [THREESCALE-10164](https://issues.redhat.com/browse/THREESCALE-10164)
+
 ## [3.14.0] 2023-07-25
 
 ### Fixed

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -507,6 +507,16 @@ directive](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_
 This parameter is only used by the services that are using content caching
 policy.
 
+### `APICAST_LARGE_CLIENT_HEADER_BUFFERS`
+
+**Default:** 4 8k
+**Value:** string
+
+Sets the maximum number and size of buffers used for reading large client request header.
+
+The format for this value is defined by the [`large_client_header_buffers` NGINX
+directive](https://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers)
+
 ### `OPENTELEMETRY`
 
 This environment variable enables NGINX instrumentation using OpenTelemetry tracing library.

--- a/gateway/http.d/core.conf
+++ b/gateway/http.d/core.conf
@@ -1,1 +1,3 @@
 client_max_body_size 0;
+
+large_client_header_buffers {{env.APICAST_LARGE_CLIENT_HEADER_BUFFERS | default:  "4 8k"}};

--- a/t/large-client-header-buffers.t
+++ b/t/large-client-header-buffers.t
@@ -5,7 +5,7 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: large header (the header exceed exceed the size of one buffer)
+=== TEST 1: large header (the header exceed the size of one buffer)
 Default configuration for large_client_header_buffers: 4 8k
 --- configuration env
 {
@@ -32,7 +32,6 @@ Default configuration for large_client_header_buffers: 4 8k
   }
 --- upstream
 
-  client_header_buffer_size 10;
   location / {
     content_by_lua_block {
         ngx.print(ngx.req.raw_header())
@@ -80,7 +79,6 @@ GET /?user_key=value
   }
 --- upstream
 
-  client_header_buffer_size 10;
   location / {
     content_by_lua_block {
         ngx.print(ngx.req.raw_header())
@@ -132,7 +130,6 @@ Large-Header: " . ("ABCDEFGH" x 1024) . "\r\n\r\n"
   }
 --- upstream
 
-  client_header_buffer_size 10;
   location / {
     content_by_lua_block {
         ngx.print(ngx.req.raw_header())
@@ -181,7 +178,6 @@ client sent too long URI while reading client request line
   }
 --- upstream
 
-  client_header_buffer_size 10;
   location / {
     content_by_lua_block {
         ngx.print(ngx.req.raw_header())

--- a/t/large-client-header-buffers.t
+++ b/t/large-client-header-buffers.t
@@ -1,0 +1,198 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: large header (the header exceed exceed the size of one buffer)
+Default configuration for large_client_header_buffers: 4 8k
+--- configuration env
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+
+  client_header_buffer_size 10;
+  location / {
+    content_by_lua_block {
+        ngx.print(ngx.req.raw_header())
+    }
+  }
+--- more_headers eval
+my $s = "User-Agent: curl\nBah: bah\n";
+$s .= "Accept: */*\n";
+$s .= "Large-Header: " . "ABCDEFGH" x 1024 . "\n";
+$s
+--- request
+GET /?user_key=value
+--- error_code: 400
+--- no_error_log
+
+
+
+=== TEST 2: large header with APICAST_LARGE_CLIENT_HEADER_BUFFERS set to 4 12k
+--- env eval
+(
+  'APICAST_LARGE_CLIENT_HEADER_BUFFERS' => '4 12k',
+)
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+
+  client_header_buffer_size 10;
+  location / {
+    content_by_lua_block {
+        ngx.print(ngx.req.raw_header())
+    }
+  }
+--- more_headers eval
+my $s = "User-Agent: curl\nBah: bah\n";
+$s .= "Accept: */*\n";
+$s .= "Large-Header: " . "ABCDEFGH" x 1024 . "\n";
+$s
+--- request
+GET /?user_key=value
+--- response_body eval
+"GET /?user_key=value HTTP/1.1\r
+X-Real-IP: 127.0.0.1\r
+Host: test:$ENV{TEST_NGINX_SERVER_PORT}\r
+User-Agent: curl\r
+Bah: bah\r
+Accept: */*\r
+Large-Header: " . ("ABCDEFGH" x 1024) . "\r\n\r\n"
+--- error_code: 200
+--- no_error_log
+
+
+
+=== TEST 3: large request line that exceed default header buffer
+--- configuration env
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+
+  client_header_buffer_size 10;
+  location / {
+    content_by_lua_block {
+        ngx.print(ngx.req.raw_header())
+    }
+  }
+--- more_headers eval
+my $s = "User-Agent: curl\nBah: bah\n";
+$s .= "Accept: */*\n";
+$s .= "Large-Header: " . "ABCDEFGH" x 1024 . "\n";
+$s
+--- request eval
+"GET /?user_key=value&foo=" . ("ABCDEFGH" x 1024)
+--- error_code: 414
+--- error_log
+client sent too long URI while reading client request line
+
+
+
+=== TEST 4: large request line with APICAST_LARGE_CLIENT_HEADER_BUFFERS set to "4 12k"
+--- env eval
+(
+  'APICAST_LARGE_CLIENT_HEADER_BUFFERS' => '4 12k',
+)
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+
+  client_header_buffer_size 10;
+  location / {
+    content_by_lua_block {
+        ngx.print(ngx.req.raw_header())
+    }
+  }
+--- more_headers eval
+my $s = "User-Agent: curl\nBah: bah\n";
+$s .= "Accept: */*\n";
+$s .= "Large-Header: " . "ABCDEFGH" x 1024 . "\n";
+$s
+--- request eval
+"GET /?user_key=value&foo=" . ("ABCDEFGH" x 1024)
+--- error_code: 200
+--- no_error_log


### PR DESCRIPTION
### What

Fixes: https://issues.redhat.com/browse/THREESCALE-10164

### Verification Steps

* Creat a `apicast-config.json` file with the following content

```json
cat <<EOF >apicast-config.json
{
    "services": [
        {
            "id": "1",
            "backend_version": "1",
            "proxy": {
                "hosts": [
                    "one"
                ],
                "api_backend": "https://echo-api.3scale.net:443",
                "backend": {
                    "endpoint": "http://127.0.0.1:8081",
                    "host": "backend"
                },
                "policy_chain": [
                    {
                        "name": "apicast.policy.apicast"
                    }
                ],
                "proxy_rules": [
                    {
                        "http_method": "GET",
                        "pattern": "/",
                        "metric_system_name": "hits",
                        "delta": 1,
                        "parameters": [],
                        "querystring_parameters": {}
                    }
                ]
            }
        }
    ]
} 
EOF
```

* Checkout this branch and start dev environment
```
make development
make dependencies
```
* Run apicast locally
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=debug APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=lazy APICAST_CONFIGURATION_CACHE=0 THREESCALE_CONFIG_FILE=apicast-config.json ./bin/apicast
```

* Capture apicast IP
```
APICAST_IP=$(docker inspect apicast_build_0-development-1 | yq e -P '.[0].NetworkSettings.Networks.apicast_build_0_default.IPAddress' -)
```
* Generate big header
```
LARGE_HEADER=$(for i in {1..1024}; do echo -n 'ABCDEFGH'; done)
```
* Send request with big header
```
curl -i -k -H "Host: one" -H "Accept: application/json" -H "Large-Header: ${LARGE_HEADER}" "http://${APICAST_IP}:8080/?user_key="
```

The response should be HTTP/1.1 400 Bad Request

```
HTTP/1.1 400 Bad Request                                          
Server: openresty                                                 
Date: Thu, 08 Feb 2024 06:49:26 GMT                               
Content-Type: text/html                                           
Content-Length: 230                                               
Connection: close                                                 
                                                                  
<html>                                                            
<head><title>400 Request Header Or Cookie Too Large</title></head>
<body>                                                            
<center><h1>400 Bad Request</h1></center>                         
<center>Request Header Or Cookie Too Large</center>               
<hr><center>openresty</center>                                    
</body>                                                           
</html>                                                           
```

* Stop the gateway
```
CTRL-C
```

* Start gateway again with `APICAST_LARGE_CLIENT_HEADER_BUFFERS=4 12k`
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=debug APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=lazy APICAST_CONFIGURATION_CACHE=0 THREESCALE_CONFIG_FILE=apicast-config.json APICAST_LARGE_CLIENT_HEADER_BUFFERS="4 12k" ./bin/apicast
```

* Send another request
```
curl -i -k -H "Host: one" -H "Accept: application/json" -H "Large-Header: ${LARGE_HEADER}" "http://${APICAST_IP}:8080/?user_key="
```

The response should be HTTP/1.1 200 OK