### PR TITLE
Logs: disable invalid upstream warning when api_backend is null and e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Replace luafilesystem-ffi with [luafilesystem](https://github.com/lunarmodules/luafilesystem) [PR #1445](https://github.com/3scale/APIcast/pull/1445) [THREESCALE-10662](https://issues.redhat.com/browse/THREESCALE-10662)
 
+- Fix "Upstream cannot be null" error in APIcast logs [PR #1449](https://github.com/3scale/APIcast/pull/1449) [THREESCALE-5225](https://issues.redhat.com/browse/THREESCALE-5225)
+
 ### Added
 
 - Detect number of CPU shares when running on Cgroups V2 [PR #1410](https://github.com/3scale/apicast/pull/1410) [THREESCALE-10167](https://issues.redhat.com/browse/THREESCALE-10167)

--- a/gateway/src/apicast/proxy.lua
+++ b/gateway/src/apicast/proxy.lua
@@ -14,6 +14,7 @@ local Usage = require('apicast.usage')
 local errors = require('apicast.errors')
 local Upstream = require('apicast.upstream')
 local escape = require("resty.http.uri_escape")
+local cjson = require('cjson')
 
 local assert = assert
 local type = type
@@ -175,7 +176,8 @@ function _M.get_upstream(service, context)
 
   -- Due to API as a product, the api_backend is no longer needed because this
   -- can be handled by routing policy
-  if not service.api_backend then
+  local api_backend = service.api_backend
+  if not api_backend or api_backend == cjson.null or api_backend == '' then
     return nil, nil
   end
 

--- a/spec/proxy_spec.lua
+++ b/spec/proxy_spec.lua
@@ -1,5 +1,6 @@
 local http_ng_response = require('resty.http_ng.response')
 local lrucache = require('resty.lrucache')
+local cjson = require('cjson')
 
 local configuration_store = require 'apicast.configuration_store'
 local Service = require 'apicast.configuration.service'
@@ -60,6 +61,18 @@ describe('Proxy', function()
 
     it("on no api_backend return nil and no error", function()
       local upstream, err = get_upstream({})
+      assert.falsy(upstream)
+      assert.falsy(err)
+    end)
+
+    it("on no api_backend return empty string and no error", function()
+      local upstream, err = get_upstream({api_backend = ''})
+      assert.falsy(upstream)
+      assert.falsy(err)
+    end)
+
+    it("on no api_backend return null and no error", function()
+      local upstream, err = get_upstream({api_backend = cjson.null})
       assert.falsy(upstream)
       assert.falsy(err)
     end)


### PR DESCRIPTION
## What
Fix https://issues.redhat.com/browse/THREESCALE-5225

PR #1285 only handles the case where `api_backend` is nil, however, when `api_backend` is set to an empty string or null json value, the warning log can still be seen in the log.

## Verification steps:
* Create a apicast-config.json file with the following content

```shell
cat <<EOF >apicast-config.json
{
  "services": [
    {
      "backend_version": "1",
      "id": "1",
      "api_backend": null,
      "proxy": {
        "api_backend": null,
        "service_backend_version": "1",
        "hosts": [
          "one"
        ],
        "backend": {
          "endpoint": "http://127.0.0.1:8081",
          "host": "backend"
        },
        "policy_chain": [
          {
            "name": "apicast.policy.routing",
            "version": "builtin",
            "enabled": true,
            "configuration": {
              "rules": [
                {
                  "url": "https://echo-api.3scale.net:443",
                  "replace_path": "{{uri | remove_first: '/test'}}",
                  "owner_type": "BackendApi",
                  "condition": {
                    "operations": [
                      {
                        "match": "path",
                        "op": "matches",
                        "value": "^(/test/.*|/test/?)"
                      }
                    ]
                  }
                }
              ]
            }
          },
          {
            "name": "apicast.policy.apicast"
          }
        ],
        "proxy_rules": [
          {
            "http_method": "GET",
            "pattern": "/",
            "metric_system_name": "hits",
            "delta": 1,
            "parameters": [],
            "querystring_parameters": {}
          }
        ]
      }
    }
  ]
}
EOF
```
* Checkout this branch and start dev environment
```shell
make development
make dependencies
```
* Run apicast locally
```shell
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=warn APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=lazy APICAST_CONFIGURATION_CACHE=0 THREESCALE_CONFIG_FILE=apicast-config.json ./bin/apicast
```
* Capture apicast IP
```shell
APICAST_IP=$(docker inspect apicast_build_0-development-1 | yq e -P '.[0].NetworkSettings.Networks.apicast_build_0_default.IPAddress' -)
```
* Send a request
```shell
curl -i -k -H "Host: one" "http://${APICAST_IP}:8080/test?user_key="
```
* The response should be HTTP/1.1 200
```shell
< HTTP/1.1 200 OK
< Server: openresty
< Date: Thu, 22 Feb 2024 01:44:59 GMT
< Content-Type: application/json
< Content-Length: 564
< Connection: keep-alive
< x-3scale-echo-api: echo-api/1.0.3
< vary: Origin
< x-content-type-options: nosniff
< x-envoy-upstream-service-time: 0
```

Check that `apicast.lua:65: upstream api for the service:1 is invalid, error:Upstream cannot be null, client: XX.XXX.X` is not visible in logs
