### PR TITLE
[THREESCALE-9537] Configure batcher policy storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added `APICAST_CLIENT_REQUEST_HEADER_BUFFERS` variable to allow configure of the NGINX `client_request_header_buffers` directive: [PR #1446](https://github.com/3scale/APIcast/pull/1446), [THREESCALE-10164](https://issues.redhat.com/browse/THREESCALE-10164)
 
+- Added the `APICAST_POLICY_BATCHER_SHARED_MEMORY_SIZE` variable to allow configuration of the batcher policy's share memory size. [PR #1452](https://github.com/3scale/APIcast/pull/1452), [THREESCALE-9537](https://issues.redhat.com/browse/THREESCALE-9537)
+
 ## [3.14.0] 2023-07-25
 
 ### Fixed

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -522,7 +522,7 @@ directive](https://nginx.org/en/docs/http/ngx_http_core_module.html#large_client
 **Default:** 20m
 **Value:** string
 
-Sets the maximum size of shared memory used by batcher policy.
+Sets the maximum size of shared memory used by batcher policy. The accepted [size units](https://github.com/openresty/lua-nginx-module?tab=readme-ov-file#lua_shared_dict) are k and m.
 
 ### `OPENTELEMETRY`
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -517,6 +517,13 @@ Sets the maximum number and size of buffers used for reading large client reques
 The format for this value is defined by the [`large_client_header_buffers` NGINX
 directive](https://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers)
 
+### `APICAST_POLICY_BATCHER_SHARED_MEMORY_SIZE`
+
+**Default:** 20m
+**Value:** string
+
+Sets the maximum size of shared memory used by batcher policy.
+
 ### `OPENTELEMETRY`
 
 This environment variable enables NGINX instrumentation using OpenTelemetry tracing library.

--- a/gateway/conf.d/backend.conf
+++ b/gateway/conf.d/backend.conf
@@ -21,3 +21,15 @@ location /transactions/oauth_authrep.xml {
 
   echo "transactions oauth_authrep!";
 }
+
+location /transactions/authorize.xml {
+  access_by_lua_block {
+    local delay = tonumber(ngx.var.arg_delay) or 0
+
+    if delay > 0 then
+      ngx.sleep(delay)
+    end
+  }
+
+  echo "transactions oauth_authrep!";
+}

--- a/gateway/conf.d/backend.conf
+++ b/gateway/conf.d/backend.conf
@@ -31,5 +31,5 @@ location /transactions/authorize.xml {
     end
   }
 
-  echo "transactions oauth_authrep!";
+  echo "transactions authorize!";
 }

--- a/gateway/conf/nginx.conf.liquid
+++ b/gateway/conf/nginx.conf.liquid
@@ -94,15 +94,6 @@ http {
     {% include file %}
   {% endfor %}
 
-  lua_shared_dict limiter 1m;
-
-  # This shared dictionaries are only used in the 3scale batcher policy.
-  # This is not ideal, but they'll need to be here until we allow policies to
-  # modify this template.
-  lua_shared_dict cached_auths 20m;
-  lua_shared_dict batched_reports 20m;
-  lua_shared_dict batched_reports_locks 1m;
-
   {% for file in "sites.d/*.conf" | filesystem %}
     {% include file %}
   {% endfor %}

--- a/gateway/http.d/shdict.conf
+++ b/gateway/http.d/shdict.conf
@@ -2,3 +2,11 @@ lua_shared_dict api_keys 30m;
 lua_shared_dict rate_limit_headers 20m;
 lua_shared_dict configuration 10m;
 lua_shared_dict locks 1m;
+lua_shared_dict limiter 1m;
+
+# This shared dictionaries are only used in the 3scale batcher policy.
+# These requirements will remain in place until we allow policy to
+# modify this template.
+lua_shared_dict cached_auths 20m;
+lua_shared_dict batched_reports 20m;
+lua_shared_dict batched_reports_locks 1m;

--- a/gateway/http.d/shdict.conf
+++ b/gateway/http.d/shdict.conf
@@ -8,5 +8,5 @@ lua_shared_dict limiter 1m;
 # These requirements will remain in place until we allow policy to
 # modify this template.
 lua_shared_dict cached_auths 20m;
-lua_shared_dict batched_reports 20m;
+lua_shared_dict batched_reports {{env.APICAST_POLICY_BATCHER_SHARED_MEMORY_SIZE | default: "20m"}};
 lua_shared_dict batched_reports_locks 1m;

--- a/gateway/src/apicast/policy/3scale_batcher/README.md
+++ b/gateway/src/apicast/policy/3scale_batcher/README.md
@@ -63,3 +63,29 @@ The effectiveness of this policy will depend on the cache hit ratio. For use
 cases where the variety of services, apps, metrics, etc. is relatively low,
 caching and batching will be very effective and will increase the throughput of
 the system significantly.
+
+### How many key/value pairs can be contained in 20m of shared memory.
+
+On my Linux x86_64 system `1m` can hold `4033 key/value pairs` with 64-byte keys and
+15-byte values. Changing the size of the shared storage to 10m gives `40673 key/value pairs`.
+It's a linear growth as expected.
+
+The following table shows the number of key/value pairs for different storage size:
+
+| Shared storage size | Key length | Value length | Key/value pairs |
+| ---- | ---- | ---- | ---- |
+| 10m | 64 | 15 | 40672 |
+|  | 128 | 15 | 40672 |
+|  | 256 | 15 | 20336 |
+|  | 512 | 15 | 10168 |
+| 20m | 64 | 15 | 81408 |
+|  | 128 | 15 | 81408 |
+|  | 256 | 15 | 40704 |
+|  | 512 | 15 | 20352 |
+| 40m | 64 | 15 | 162848 |
+|  | 128 | 15 | 162848 |
+|  | 256 | 15 | 81424 |
+|  | 512 | 15 | 40712 |
+
+In practice, the actual number will depend on the size of the key/value pair, the
+underlying operating system (OS) architecture and memory segment sizes, etc... More details [here](https://blog.openresty.com/en/nginx-shm-frag/)


### PR DESCRIPTION
### What

Fixes: https://issues.redhat.com/browse/THREESCALE-9537

### Dev notes
#### 1.  What shared dict value should we increase?
3scale batcher policy use a few different shared dict caches

```
lua_shared_dict cached_auths 20m;
lua_shared_dict batched_reports 20m;
lua_shared_dict batched_reports_locks 1m;
```

and `api_keys` if Caching policy included in the chain

```
lua_shared_dict api_keys 30m;
```

First let's run some test to see how much `1m` of shared cache can hold.

```
lua_shared_dict test 1m;
location = /t {
	content_by_lua_block{
		local rep = string.rep
		local dt = ngx.shared.test
		local val = rep("v", 15)
                local key = rep("k", 32)
		local i = 0
		while i < 200000 do
                    local ok, err = dt:safe_add("service_id:_" .. i ..",user_key:".. key ..",metric:hits", i)
                    if not ok then
		        break
		    end
		    i = i + 1
		end
		ngx.say(i, " key/value pairs inserted")
    }
}
```

The reason to use `safe_set()` here is to prevent automatic evicting least recently used items upon memory shortage in set().

Querying /t gives the response body on my Linux x86_64 system. NOTE: you may get different value as this actually depends on the underlying architecture.

```
4033 key/value pairs inserted.
```

So a `1m` store can hold 4033 key/value pairs with 57-byte keys and 15-byte values. In reality, the actual available space will depend on the memory fragment but since these key/value pairs are consistent in size, we should have no problem.  More details [here](https://blog.openresty.com/en/nginx-shm-frag/)

Changing the "dict" store to 10m gives

```
40673 key/value pairs inserted.
```

So a 10m store can hold 40673 pairs. It's a linear growth as expected. 

| Name | Method | When full | TTL | Growth |
| ---- | ---- | ---- | ---- | ---- |
| cached_auths | set/get | evict old/expired key | 10 | 1 for each new transaction |
| batched_reports | safe_add/incr | return error |  | 1 for each transaction that return 200. If the key exist then update the existing key. Flush all keys after batch report seconds timeout (default 10s)  |
| batched_reports_locks | set/delete | evict old/expired key | None.  | 1 for each transaction. But lock is release in the same function |
| api_keys | get/set/delete | evict old/expired key | None |  |

So we can see that all will grow the equally, but due to the use of [safe_add](https://github.com/openresty/lua-nginx-module?tab=readme-ov-file#ngxshareddictsafe_add) and cache reports for 10 seconds, only`batched_reports` will return `no memory` error.

A possible workaround is to set `batch_report_seconds` to lower value.

#### 2. Do I need to increase the batcher policy storage.

Let do a small test and increase the key size:

| Key | Value | Key format | credential lengths | Key/values pairs |  |
| ---- | ---- | ---- | ---- | ---- | ---- |
| batched_reports | 20m | service_id:<service_id>,user_key:<service_crendential>,metric:<metric_name> | 60 | 81409 |  |
|  |  |  | 120 | 81409 |  |
|  |  |  | 142 | 40705 |  |
|  |  |  | 400 | 20400 |  |

with a key that >400bytes, for the `batched_reports` to be fully filled, it would require `20400/10 = 2040 req/sec`. It's very unlikely that a single gateway will be hit with this much traffic. 

@eguzki do you know what is the highest load a single gateway can handle?

### Verification Steps

Filling the storage is a bit tricky so I just check to see if the configuration file is filled with the correct value.

* Create a apicast-config.json file with the following content
```
cat <<EOF >apicast-config.json
{
    "services": [
        {
            "id": "1",
            "backend_version": "1",
            "proxy": {
                "hosts": [
                    "one"
                ],
                "api_backend": "https://echo-api.3scale.net:443",
                "backend": {
                    "endpoint": "http://127.0.0.1:8081",
                    "host": "backend"
                },
                "policy_chain": [
                    {
                        "name": "apicast.policy.apicast"
                    }
                ],
                "proxy_rules": [
                    {
                        "http_method": "GET",
                        "pattern": "/",
                        "metric_system_name": "hits",
                        "delta": 1,
                        "parameters": [],
                        "querystring_parameters": {}
                    }
                ]
            }
        }
    ]
} 
EOF
```

* Checkout this branch and start dev environment
```
make development
make dependencies
```

* Run apicast locally with `APICAST_POLICY_BATCHER_SHARED_MEMORY_SIZE` set to 40m
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=debug APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=lazy APICAST_CONFIGURATION_CACHE=0  APICAST_POLICY_BATCHER_SHARED_MEMORY_SIZE="40m" THREESCALE_CONFIG_FILE=apicast-config.json ./bin/apicast
```

* Stop the gateway
```
CTRL-C
```

* Check that `lua_shared_dict batched_reports` is set to 40m

```
$ grep -nr "batched_reports" /tmp

/tmp/lua_PRpxLW:67:lua_shared_dict batched_reports 40m;
/tmp/lua_PRpxLW:68:lua_shared_dict batched_reports_locks 1m;
```