### PR TITLE
[THREESCALE-10934] [3scale_batcher] Update regex to match key with special chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Replace luafilesystem-ffi with [luafilesystem](https://github.com/lunarmodules/luafilesystem) [PR #1445](https://github.com/3scale/APIcast/pull/1445) [THREESCALE-10662](https://issues.redhat.com/browse/THREESCALE-10662)
 
 - Fix "Upstream cannot be null" error in APIcast logs [PR #1449](https://github.com/3scale/APIcast/pull/1449) [THREESCALE-5225](https://issues.redhat.com/browse/THREESCALE-5225)
+- Fixed 3scale Batcher policy unable to handle base64 encoded `user_key` [PR #1453](https://github.com/3scale/APIcast/pull/1453) [THREESCALE-10934](https://issues.redhat.com/browse/THREESCALE-10934)
 
 ### Added
 

--- a/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
@@ -39,9 +39,9 @@ local function metrics_part_in_key(usage)
 end
 
 local regexes_report_key = {
-  [[service_id:(?<service_id>[\w-]+),user_key:(?<user_key>[\w-]+),metric:(?<metric>[\S-]+)]],
+  [[service_id:(?<service_id>[\w-]+),user_key:(?<user_key>[\S-]+),metric:(?<metric>[\S-]+)]],
   [[service_id:(?<service_id>[\w-]+),access_token:(?<access_token>[\w-]+),metric:(?<metric>[\S-]+)]],
-  [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\w-]+),app_key:(?<app_key>[\w-]+),metric:(?<metric>[\S-]+)]],
+  [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\w-]+),app_key:(?<app_key>[\S-]+),metric:(?<metric>[\S-]+)]],
   [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\w-]+),metric:(?<metric>[\S-]+)]],
 }
 

--- a/spec/policy/3scale_batcher/keys_helper_spec.lua
+++ b/spec/policy/3scale_batcher/keys_helper_spec.lua
@@ -34,6 +34,11 @@ describe('Keys Helper', function()
 
       local report = keys_helper.report_from_key_batched_report(key)
       assert.same({ service_id = 's1', app_id = 'ai', app_key = 'ak', metric = 'm1' }, report)
+
+      -- special chars
+      key = 'service_id:s1,app_id:ai,app_key:!#$%&\'()*+,-.:;<=>?@[]^_`{|}~,metric:m1'
+      report = keys_helper.report_from_key_batched_report(key)
+      assert.same({ service_id = 's1', app_id = 'ai', app_key = '!#$%&\'()*+,-.:;<=>?@[]^_`{|}~', metric = 'm1' }, report)
     end)
 
     it('returns a valid metric in case of special chars', function()
@@ -56,6 +61,24 @@ describe('Keys Helper', function()
 
       local report = keys_helper.report_from_key_batched_report(key)
       assert.same({ service_id = 's1', user_key = 'uk', metric = 'm1' }, report)
+
+      key = 'service_id:s1,user_key:you-&$#!!!,metric:m1'
+      report = keys_helper.report_from_key_batched_report(key)
+      assert.same({ service_id = 's1', user_key = 'you-&$#!!!', metric = 'm1' }, report)
+
+      -- Base64
+      key = 'service_id:s1,user_key:aGVsbG93b3JsZAo=,metric:m1'
+      report = keys_helper.report_from_key_batched_report(key)
+      assert.same({ service_id = 's1', user_key = 'aGVsbG93b3JsZAo=', metric = 'm1' }, report)
+
+    end)
+
+    it('returns an error when user_key has space', function()
+      local key = 'service_id:s1,app_id:ai,app_key:I have spaces,metric:m%1'
+      assert.returns_error('credentials not found', keys_helper.report_from_key_batched_report(key))
+
+      key = 'service_id:s1,user_key:I have spaces,metric:m1'
+      assert.returns_error('credentials not found', keys_helper.report_from_key_batched_report(key))
     end)
 
     it('returns a report given a key of a batched report with access token', function()


### PR DESCRIPTION
## What

Fix https://issues.redhat.com/browse/THREESCALE-10934

## Dev notes
In my opinion there are 2 ways to fix this:
1. Replace the current regrex with the regrex from porta repo.  The allowed key formats are describe in the linked JIRA. I don't like this approach because we always have to make sure that the APIcast regular expression matches the one from the porta. Also, the current code allows `set` keys of any format but restricting the format when `get` is also strange to me.
2. Allow everything except spaces and let porta handle the validation during the authorization call. I think this is a better option but would be happy to discuss further.

## Verification Steps 

* Configure a single Product A with user_key 
```
aGVsbG93b3JsZAo=
```
* Configure batcher policy with the following:
```
{ "name" : "apicast.policy.3scale_batcher", "configuration" : { "batch_report_seconds" : 1 } }
```
* Start dev environment
```
make development
make dependencies
```
* Run apicast locally
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=debug APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=lazy APICAST_CONFIGURATION_CACHE=0 THREESCALE_PORTAL_ENDPOINT=https://token@3scale-admin.example.com ./bin/apicast
```
* Run query with the valid user_key
```
# capture apicast IP
APICAST_IP=$(docker inspect apicast_build_0-development-1 | yq e -P '.[0].NetworkSettings.Networks.apicast_build_0_default.IPAddress' -)

curl -v -k -H "Host: example.com:443" "http://${APICAST_IP}:8080/?user_key=aGVsbG93b3JsZAo="
```
* Check that `credentials not found` error does not appear in the log. For example:
```
reports_batcher.lua:99: get_all(): failed to get report for key service_id:12,user_key:aGVsbG93b3JsZAo=,metric:Hits err: credentials not found, context: ngx.timer, client: 10.10.10.1, server: 0.0.0.0:8080 
```