### PR TITLE
Disable _G write guard warning

### DIFF
--- a/gateway/src/apicast/cli/template.lua
+++ b/gateway/src/apicast/cli/template.lua
@@ -1,3 +1,8 @@
+--- These lines to avoid _G write guard issues, external depencies
+--  See https://github.com/openresty/lua-nginx-module/issues/1558 for more info
+rawset(_G, 'lfs', false)
+rawset(_G, 'warn', false)
+
 local _M = {}
 
 local setmetatable = setmetatable


### PR DESCRIPTION
## What

Re-added the code to disable warning about writing to global variable  that was added in https://github.com/3scale/APIcast/commit/d8bfb0c80a2d68c2b1d8fc6cbb9a5768b31b82f2

## Verification steps
* Checkout this branch
* Build runtime-image
```
make runtime-image
```
* Start APIcast
```
docker run --rm -ti --name apicast -p 8080:8080 --env THREESCALE_DEPLOYMENT_ENV=staging --env APICAST_LOG_LEVEL=debug --env APICAST_WORKER=1 --env APICAST_CONFIGURATION_LOADER=lazy --env APICAST_CONFIGURATION_CACHE=0 --env THREESCALE_PORTAL_ENDPOINT=https://example.com  apicast-runtime-image:latest
```
* Check that the following warning is not present in the log
```
~ vim-rust ❯ docker run --rm -ti --name apicast -p 8080:8080 --env THREESCALE_DEPLOYMENT_ENV=staging --env APICAST_LOG_LEVEL=debug --env APICAST_WORKER=1 --env APICAST_CONFIGURATION_LOADER=lazy --env APICAST_CONFIGURATION_CACHE=0 --env THREESCALE_PORTAL_ENDPOINT=https://****@3scale-supertest-admin.3scale.net apicast-runtime-image:latest
2024/04/02 09:47:15 [notice] 14#14: using the "epoll" event method
2024/04/02 09:47:15 [notice] 14#14: openresty/1.19.3.1
2024/04/02 09:47:15 [notice] 14#14: OS: Linux 6.5.0-26-generic
2024/04/02 09:47:15 [notice] 14#14: getrlimit(RLIMIT_NOFILE): 1048576:1048576
2024/04/02 09:47:15 [debug] 14#14: *2 [lua] env.lua:86: fetch(): env: APICAST_VALIDATE_POLICY_CONFIGS = nil
2024/04/02 09:47:15 [debug] 14#14: *2 [lua] env.lua:86: fetch(): env: TEST_NGINX_BINARY = nil
2024/04/02 09:47:15 [warn] 14#14: *2 [lua] _G write guard:12: writing a global Lua variable ('lfs') which may lead to race conditions between concurrent requests, so prefer the use of 'local' variables
stack traceback:
	[C]: at 0x71ee237368f0
	[C]: at 0x71ee2524e240
	[C]: in function 'pcall'
	/usr/local/share/lua/5.1/pl/path.lua:24: in main chunk
	[C]: in function 'require'
	/usr/local/share/lua/5.1/pl/dir.lua:9: in main chunk
	[C]: in function 'require'
	/opt/app-root/src/src/apicast/cli/template.lua:11: in main chunk
	[C]: in function 'require'
	/opt/app-root/src/src/apicast/cli/command/start.lua:17: in main chunk
	[C]: in function 'require'
	/opt/app-root/src/src/apicast/cli.lua:18: in function 'load_commands'
	/opt/app-root/src/src/apicast/cli.lua:23: in main chunk
	[C]: in function 'require'
	/opt/app-root/src/bin/apicast_cli.lua:47: in function 'file_gen'
	init_worker_by_lua:45: in function <init_worker_by_lua:43>
	[C]: in function 'xpcall'
	init_worker_by_lua:52: in function <init_worker_by_lua:50>, context: ngx.timer
```