### PR TITLE
[chore] Remove unused shared dict

### DIFF
--- a/gateway/http.d/init.conf
+++ b/gateway/http.d/init.conf
@@ -104,5 +104,3 @@ init_worker_by_lua_block {
 
     require('apicast.executor'):init_worker()
 }
-
-lua_shared_dict init 256k;

--- a/gateway/http.d/shdict.conf
+++ b/gateway/http.d/shdict.conf
@@ -1,7 +1,5 @@
 lua_shared_dict api_keys 30m;
 lua_shared_dict rate_limit_headers 20m;
-lua_shared_dict configuration 10m;
-lua_shared_dict locks 1m;
 lua_shared_dict limiter 1m;
 
 # This shared dictionaries are only used in the 3scale batcher policy.

--- a/t/prometheus-metrics.t
+++ b/t/prometheus-metrics.t
@@ -36,10 +36,7 @@ openresty_shdict_capacity{dict="api_keys"} 31457280
 openresty_shdict_capacity{dict="batched_reports"} 20971520
 openresty_shdict_capacity{dict="batched_reports_locks"} 1048576
 openresty_shdict_capacity{dict="cached_auths"} 20971520
-openresty_shdict_capacity{dict="configuration"} 10485760
-openresty_shdict_capacity{dict="init"} 262144
 openresty_shdict_capacity{dict="limiter"} 1048576
-openresty_shdict_capacity{dict="locks"} 1048576
 openresty_shdict_capacity{dict="prometheus_metrics"} 16777216
 openresty_shdict_capacity{dict="rate_limit_headers"} 20971520
 # HELP openresty_shdict_free_space OpenResty shared dictionary free space
@@ -48,10 +45,7 @@ openresty_shdict_free_space{dict="api_keys"} 31264768
 openresty_shdict_free_space{dict="batched_reports"} 20840448
 openresty_shdict_free_space{dict="batched_reports_locks"} 1032192
 openresty_shdict_free_space{dict="cached_auths"} 20840448
-openresty_shdict_free_space{dict="configuration"} 10412032
-openresty_shdict_free_space{dict="init"} 249856
 openresty_shdict_free_space{dict="limiter"} 1032192
-openresty_shdict_free_space{dict="locks"} 1032192
 openresty_shdict_free_space{dict="prometheus_metrics"} 16662528
 openresty_shdict_free_space{dict="rate_limit_headers"} 20840448
 # HELP worker_process Number of times that a nginx worker has been started


### PR DESCRIPTION
Remove unused shared dict. May be help to save a few mb of memory 

## Verification steps

* Create a apicast-config.json file with the following content

```
cat <<EOF >apicast-config.json
{
    "services": [
        {
            "id": "1",
            "backend_version": "1",
            "proxy": {
                "hosts": [
                    "one"
                ],
                "api_backend": "https://echo-api.3scale.net:443",
                "backend": {
                    "endpoint": "http://127.0.0.1:8081",
                    "host": "backend"
                },
                "policy_chain": [
                    {
                        "name": "apicast.policy.apicast"
                    }
                ],
                "proxy_rules": [
                    {
                        "http_method": "GET",
                        "pattern": "/",
                        "metric_system_name": "hits",
                        "delta": 1,
                        "parameters": [],
                        "querystring_parameters": {}
                    }
                ]
            }
        }
    ]
} 
EOF
```
* Checkout this branch and start dev environment
```
make development
make dependencies
```
* Run apicast locally
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=debug APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=lazy APICAST_CONFIGURATION_CACHE=0  THREESCALE_CONFIG_FILE=apicast-config.json ./bin/apicast
```
* Capture apicast IP
```
APICAST_IP=$(docker inspect apicast_build_0-development-1 | yq e -P '.[0].NetworkSettings.Networks.apicast_build_0_default.IPAddress' -)
```
* Send a request
```
curl -i -k -H "Host: one" "http://${APICAST_IP}:8080/test?user_key="
```
* The response should be HTTP/1.1 200
```
HTTP/1.1 200 OK
Server: openresty
Date: Tue, 16 Apr 2024 06:56:54 GMT
Content-Type: application/json
Content-Length: 569
Connection: keep-alive
x-3scale-echo-api: echo-api/1.0.3
vary: Origin
x-content-type-options: nosniff
x-envoy-upstream-service-time: 0
```