### PR TITLE
[3scale_batcher] Update regrex to match app_id with special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed 3scale Batcher policy unable to handle `app_id`/`access_token` contains special characters [PR #1457](https://github.com/3scale/APIcast/pull/1457) [THREESCALE-10934](https://issues.redhat.com/browse/THREESCALE-10934)
+
 ## [3.15.0] 2024-04-04
 
 ### Fixed

--- a/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
@@ -40,9 +40,9 @@ end
 
 local regexes_report_key = {
   [[service_id:(?<service_id>[\w-]+),user_key:(?<user_key>[\S-]+),metric:(?<metric>[\S-]+)]],
-  [[service_id:(?<service_id>[\w-]+),access_token:(?<access_token>[\w-]+),metric:(?<metric>[\S-]+)]],
-  [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\w-]+),app_key:(?<app_key>[\S-]+),metric:(?<metric>[\S-]+)]],
-  [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\w-]+),metric:(?<metric>[\S-]+)]],
+  [[service_id:(?<service_id>[\w-]+),access_token:(?<access_token>[\S-]+),metric:(?<metric>[\S-]+)]],
+  [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\S-]+),app_key:(?<app_key>[\S-]+),metric:(?<metric>[\S-]+)]],
+  [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\S-]+),metric:(?<metric>[\S-]+)]],
 }
 
 function _M.key_for_cached_auth(transaction)


### PR DESCRIPTION
## What

A user reported similar error in #1453 but they have `app_id` with special chars instead.  I also think that user with `access_token` will have similar problem

From the portal code, app_id allows the following:

```
Allowed characters: 
A-Z a-z 0-9 ! " # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \ ] ^ _ ` { | } ~ # Spaces are not allowed
```

I'm not sure if porta ever validate `access_token` but from the RFC the format is as follow

```
b64token    = 1*( ALPHA / DIGIT /
                       "-" / "." / "_" / "~" / "+" / "/" ) *"="
credentials = "Bearer" 1*SP b64token
```

## Verification steps

* Configure Product A with app_id/app_key both contains special characters. For example
```
app_id: something:special
app_key: coffee_brain_food
```

* Configure batcher policy for both Product A and Product B with the following:

{ "name" : "apicast.policy.3scale_batcher", "configuration" : { "batch_report_seconds" : 1 } }

* Start dev environment
```
make development
make dependencies
```
* Run apicast locally
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=debug APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=lazy APICAST_CONFIGURATION_CACHE=0 THREESCALE_PORTAL_ENDPOINT=https://token@3scale-admin.example.com ./bin/apicast
```
* Capture APIcast IP
```
APICAST_IP=$(docker inspect apicast_build_0-development-1 | yq e -P '.[0].NetworkSettings.Networks.apicast_build_0_default.IPAddress' -)
```
* Send a  query to Product A with the valid app_id/app_key
```
curl -i -k -H "Host: example.com" "http://${APICAST_IP}:8080/?app_id=something:special&app_key=coffee_brain_food"
```
* Check that credentials not found error does not appear in the log. For example:
```
reports_batcher.lua:99: get_all(): failed to get report for key service_id:12,app_id:something:special,app_key:coffee_brain_food,metric:Hits err: credentials not found, context: ngx.timer, client: 10.10.10.1, server: 0.0.0.0:8080 
```

---
* Configure a single Product B with an OpenID Provider + realm `basic `
* Create 3scale application App01 for product B. That will generate Client ID and Client Secret.
* Configure batcher policy for Product B with the following:
```
{ "name" : "apicast.policy.3scale_batcher", "configuration" : { "batch_report_seconds" : 1 } }
```
* Generate token from a realm basic using client credentials from the application App01
```
curl -v -k -H "Content-Type: application/x-www-form-urlencoded" \
        -d 'grant_type=password' \
        -d 'client_id=${CLIENT_ID_FROM_3SCALE_APPLICATION}' \
        -d 'client_secret=${CLIENT_SECRET_FROM_3SCALE_APPLICATION}' \
        -d 'username=${USER_CREATED_IN_KEYCLOAK}' \
        -d 'password=***' "https://keycloak.example.com/auth/realms/basic/protocol/openid-connect/token"

# capture access token
ACCESS_TOKEN=eyJhb...
``` 

* Send a query to Product B with a valid access token
```
curl -i -k -H "Host: example.com"  -H "Authorization: Bearer ${ACCESS_TOKEN}" "http://${APICAST_IP}:8080/"
```

* Check that credentials not found error does not appear in the log. For example:
