### PR TITLE
THREESCALE-11015 - Support client_secret_jwt and private_key_jwt as authentication type for token introspection policy

### DIFF
--- a/gateway/src/apicast/policy/token_introspection/apicast-policy.json
+++ b/gateway/src/apicast/policy/token_introspection/apicast-policy.json
@@ -11,7 +11,7 @@
     "properties": {
       "auth_type": {
         "type": "string",
-        "enum": ["use_3scale_oidc_issuer_endpoint", "client_id+client_secret", "client_secret_jwt"],
+        "enum": ["use_3scale_oidc_issuer_endpoint", "client_id+client_secret", "client_secret_jwt", "private_key_jwt"],
         "default": "client_id+client_secret"
       },
       "max_ttl_tokens": {
@@ -84,6 +84,11 @@
                 "description": "Audience. The aud claim of the singed JWT. The audience SHOULD be the URL of the Authorization Server’s Token Endpoint.",
                 "type": "string"
               },
+              "client_jwt_assertion_algorithm": {
+                "type": "string",
+                "enum": ["HS256"],
+                "default": "HS256"
+              },
               "introspection_url": {
                 "description": "Introspection Endpoint URL",
                 "type": "string"
@@ -92,6 +97,78 @@
             "required": [
               "client_id", "client_secret", "introspection_url", "client_jwt_assertion_audience"
             ]
+        }, {
+          "properties": {
+            "auth_type": {
+              "describe": "Authenticate with client_secret_jwt method defined in https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication",
+              "enum": ["private_key_jwt"]
+            },
+            "client_id": {
+              "description": "Client ID for the Token Introspection Endpoint",
+              "type": "string"
+            },
+            "introspection_url": {
+              "description": "Introspection Endpoint URL",
+              "type": "string"
+            },
+            "client_jwt_assertion_expires_in": {
+              "description": "Duration of the singed JWT in seconds",
+              "type": "integer",
+              "default": 60
+            },
+            "client_jwt_assertion_audience": {
+              "description": "Audience. The aud claim of the singed JWT. The audience SHOULD be the URL of the Authorization Server’s Token Endpoint.",
+              "type": "string"
+            },
+            "client_jwt_assertion_algorithm": {
+              "type": "string",
+              "enum": ["RS256"],
+              "default": "RS256"
+            },
+            "certificate_type": {
+              "title": "Certificate type",
+              "type": "string",
+              "enum": [
+                "path",
+                "embedded"
+              ],
+              "default": "path"
+            }
+          },
+          "dependencies": {
+            "certificate_type": {
+              "oneOf": [
+                {
+                  "properties": {
+                    "certificate_type": {
+                      "const": "embedded"
+                    },
+                    "certificate": {
+                      "title": "Certificate",
+                      "description": "Client RSA private key used to sign JWT.",
+                      "format": "data-url",
+                      "type": "string"
+                    }
+                  }
+                },
+                {
+                  "properties": {
+                    "certificate_type": {
+                      "const": "path"
+                    },
+                    "certificate": {
+                      "title": "Certificate",
+                      "description": "Client RSA private key used to sign JWT.",
+                      "type": "string"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "required": [
+            "client_id", "introspection_url", "client_jwt_assertion_audience", "certificate_type"
+          ]
         }]
       }
     }

--- a/gateway/src/apicast/policy/token_introspection/apicast-policy.json
+++ b/gateway/src/apicast/policy/token_introspection/apicast-policy.json
@@ -11,7 +11,7 @@
     "properties": {
       "auth_type": {
         "type": "string",
-        "enum": ["use_3scale_oidc_issuer_endpoint", "client_id+client_secret"],
+        "enum": ["use_3scale_oidc_issuer_endpoint", "client_id+client_secret", "client_secret_jwt"],
         "default": "client_id+client_secret"
       },
       "max_ttl_tokens": {
@@ -61,6 +61,37 @@
           "required": [
             "client_id", "client_secret", "introspection_url"
           ]
+        }, {
+            "properties": {
+              "auth_type": {
+                "describe": "Authenticate with client_secret_jwt method defined in https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication",
+                "enum": ["client_secret_jwt"]
+              },
+              "client_id": {
+                "description": "Client ID for the Token Introspection Endpoint",
+                "type": "string"
+              },
+              "client_secret": {
+                "description": "Client Secret for the Token Introspection Endpoint",
+                "type": "string"
+              },
+              "client_jwt_assertion_expires_in": {
+                "description": "Duration of the singed JWT in seconds",
+                "type": "integer",
+                "default": 60
+              },
+              "client_jwt_assertion_audience": {
+                "description": "Audience. The aud claim of the singed JWT. The audience SHOULD be the URL of the Authorization Server’s Token Endpoint.",
+                "type": "string"
+              },
+              "introspection_url": {
+                "description": "Introspection Endpoint URL",
+                "type": "string"
+              }
+            },
+            "required": [
+              "client_id", "client_secret", "introspection_url", "client_jwt_assertion_audience"
+            ]
         }]
       }
     }

--- a/gateway/src/apicast/policy/token_introspection/apicast-policy.json
+++ b/gateway/src/apicast/policy/token_introspection/apicast-policy.json
@@ -84,11 +84,6 @@
                 "description": "Audience. The aud claim of the singed JWT. The audience SHOULD be the URL of the Authorization Server’s Token Endpoint.",
                 "type": "string"
               },
-              "client_jwt_assertion_algorithm": {
-                "type": "string",
-                "enum": ["HS256"],
-                "default": "HS256"
-              },
               "introspection_url": {
                 "description": "Introspection Endpoint URL",
                 "type": "string"
@@ -119,11 +114,6 @@
             "client_jwt_assertion_audience": {
               "description": "Audience. The aud claim of the singed JWT. The audience SHOULD be the URL of the Authorization Server’s Token Endpoint.",
               "type": "string"
-            },
-            "client_jwt_assertion_algorithm": {
-              "type": "string",
-              "enum": ["RS256"],
-              "default": "RS256"
             },
             "certificate_type": {
               "title": "Certificate type",

--- a/gateway/src/apicast/policy/token_introspection/token_introspection.lua
+++ b/gateway/src/apicast/policy/token_introspection/token_introspection.lua
@@ -28,7 +28,8 @@ function _M.new(config)
   --- authorization for the token introspection endpoint.
   -- https://tools.ietf.org/html/rfc7662#section-2.2
   if self.auth_type == "client_id+client_secret" then
-    self.credential = create_credential(self.config.client_id or '', self.config.client_secret or '')
+    self.client_id = self.config.client_id or ''
+    self.client_secret = self.config.client_secret or ''
     self.introspection_url = config.introspection_url
   end
   self.http_client = http_ng.new{
@@ -60,10 +61,15 @@ local function introspect_token(self, token)
   local cached_token_info = self.tokens_cache:get(token)
   if cached_token_info then return cached_token_info end
 
+  local headers = {}
+  if self.client_id and self.client_secret then
+    headers['Authorization'] = create_credential(self.client_id or '', self.client_secret or '')
+  end
+
   --- Parameters for the token introspection endpoint.
   -- https://tools.ietf.org/html/rfc7662#section-2.1
   local res, err = self.http_client.post{self.introspection_url , { token = token, token_type_hint = 'access_token'},
-    headers = {['Authorization'] = self.credential}}
+    headers = headers}
   if err then
     ngx.log(ngx.WARN, 'token introspection error: ', err, ' url: ', self.introspection_url)
     return { active = false }
@@ -93,7 +99,8 @@ function _M:access(context)
     end
 
     local components = resty_url.parse(context.service.oidc.issuer_endpoint)
-    self.credential = create_credential(components.user, components.password)
+    self.client_id = components.user
+    self.client_secret = components.password
     local oauth_config = context.proxy.oauth.config
     -- token_introspection_endpoint being deprecated in RH SSO 7.4 and removed in 7.5
     -- https://access.redhat.com/documentation/en-us/red_hat_single_sign-on/7.5/html-single/upgrading_guide/index#non_standard_token_introspection_endpoint_removed

--- a/gateway/src/apicast/policy/token_introspection/token_introspection.lua
+++ b/gateway/src/apicast/policy/token_introspection/token_introspection.lua
@@ -7,6 +7,7 @@ local http_ng = require 'resty.http_ng'
 local user_agent = require 'apicast.user_agent'
 local resty_env = require('resty.env')
 local resty_url = require('resty.url')
+local resty_jwt = require('resty.jwt')
 
 local tokens_cache = require('tokens_cache')
 
@@ -27,10 +28,15 @@ function _M.new(config)
   self.auth_type = config.auth_type or "client_id+client_secret"
   --- authorization for the token introspection endpoint.
   -- https://tools.ietf.org/html/rfc7662#section-2.2
-  if self.auth_type == "client_id+client_secret" then
+  if self.auth_type ~= "use_3scale_oidc_issuer_endpoint" then
     self.client_id = self.config.client_id or ''
     self.client_secret = self.config.client_secret or ''
     self.introspection_url = config.introspection_url
+
+    if self.auth_type == "client_secret_jwt" then
+      self.client_jwt_assertion_expires_in = self.config.client_jwt_assertion_expires_in or 60
+      self.client_aud = config.client_jwt_assertion_audience or ''
+    end
   end
   self.http_client = http_ng.new{
     backend = config.client,
@@ -62,14 +68,41 @@ local function introspect_token(self, token)
   if cached_token_info then return cached_token_info end
 
   local headers = {}
-  if self.client_id and self.client_secret then
-    headers['Authorization'] = create_credential(self.client_id or '', self.client_secret or '')
+
+  local body = {
+    token = token,
+    token_type_hint = 'access_token'
+  }
+
+  if self.auth_type == "client_id+client_secret" or self.auth_type == "use_3scale_oidc_issuer_endpoint" then
+      headers['Authorization'] = create_credential(self.client_id or '', self.client_secret or '')
+  elseif self.auth_type == "client_secret_jwt" then
+    local key = self.client_secret
+    body.client_id = self.client_id
+    body.client_assertion_type = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+    local now = ngx.time()
+
+    local assertion = {
+      header = {
+        typ = "JWT",
+        alg = "HS256",
+      },
+      payload = {
+        iss = self.client_id,
+        sub = self.client_id,
+        aud = self.client_aud,
+        jti = ngx.var.request_id,
+        exp = now + (self.client_jwt_assertion_expires_in and self.client_jwt_assertion_expires_in or 60),
+        iat = now
+      }
+    }
+
+    body.client_assertion = resty_jwt:sign(key, assertion)
   end
 
   --- Parameters for the token introspection endpoint.
   -- https://tools.ietf.org/html/rfc7662#section-2.1
-  local res, err = self.http_client.post{self.introspection_url , { token = token, token_type_hint = 'access_token'},
-    headers = headers}
+  local res, err = self.http_client.post{self.introspection_url , body, headers = headers}
   if err then
     ngx.log(ngx.WARN, 'token introspection error: ', err, ' url: ', self.introspection_url)
     return { active = false }

--- a/gateway/src/apicast/policy/token_introspection/token_introspection.lua
+++ b/gateway/src/apicast/policy/token_introspection/token_introspection.lua
@@ -68,7 +68,6 @@ function _M.new(config)
     if self.auth_type == "client_secret_jwt" or self.auth_type == "private_key_jwt" then
       self.client_jwt_assertion_expires_in = self.config.client_jwt_assertion_expires_in or 60
       self.client_aud = config.client_jwt_assertion_audience or ''
-      self.client_algorithm = config.client_jwt_assertion_algorithm
     end
 
     if self.auth_type == "private_key_jwt" then
@@ -129,7 +128,7 @@ local function introspect_token(self, token)
     local assertion = {
       header = {
         typ = "JWT",
-        alg = self.client_algorithm,
+        alg = self.auth_type == "client_secret_jwt" and "HS256" or "RS256",
       },
       payload = {
         iss = self.client_id,

--- a/spec/policy/token_introspection/token_introspection_spec.lua
+++ b/spec/policy/token_introspection/token_introspection_spec.lua
@@ -4,6 +4,8 @@ local format = string.format
 local test_backend_client = require('resty.http_ng.backend.test')
 local cjson = require('cjson')
 local resty_jwt = require "resty.jwt"
+local util = require 'apicast.util'
+
 describe("token introspection policy", function()
   describe("execute introspection", function()
     local context
@@ -398,6 +400,134 @@ describe("token introspection policy", function()
       end)
 
       it('failed with invalid token', function()
+        test_backend
+          .expect{
+            url = introspection_url,
+            method = 'POST',
+          }
+          .respond_with{
+            status = 200,
+            body = cjson.encode({
+                active = false
+            })
+          }
+        stub(ngx, 'say')
+        stub(ngx, 'exit')
+
+        local token_policy = TokenIntrospection.new(policy_config)
+        token_policy.http_client.backend = test_backend
+        token_policy:access(context)
+        assert_authentication_failed()
+      end)
+    end)
+
+    describe('private_key_jwt introspection auth type', function()
+      local auth_type = "private_key_jwt"
+      local introspection_url = "http://example/token/introspection"
+      local audience = "http://example/auth/realm/basic"
+      local certificate_path = 't/fixtures/rsa.pem'
+      local path_type = "path"
+      local embedded_type = "embedded"
+
+      describe("certificate validation", function()
+        it("Reads correctly the file path", function()
+          local policy_config = {
+            auth_type = auth_type,
+            introspection_url = introspection_url,
+            client_id = test_client_id,
+            client_jwt_assertion_audience = audience,
+            certificate = certificate_path,
+            certificate_type = path_type,
+          }
+          local token_policy = TokenIntrospection.new(policy_config)
+          assert.truthy(token_policy.client_rsa_private_key)
+        end)
+
+        it("Read correctly the embedded path", function()
+          local policy_config = {
+            auth_type = auth_type,
+            introspection_url = introspection_url,
+            client_id = test_client_id,
+            client_jwt_assertion_audience = audience,
+            certificate_type = embedded_type,
+            certificate = "data:application/x-x509-ca-cert;name=rsa.pem;base64,LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlCUEFJQkFBSkJBTENsejk2Y0RROTY1RU5ZTWZaekcrQWN1MjVscHgyS05wQUFMQlErY2F0Q0E1OXVzNyt1CkxZNXJqUVI2U09nWnBDejVQSmlLTkFkUlBESk1YU21YcU0wQ0F3RUFBUUpCQUpud1phNEJJQUNWZjhhUVhUb0EKSmhLdjkwYkZuMVRHMWJXMzhMSFRtUXM4RU05WENtZ2hMV0NqZTdkL05iVXJVY2VvdElPbmp0di94SFR5d0d0MgpOd0VDSVFEaHZNWkRRK1pSUmJid09OY3ZPOUc3aDZoRmd5MG9raXY2SmNpWmNjdnR4UUloQU1oVVRBV2dWMWhRCk8yeVdUUllSUVpvc0VJc0ZCM2taZnNMTWVUS2prOGRwQWlFQXNsc1o5Mm05bjNkS3JKRHNqRmhpUlI1Uk9PTUYKR2lvcjd4Qk5aOWUrdmRVQ0lEc2pmNG5OcXR0Y1hCNlRSRkIyYWFwc3hibDBrNTh4WXBWNUxYSkFqZmk1QWlFQQp2UmFTYXVCZlJDUDNKZ1hITmdjRFNXMDE3L0J0YndHaXo4YUlUdjZCMEZ3PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo="
+          }
+          local token_policy = TokenIntrospection.new(policy_config)
+          assert.truthy(token_policy.client_rsa_private_key)
+        end)
+      end)
+
+      describe('success with valid token', function()
+        local policy_config = {
+          auth_type = auth_type,
+          introspection_url = introspection_url,
+          client_id = test_client_id,
+          client_jwt_assertion_audience = audience,
+          certificate = certificate_path,
+          certificate_type = path_type,
+        }
+        before_each(function()
+          test_backend
+            .expect{
+              url = introspection_url,
+              method = 'POST',
+            }
+            .respond_with{
+              status = 200,
+              body = cjson.encode({
+                  active = true
+              })
+            }
+          local token_policy = TokenIntrospection.new(policy_config)
+          token_policy.http_client.backend = test_backend
+          token_policy:access(context)
+        end)
+
+        it('the request does not contains basic auth header', function()
+          assert.is_nil(test_backend.get_requests()[1].headers['Authorization'])
+        end)
+
+        it('the request does not contains client_secret in body', function()
+          local body = ngx.decode_args(test_backend.get_requests()[1].body)
+          assert.is_nil(body.client_secret)
+        end)
+
+        it('the request contains correct fields in body', function()
+          local body = ngx.decode_args(test_backend.get_requests()[1].body)
+          assert.same(body.client_id, test_client_id)
+          assert.same(body.client_assertion_type, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+          assert.is_not_nil(body.client_assertion)
+        end)
+
+        it("has correct JWT headers", function()
+          local body = ngx.decode_args(test_backend.get_requests()[1].body)
+          local jwt_obj = resty_jwt:load_jwt(body.client_assertion)
+          assert.same(jwt_obj.header.typ, "JWT")
+          assert.same(jwt_obj.header.alg, "RS256")
+        end)
+
+        it("has correct JWT body", function()
+          local body = ngx.decode_args(test_backend.get_requests()[1].body)
+          local jwt_obj = resty_jwt:load_jwt(body.client_assertion)
+          assert.same(jwt_obj.payload.sub, test_client_id)
+          assert.same(jwt_obj.payload.iss, test_client_id)
+          assert.truthy(jwt_obj.signature)
+          assert.truthy(jwt_obj.payload.jti)
+          assert.truthy(jwt_obj.payload.exp)
+          assert.is_true(jwt_obj.payload.exp > os.time())
+        end)
+      end)
+
+      it('failed with invalid token', function()
+        local policy_config = {
+          auth_type = auth_type,
+          introspection_url = introspection_url,
+          client_id = test_client_id,
+          client_secret = test_client_secret,
+          client_jwt_assertion_audience = audience,
+          certificate_type= "path",
+          certificate = certificate_path
+        }
         test_backend
           .expect{
             url = introspection_url,

--- a/spec/policy/token_introspection/token_introspection_spec.lua
+++ b/spec/policy/token_introspection/token_introspection_spec.lua
@@ -3,6 +3,7 @@ local TokensCache = require('apicast.policy.token_introspection.tokens_cache')
 local format = string.format
 local test_backend_client = require('resty.http_ng.backend.test')
 local cjson = require('cjson')
+local resty_jwt = require "resty.jwt"
 describe("token introspection policy", function()
   describe("execute introspection", function()
     local context
@@ -22,6 +23,7 @@ describe("token introspection policy", function()
       test_backend = test_backend_client.new()
       ngx.var = {}
       ngx.var.http_authorization = "Bearer "..test_access_token
+      ngx.var.request_id = "1234"
       context = {
         service = {
           auth_failed_status = 403,
@@ -328,6 +330,93 @@ describe("token introspection policy", function()
             { token = "test", token_type_hint = "access_token" })
       end)
 
+    end)
+
+    describe('client_secret_jwt introspection auth type', function()
+      local auth_type = "client_secret_jwt"
+      local introspection_url = "http://example/token/introspection"
+      local audience = "http://example/auth/realm/basic"
+      local policy_config = {
+        auth_type = auth_type,
+        introspection_url = introspection_url,
+        client_id = test_client_id,
+        client_secret = test_client_secret,
+        client_jwt_assertion_audience = audience,
+      }
+
+      describe('success with valid token', function()
+        local token_policy = TokenIntrospection.new(policy_config)
+        before_each(function()
+          test_backend
+            .expect{
+              url = introspection_url,
+              method = 'POST',
+            }
+            .respond_with{
+              status = 200,
+              body = cjson.encode({
+                  active = true
+              })
+            }
+          token_policy.http_client.backend = test_backend
+          token_policy:access(context)
+        end)
+
+        it('the request does not contains basic auth header', function()
+          assert.is_nil(test_backend.get_requests()[1].headers['Authorization'])
+        end)
+
+        it('the request does not contains client_secret in body', function()
+          local body = ngx.decode_args(test_backend.get_requests()[1].body)
+          assert.is_nil(body.client_secret)
+        end)
+
+        it('the request contains correct fields in body', function()
+          local body = ngx.decode_args(test_backend.get_requests()[1].body)
+          assert.same(body.client_id, test_client_id)
+          assert.same(body.client_assertion_type, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+          assert.is_not_nil(body.client_assertion)
+        end)
+
+        it("has correct JWT headers", function()
+          local body = ngx.decode_args(test_backend.get_requests()[1].body)
+          local jwt_obj = resty_jwt:load_jwt(body.client_assertion)
+          assert.same(jwt_obj.header.typ, "JWT")
+          assert.same(jwt_obj.header.alg, "HS256")
+        end)
+
+        it("has correct JWT body", function()
+          local body = ngx.decode_args(test_backend.get_requests()[1].body)
+          local jwt_obj = resty_jwt:load_jwt(body.client_assertion)
+          assert.same(jwt_obj.payload.sub, test_client_id)
+          assert.same(jwt_obj.payload.iss, test_client_id)
+          assert.truthy(jwt_obj.signature)
+          assert.truthy(jwt_obj.payload.jti)
+          assert.truthy(jwt_obj.payload.exp)
+          assert.is_true(jwt_obj.payload.exp > os.time())
+        end)
+      end)
+
+      it('failed with invalid token', function()
+        test_backend
+          .expect{
+            url = introspection_url,
+            method = 'POST',
+          }
+          .respond_with{
+            status = 200,
+            body = cjson.encode({
+                active = false
+            })
+          }
+        stub(ngx, 'say')
+        stub(ngx, 'exit')
+
+        local token_policy = TokenIntrospection.new(policy_config)
+        token_policy.http_client.backend = test_backend
+        token_policy:access(context)
+        assert_authentication_failed()
+      end)
     end)
 
     describe('when caching is enabled', function()

--- a/t/apicast-policy-token-introspection.t
+++ b/t/apicast-policy-token-introspection.t
@@ -666,3 +666,184 @@ my $jwt = encode_jwt(payload => {
 --- error_code: 403
 --- no_error_log
 [error]
+
+
+
+=== TEST 11: Token introspection request success with client_secret_jwt method
+--- backend
+  location /token/introspection {
+    content_by_lua_block {
+      ngx.req.read_body()
+      local args, err = ngx.req.get_post_args()
+      local assert = require('luassert')
+      assert.same(args.client_id, "app")
+      assert.same(args.client_assertion_type, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+      assert.is_not_nil(args.client_assertion)
+
+      local resty_jwt = require "resty.jwt"
+      local jwt_obj = resty_jwt:load_jwt(args.client_assertion)
+      assert.same(jwt_obj.header.typ, "JWT")
+      assert.same(jwt_obj.header.alg, "HS256")
+      assert.same(jwt_obj.payload.sub, "app")
+      assert.same(jwt_obj.payload.iss, "app")
+      assert.same(jwt_obj.payload.aud, "http://test_backend/auth/realms/basic")
+      assert.truthy(jwt_obj.signature)
+      assert.truthy(jwt_obj.payload.jti)
+      assert.truthy(jwt_obj.payload.exp)
+      assert.is_true(jwt_obj.payload.exp > os.time())
+      ngx.say('{"active": true}')
+    }
+  }
+
+  location /transactions/oauth_authrep.xml {
+    content_by_lua_block {
+      ngx.exit(200)
+    }
+  }
+
+--- configuration
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": {
+        "id_token_signing_alg_values_supported": [ "RS256" ],
+        "introspection_endpoint": "http://test_backend:$TEST_NGINX_SERVER_PORT/token/introspection"
+      },
+      "keys": { "somekid": { "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----", "alg": "RS256" } }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "http://app:appsec@test_backend:$TEST_NGINX_SERVER_PORT/issuer/endpoint",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.token_introspection",
+            "configuration": {
+              "auth_type": "client_secret_jwt",
+              "client_id": "app",
+              "client_secret": "appsec",
+              "introspection_url": "http://test_backend:$TEST_NGINX_SERVER_PORT/token/introspection",
+              "client_jwt_assertion_audience": "http://test_backend/auth/realms/basic"
+            }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /echo {
+    content_by_lua_block {
+      ngx.say('yay, api backend');
+    }
+  }
+--- request
+GET /echo
+--- more_headers eval
+use Crypt::JWT qw(encode_jwt);
+my $jwt = encode_jwt(payload => {
+  aud => 'the_token_audience',
+  sub => 'someone',
+  iss => 'https://example.com/auth/realms/apicast',
+  exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers => { kid => 'somekid' });
+"Authorization: Bearer $jwt"
+--- error_code: 200
+--- response_body
+yay, api backend
+--- no_error_log
+[error]
+oauth failed with
+
+
+
+=== TEST 12: Token introspection request failed with client_secret_jwt method
+    and invalid token
+--- backend
+  location /token/introspection {
+    content_by_lua_block {
+      ngx.say('{"active": false}')
+    }
+  }
+
+  location /transactions/oauth_authrep.xml {
+    content_by_lua_block {
+      ngx.exit(200)
+    }
+  }
+
+--- configuration
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": {
+        "id_token_signing_alg_values_supported": [ "RS256" ],
+        "introspection_endpoint": "http://test_backend:$TEST_NGINX_SERVER_PORT/token/introspection"
+      },
+      "keys": { "somekid": { "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----", "alg": "RS256" } }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "http://app:appsec@test_backend:$TEST_NGINX_SERVER_PORT/issuer/endpoint",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.token_introspection",
+            "configuration": {
+              "auth_type": "client_secret_jwt",
+              "client_id": "app",
+              "client_secret": "appsec",
+              "introspection_url": "http://test_backend:$TEST_NGINX_SERVER_PORT/token/introspection",
+              "client_jwt_assertion_audience": "http://test_backend/auth/realms/basic"
+            }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /echo {
+    content_by_lua_block {
+      ngx.say('yay, api backend');
+    }
+  }
+--- request
+GET /echo
+--- more_headers eval
+use Crypt::JWT qw(encode_jwt);
+my $jwt = encode_jwt(payload => {
+  aud => 'the_token_audience',
+  sub => 'someone',
+  iss => 'https://example.com/auth/realms/apicast',
+  exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers => { kid => 'somekid' });
+"Authorization: Bearer $jwt"
+--- error_code: 403
+--- response_body
+Authentication failed
+--- no_error_log
+[error]
+oauth failed with

--- a/t/apicast-policy-token-introspection.t
+++ b/t/apicast-policy-token-introspection.t
@@ -847,3 +847,187 @@ Authentication failed
 --- no_error_log
 [error]
 oauth failed with
+
+
+
+=== TEST 13: Token introspection request success with private_key_jwt method
+--- backend
+  location /token/introspection {
+    content_by_lua_block {
+      ngx.req.read_body()
+      local args, err = ngx.req.get_post_args()
+      local assert = require('luassert')
+      assert.same(args.client_id, "app")
+      assert.same(args.client_assertion_type, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+      assert.is_not_nil(args.client_assertion)
+
+      local resty_jwt = require "resty.jwt"
+      local jwt_obj = resty_jwt:load_jwt(args.client_assertion)
+      assert.same(jwt_obj.header.typ, "JWT")
+      assert.same(jwt_obj.header.alg, "RS256")
+      assert.same(jwt_obj.payload.sub, "app")
+      assert.same(jwt_obj.payload.iss, "app")
+      assert.same(jwt_obj.payload.aud, "http://test_backend/auth/realms/basic")
+      assert.truthy(jwt_obj.signature)
+      assert.truthy(jwt_obj.payload.jti)
+      assert.truthy(jwt_obj.payload.exp)
+      assert.is_true(jwt_obj.payload.exp > os.time())
+      ngx.say('{"active": true}')
+    }
+  }
+
+  location /transactions/oauth_authrep.xml {
+    content_by_lua_block {
+      ngx.exit(200)
+    }
+  }
+
+--- configuration
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": {
+        "id_token_signing_alg_values_supported": [ "RS256" ],
+        "introspection_endpoint": "http://test_backend:$TEST_NGINX_SERVER_PORT/token/introspection"
+      },
+      "keys": { "somekid": { "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----", "alg": "RS256" } }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "http://app:appsec@test_backend:$TEST_NGINX_SERVER_PORT/issuer/endpoint",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.token_introspection",
+            "configuration": {
+              "auth_type": "private_key_jwt",
+              "client_id": "app",
+              "introspection_url": "http://test_backend:$TEST_NGINX_SERVER_PORT/token/introspection",
+              "client_jwt_assertion_audience": "http://test_backend/auth/realms/basic",
+              "certificate_type": "embedded",
+              "certificate": "data:application/x-x509-ca-cert;name=rsa.pem;base64,LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlCUEFJQkFBSkJBTENsejk2Y0RROTY1RU5ZTWZaekcrQWN1MjVscHgyS05wQUFMQlErY2F0Q0E1OXVzNyt1CkxZNXJqUVI2U09nWnBDejVQSmlLTkFkUlBESk1YU21YcU0wQ0F3RUFBUUpCQUpud1phNEJJQUNWZjhhUVhUb0EKSmhLdjkwYkZuMVRHMWJXMzhMSFRtUXM4RU05WENtZ2hMV0NqZTdkL05iVXJVY2VvdElPbmp0di94SFR5d0d0MgpOd0VDSVFEaHZNWkRRK1pSUmJid09OY3ZPOUc3aDZoRmd5MG9raXY2SmNpWmNjdnR4UUloQU1oVVRBV2dWMWhRCk8yeVdUUllSUVpvc0VJc0ZCM2taZnNMTWVUS2prOGRwQWlFQXNsc1o5Mm05bjNkS3JKRHNqRmhpUlI1Uk9PTUYKR2lvcjd4Qk5aOWUrdmRVQ0lEc2pmNG5OcXR0Y1hCNlRSRkIyYWFwc3hibDBrNTh4WXBWNUxYSkFqZmk1QWlFQQp2UmFTYXVCZlJDUDNKZ1hITmdjRFNXMDE3L0J0YndHaXo4YUlUdjZCMEZ3PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo="
+            }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /echo {
+    content_by_lua_block {
+      ngx.say('yay, api backend');
+    }
+  }
+--- user_files
+--- request
+GET /echo
+--- more_headers eval
+use Crypt::JWT qw(encode_jwt);
+my $jwt = encode_jwt(payload => {
+  aud => 'the_token_audience',
+  sub => 'someone',
+  iss => 'https://example.com/auth/realms/apicast',
+  exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers => { kid => 'somekid' });
+"Authorization: Bearer $jwt"
+--- error_code: 200
+--- response_body
+yay, api backend
+--- no_error_log
+[error]
+oauth failed with
+
+
+
+=== TEST 14: Token introspection request failed with private_key_jwt method
+--- backend
+  location /token/introspection {
+    content_by_lua_block {
+      ngx.say('{"active": false}')
+    }
+  }
+
+  location /transactions/oauth_authrep.xml {
+    content_by_lua_block {
+      ngx.exit(200)
+    }
+  }
+
+--- configuration
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": {
+        "id_token_signing_alg_values_supported": [ "RS256" ],
+        "introspection_endpoint": "http://test_backend:$TEST_NGINX_SERVER_PORT/token/introspection"
+      },
+      "keys": { "somekid": { "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----", "alg": "RS256" } }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "http://app:appsec@test_backend:$TEST_NGINX_SERVER_PORT/issuer/endpoint",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.token_introspection",
+            "configuration": {
+              "auth_type": "private_key_jwt",
+              "client_id": "app",
+              "introspection_url": "http://test_backend:$TEST_NGINX_SERVER_PORT/token/introspection",
+              "client_jwt_assertion_audience": "http://test_backend/auth/realms/basic",
+              "certificate_type": "embedded",
+              "certificate": "data:application/x-x509-ca-cert;name=rsa.pem;base64,LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlCUEFJQkFBSkJBTENsejk2Y0RROTY1RU5ZTWZaekcrQWN1MjVscHgyS05wQUFMQlErY2F0Q0E1OXVzNyt1CkxZNXJqUVI2U09nWnBDejVQSmlLTkFkUlBESk1YU21YcU0wQ0F3RUFBUUpCQUpud1phNEJJQUNWZjhhUVhUb0EKSmhLdjkwYkZuMVRHMWJXMzhMSFRtUXM4RU05WENtZ2hMV0NqZTdkL05iVXJVY2VvdElPbmp0di94SFR5d0d0MgpOd0VDSVFEaHZNWkRRK1pSUmJid09OY3ZPOUc3aDZoRmd5MG9raXY2SmNpWmNjdnR4UUloQU1oVVRBV2dWMWhRCk8yeVdUUllSUVpvc0VJc0ZCM2taZnNMTWVUS2prOGRwQWlFQXNsc1o5Mm05bjNkS3JKRHNqRmhpUlI1Uk9PTUYKR2lvcjd4Qk5aOWUrdmRVQ0lEc2pmNG5OcXR0Y1hCNlRSRkIyYWFwc3hibDBrNTh4WXBWNUxYSkFqZmk1QWlFQQp2UmFTYXVCZlJDUDNKZ1hITmdjRFNXMDE3L0J0YndHaXo4YUlUdjZCMEZ3PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo="
+            }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+  location /echo {
+    content_by_lua_block {
+      ngx.say('yay, api backend');
+    }
+  }
+--- user_files
+--- request
+GET /echo
+--- more_headers eval
+use Crypt::JWT qw(encode_jwt);
+my $jwt = encode_jwt(payload => {
+  aud => 'the_token_audience',
+  sub => 'someone',
+  iss => 'https://example.com/auth/realms/apicast',
+  exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers => { kid => 'somekid' });
+"Authorization: Bearer $jwt"
+--- error_code: 403
+--- response_body
+Authentication failed
+--- no_error_log
+[error]
+oauth failed with


### PR DESCRIPTION
# Known issue
Some time failed with the following error 
```
/opt/app-root/src/gateway/src/apicast/policy_loader.lua:98: Invalid config for policy: failed to validate dependent schema for "auth_type": value should match only one schema, but matches none
```
~~This is due to the use of `oneOf` and seems like a bug. I will need to investigate this further.~~

The original intention was to add support for a single algorithm and then upgrade lua-retsy-jwt afterwards and have a minimal schema structure change. However, the jsonschema validation fails when the emum field only contains a single value so I decided to remove it for now.

~~@eguzki if you know a better way to build `apicast-config.json` or how to solve this problem, please let me know~~

-------
## What

This PR mainly adding 2 new authentication method for token introspection policy, `client_secret_jwt` and `private_key_jwt`. 

JIRA:  https://issues.redhat.com/browse/THREESCALE-11015
Reference: https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication

## Why only  HS256 and RS256 are supported?

This is due to the version of `lua-resty-jwt` (0.20) that we use

Support sign algorithm

|  | RHKB 24 | lua-resty-jwt 0.20 | lua-resty-0.2.2 | lua-resty-0.2.3 |
| ---- | ---- | ---- | ---- | ---- |
| client_secret_jwt | HS256</br>HS384</br>HS512 | HS256</br>HS512 | HS256</br>HS512 | HS256</br>HS512 |
| private_key_jwt | RS256</br>RS382</br>RS512</br>ES256</br>ES384</br>ES512</br>PS256</br>PS384</br>PS512 | RS256 | RS256</br>ES256 | RS256</br>RS512</br>ES256</br>ES512 |
|  |  |  |  |  |

Highest we can go is 0.2.2 but this only add support for ES256
0.2.3 introduce a new dependency lua-resty-openssl. See https://github.com/3scale/APIcast/issues/1375#issuecomment-1281071040

Eventually we will need an update but given the amount of work involved, I'd like to keep version 0.20 for now

## Verification steps:
### Validate `client_secret_jwt` authentication method
* Checkout this PR
* Build a new runtime image
```
$ make runtime-image IMAGE_NAME=apicast-test
```
* Navigate to keycloak dev-environment
```
$ cd dev-environments/keycloak-env
```
* Update apicast-config.json with the following
```diff
diff --git a/dev-environments/keycloak-env/apicast-config.json b/dev-environments/keycloak-env/apicast-config.json
index 071296cd..2ee79be1 100644
--- a/dev-environments/keycloak-env/apicast-config.json
+++ b/dev-environments/keycloak-env/apicast-config.json
@@ -90,6 +90,17 @@
               "auth_type": "use_3scale_oidc_issuer_endpoint"
             }
           },
+          {
+            "name": "token_introspection",
+            "version": "builtin",
+            "configuration": {
+              "auth_type": "client_secret_jwt",
+              "client_id": "oidc-issuer-for-3scale",
+              "client_secret": "oidc-issuer-for-3scale-secret",
+              "client_jwt_assertion_audience": "http://keycloak:8080/realms/basic/protocol/openid-connect/token",
+              "introspection_url": "http://keycloak:8080/realms/basic/protocol/openid-connect/token/introspect"
+            }
+          },
           {
             "name": "apicast",
             "version": "builtin",
```
* Start dev-environment
```
$ make gateway IMAGE_NAME=apicast-test
$ make keycloak-data
```
* Configure keycloak client to use `client-secret-jwt`
  * Open keycloak dashboard in the browser at `http://127.0.0.1:9090
  * Login with `admin/adminpass`
  * Navigate to `basic` realm
  * Navigate to Client -> `oidc-issuer-for-3scale` -> Credentials
  * Change `Client Authenticator` to `Signed JWT with Client Secret` and use `HS256` algorithm
  * Click Save
* Get the access token
```
$ export ACCESS_TOKEN=$(make token)
```
* Run request
```
$ curl -v --resolve stg.example.com:8080:127.0.0.1 -H "Authorization: Bearer ${ACCESS_TOKEN}" "http://stg.example.com:8080"
```
* The response should be 200
### Validate `private_key_jwt` authentication method
* Configure keycloak client to use `signed_jwt`
  * Navigate to the keycloak dashboard `Client -> oidc-issuer-for-3scale -> Credentials`
  * Change `Client Authenticator` to `Signed JWT` with RS256 signature algorithm
  * Navigate to `Key` tab and click generate a new key
  * Select archive format `PCKS12` and fill in required fill and save keystore file to local disk
  * From the downloaded `keystore.p12` file, run the following command to extract private key
```
openssl pkcs12 -in keystore.p12 -nodes -nocerts | openssl rsa -out privatekey.rsa
```
* Encode certificate as base64
```
$ openssl base64 -A -in privatekey.rsa
```
* Stop dev-environment
```
CTRL-C
```
* Update apicast-config.json
```diff
diff --git a/dev-environments/keycloak-env/apicast-config.json b/dev-environments/keycloak-env/apicast-config.json
index 071296cd..a5ff3ffb 100644
--- a/dev-environments/keycloak-env/apicast-config.json
+++ b/dev-environments/keycloak-env/apicast-config.json
@@ -90,6 +90,19 @@
               "auth_type": "use_3scale_oidc_issuer_endpoint"
             }
           },
+          {
+            "name": "token_introspection",
+            "version": "builtin",
+            "configuration": {
+              "auth_type": "private_key_jwt",
+              "client_id": "oidc-issuer-for-3scale",
+              "client_secret": "oidc-issuer-for-3scale-secret",
+              "client_jwt_assertion_audience": "http://keycloak:8080/realms/basic/protocol/openid-connect/token",
+              "introspection_url": "http://keycloak:8080/realms/basic/protocol/openid-connect/token/introspect",
+              "certificate_type": "embedded",
+              "certificate": "data:application/octet-stream;name=privatekey.rsa;base64,LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2d0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktrd2dnU2xBZ0VBQW9JQkFRRDQwNWl2OG5GNlNpTmIKUFVIOTdqVjVxNXliOVlDd3hXVGdQZVF1Y0l0c1RJWDNMcDF1aSs5TXZueDUzYStERGhmUjJ2SE5hcS90aXE1aQpsalNGL3V1TEZZdjhPOGc0eFVZUTVFTjFjR1VDSld1NkRTNmtDRFI2VjM0MVgxb0xpWUp4M05zbHdLdUcwcm5qCmpyZURpK2tXaHdrMWZYVE5LczJRSlI1U
npsbW9YMFN5Wnh5YzUyN2ZZYmdjRGlQUFI3RTZrT2wvdXdEMlI4bk0KY28xcE5EKzJvL2svMWtQV2dLNXlZeEswYmRRd2JpcENoKzBUaUlnSXBxS3h0WVlZVHZyalVoRjNUNHpCYXErNQpNZ1ljRjdFSlRJM3ZFaklodmFSN1ZjUjNsYW9QUU9KcCtQMmErUkZCN3IwMEVOTHduUmdyWXhHa1JtK3dUeDA5CjZnTnozTFh6QWdNQkFBRUNnZ0VBTmxjN29yMC9WQllwMTR5dXcwNkpCaXZZMVdTTnVNMDdKUS9QSytjdlE3VUkKa3IxdTYwd0xORWJyZDAvWE96ZFNNMlh0NWM4VllicW1MK2lleXQ2cndTR3hBeUpwTFNERUZ2OUt6alNBRXJKcQpidVRmR1RxamYwNXBS
UzJ3UkJIQlY2MkVmSit4dGcyQ1JEU1FWbDJ4UjFheFI2bkEzdWVvb2dEQk9OdG9VREVqCjJhMDNQd2M0ano1Qlo4RmZsQ3JPcmE5M2dlTlRpLzRRTUwrZDdlbWIrQjN3a2R4aFF4ZnUwdWtxeUl6c1VXTy8KV2plMzFQbWZRL0hKRUhtM3BUMklySTIva21lQjN4NzBkUmRLYnJEK2taMXFDK2JpOWhoZjUvZThVbzBWM0d5RgoxeDd5RXQ2VHY5aWk2UjZESVlUMDV1T1V1MUU2aXVOQmN3SzFBSWYwRlFLQmdRRDlrV3pOMzNUZVpKSFBFdjdMCmlQNmFEbjdDS1liWVRwcDVOT0dkL3Vab2Q4dTV1ZkZJRW1NV00yc0RMZEp3cGRIWVRpZENxSktlQlRkbC85ODUKcU9
WNHRLbmxNV2NZam96bysrT0JPc2U0cnd0NDNCMVRLNzRDdHRCYlZWVElPbnVqdlk4d2EvU0hiaDlESlNFLwpEcjdOeUxiWDloY3BLeHVIaHF0NWJqV1hiUUtCZ1FEN05vZWU5eVFSYklQbUxHRjI3QnFmenBXdjhERDNuUkdBCnFBWnY2VHdTblpUOTM5UVlzRi9ZLzIxdjVPamdGcGJERmt4S3lNMkJHV09sZ1RMaXZHUnIzZ2o3TGxMRUh6OTYKejRVSEUzVlpJbDVIY2hQemZHakpVVVJscXVxbk1MRHJ5ME1uZ1RIREhuME5KdXhJTm9xUXdPaHJpQ1FRSzVOMwoxelJoSVI1RzN3S0JnUURqd3VPYmpMTWFLL1c0cmRSR0dIaXhBb0lqZjArTExoZWM5YjRPdis1UU
9nSzVnZWJUCm1RaDk0Wk9tMkZybEtsenlVVWo4bkJTT2Noc1B1S1RXMHZuRDBXdWwzaGsvdXBPaGx0Z0V0VHEramlUYzI4SlAKZWNRRUJoZmpZaU4wY3V1cDZWUWI1MnhPMWNDby9Fbi9yUXdBSmVEdTNUSnluVER1TEM0TU5jMVhoUUtCZ1FDcwphVUZ0UGFzNGRpU1ViYk02dmxLTGlXbzhoUG5taDV0Q2xJOU9jV0cwV1FpdnNOWE5XQWVBVTlZVkxLTVRZUTE1CnVTMEZTb21ZYUFkMnlKUlcvdnRnK05OcktPRFBENjh1cDR4aVRkMkZIa3hjZHBQdzBWck5pSVFMenVFYmZCU0EKMEZFM3BMaTFkSkJZM1hUZkh1ZTg3MWpVckd3cjJPeHVISG9yaTJKUE93S0JnU
UNoTUxUUXFBNlE2Qk9CUFAxYQpsQlNSMG05RUJld0k2Y0s0QmhUNVl0U21JUjN3Kzk3OWN5eEJJQ0JVcHRMelEyVzMwM0syc1l2RXhkYzRTU2hVCkFuV01jZE5WWDhvQmc4bEFpZTFuaUFuTmFqb213SGxCV25OUUVUZjdTYmR6NHFFUFVFbFJRaXRId0VhUjdIbmQKMG1tQzRXcllqQUJVRDFUMlVUWXdQYWJmbWc9PQotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg=="
+            }
+          },
           {
             "name": "apicast",
             "version": "builtin",
```
Replace the content after `base64` with the based64 string of your certificate from previous step.
* Start gateway
```
$ make gateway IMAGE_NAME=apicast-test
```
* Run request
```
$ curl -v --resolve stg.example.com:8080:127.0.0.1 -H "Authorization: Bearer ${ACCESS_TOKEN}" "http://stg.example.com:8080"
```
* The response should be 200

