### PR TITLE
[THREESCALE-11019] - FAPI advance profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Bump openresty to 1.21.4.3 [PR #1461](https://github.com/3scale/APIcast/pull/1461) [THREESCALE-10601](https://issues.redhat.com/browse/THREESCALE-10601)
 
-- Support Financial-grade API (FAPI) - Baseline profile [PR #1465](https://github.com/3scale/APIcast/pull/1465) [THREESCALE-10973](https://issues.redhat.com/browse/THREESCALE-10973)
+- Support Financial-grade API (FAPI) 1.0 - Baseline profile [PR #1465](https://github.com/3scale/APIcast/pull/1465) [THREESCALE-10973](https://issues.redhat.com/browse/THREESCALE-10973)
+
+- Support Financial-grade API (FAPI) 1.0 - Advance profile [PR #1465](https://github.com/3scale/APIcast/pull/1466) [THREESCALE-11019](https://issues.redhat.com/browse/THREESCALE-11019)
 
 ## [3.15.0] 2024-04-04
 

--- a/gateway/src/apicast/policy/fapi/README.md
+++ b/gateway/src/apicast/policy/fapi/README.md
@@ -4,6 +4,9 @@
 
 The FAPI policy supports various features of the Financial-grade API (FAPI) standard.
 
+* FAPI 1.0 Baseline Profile
+* FAPI 1.0 Advance Profile
+
 ## Example configuration
 
 ```
@@ -23,6 +26,22 @@ The FAPI policy supports various features of the Financial-grade API (FAPI) stan
       "name": "apicast.policy.fapi",
       "configuration": {
         "validate_x_fapi_customer_ip_address": true
+      }
+    },
+    {
+      "name": "apicast.policy.apicast"
+    }
+]
+```
+
+### Validate certificate-bound access tokens
+
+```
+"policy_chain": [
+    {
+      "name": "apicast.policy.fapi",
+      "configuration": {
+        "enable_oauth2_mtls": true
       }
     },
     {

--- a/gateway/src/apicast/policy/fapi/README.md
+++ b/gateway/src/apicast/policy/fapi/README.md
@@ -41,7 +41,7 @@ The FAPI policy supports various features of the Financial-grade API (FAPI) stan
     {
       "name": "apicast.policy.fapi",
       "configuration": {
-        "enable_oauth2_mtls": true
+        "validate_oauth2_certificate_bound_access_token": true
       }
     },
     {

--- a/gateway/src/apicast/policy/fapi/apicast-config.json
+++ b/gateway/src/apicast/policy/fapi/apicast-config.json
@@ -9,7 +9,14 @@
     "type": "object",
     "properties": {
       "validate_x_fapi_customer_ip_address": {
-        "description": "Validate x-fapi-customer-ip-address header",
+        "description": "Validate x-fapi-customer-ip-address header. If the verification fails, the request will be rejected with 403",
+        "title": "Validate x-fapi-customer-ip-address header",
+        "type": "boolean",
+        "default": "false"
+      },
+      "validate_oauth2_certificate_bound_access_token ": {
+        "description": "Validate OAuth 2.0 Mutual TLS Certificate Bound access token. If enable, all tokens are verified and must contain the certificate hash claim (cnf). If the verification fails, the request will be rejected with 401.",
+        "title": "Validate OAuth 2.0 Mutual TLS Certificate Bound access token",
         "type": "boolean",
         "default": "false"
       }

--- a/gateway/src/apicast/policy/fapi/fapi.lua
+++ b/gateway/src/apicast/policy/fapi/fapi.lua
@@ -1,15 +1,26 @@
 --- Financial-grade API (FAPI) policy
+-- Current support the following profile:
+--    FAPI 1.0 - Baseline profile
+--    FAPI 1.0 - Advance profile
 
 local policy = require('apicast.policy')
 local _M = policy.new('Financial-grade API (FAPI) Policy', 'builtin')
 
 local uuid = require 'resty.jit-uuid'
 local ipmatcher = require "resty.ipmatcher"
+local X509 = require('resty.openssl.x509')
+local b64 = require('ngx.base64')
 local fmt = string.format
 
 local new = _M.new
 local X_FAPI_TRANSACTION_ID_HEADER = "x-fapi-transaction-id"
 local X_FAPI_CUSTOMER_IP_ADDRESS = "x-fapi-customer-ip-address"
+
+-- The "x5t#S256" (X.509 Certificate SHA-256 Thumbprint) Header
+-- Parameter is a base64url encoded SHA-256 thumbprint (a.k.a. digest)
+-- of the DER encoding of the X.509 certificate.
+-- https://tools.ietf.org/html/rfc7515#section-4.1.8
+local header_parameter = 'x5t#S256'
 
 local function is_valid_ip(ip)
   if type(ip) ~= "string" then
@@ -29,16 +40,43 @@ local function error(status_code, msg)
   ngx.exit(ngx.status)
 end
 
+-- https://datatracker.ietf.org/doc/html/rfc8705#name-jwt-certificate-thumbprint-
+local function check_certificate(cert, cnf)
+  if not cert then
+    ngx.log(ngx.DEBUG, "client certificate is not available")
+    return false
+  end
+
+  if not cnf then
+    ngx.log(ngx.DEBUG, "cnf claim is not available")
+    return false
+  end
+  return b64.encode_base64url(cert:digest('SHA256')) == cnf[header_parameter]
+end
+
 --- Initialize FAPI policy
 -- @tparam[config] table config
 -- @field[config] validate_x_fapi_customer_ip_address Boolean
+-- @field[config] validate_oauth2_certificate_bound_access_token Boolean
 function _M.new(config)
   local self = new(config)
   self.validate_customer_ip_address = config and config.validate_x_fapi_customer_ip_address
+  self.validate_oauth2_certificate_bound_access_token = config and config.validate_oauth2_certificate_bound_access_token
   return self
 end
 
-function _M:access()
+function _M:access(context)
+  if self.validate_oauth2_certificate_bound_access_token then
+    if not context.jwt then return error(context.service or {}) end
+
+    local cert = X509.parse_pem_cert(ngx.var.ssl_client_raw_cert)
+
+    if not check_certificate(cert, context.jwt.cnf) then
+      ngx.log(ngx.WARN, 'fapi oauth_mtls failed for service ', context.service and context.service.id)
+      return error(ngx.HTTP_UNAUTHORIZED, "invalid_token")
+    end
+  end
+
   --- 6.2.1.13
   -- shall not reject requests with a x-fapi-customer-ip-address header containing a valid IPv4 or IPv6 address.
   if self.validate_customer_ip_address then

--- a/spec/policy/fapi/fapi_spec.lua
+++ b/spec/policy/fapi/fapi_spec.lua
@@ -1,5 +1,15 @@
 local FAPIPolicy = require('apicast.policy.fapi')
 local uuid = require('resty.jit-uuid')
+local X509 = require('resty.openssl.x509')
+local b64 = require('ngx.base64')
+local clientCert = assert(fixture('CA', 'client.crt'))
+
+local header_parameter = 'x5t#S256'
+
+local function jwt_cnf()
+  local cnf = b64.encode_base64url(X509.parse_pem_cert(clientCert):digest('SHA256'))
+  return { [header_parameter] = b64.encode_base64url(X509.parse_pem_cert(clientCert):digest('SHA256')) }
+end
 
 describe('fapi_1_baseline_profile policy', function()
     local ngx_req_headers = {}
@@ -27,29 +37,29 @@ describe('fapi_1_baseline_profile policy', function()
   describe('.header_filter', function()
     it('Use value from request', function()
         ngx_req_headers['x-fapi-transaction-id'] = 'abc'
-        local transaction_id_policy = FAPIPolicy.new({})
-        transaction_id_policy:header_filter()
+        local fapi_policy = FAPIPolicy.new({})
+        fapi_policy:header_filter()
         assert.same('abc', ngx.header['x-fapi-transaction-id'])
     end)
 
     it('Only use x-fapi-transaction-id from request if the header also exist in response from upstream', function()
         ngx_req_headers['x-fapi-transaction-id'] = 'abc'
         ngx_resp_headers['x-fapi-transaction-id'] = 'bdf'
-        local transaction_id_policy = FAPIPolicy.new({})
-        transaction_id_policy:header_filter()
+        local fapi_policy = FAPIPolicy.new({})
+        fapi_policy:header_filter()
         assert.same('abc', ngx.header['x-fapi-transaction-id'])
     end)
 
     it('Use x-fapi-transaction-id from upstream response', function()
         ngx_resp_headers['x-fapi-transaction-id'] = 'abc'
-        local transaction_id_policy = FAPIPolicy.new({})
-        transaction_id_policy:header_filter()
+        local fapi_policy = FAPIPolicy.new({})
+        fapi_policy:header_filter()
         assert.same('abc', ngx.header['x-fapi-transaction-id'])
     end)
 
     it('generate uuid if header does not exist in both request and response', function()
-        local transaction_id_policy = FAPIPolicy.new({})
-        transaction_id_policy:header_filter()
+        local fapi_policy = FAPIPolicy.new({})
+        fapi_policy:header_filter()
         assert.is_true(uuid.is_valid(ngx.header['x-fapi-transaction-id']))
     end)
   end)
@@ -57,25 +67,100 @@ describe('fapi_1_baseline_profile policy', function()
   describe('x-fapi-customer-ip-address', function()
     it('Allow request with valid IPv4', function()
         ngx_req_headers['x-fapi-customer-ip-address'] = '127.0.0.1'
-        local transaction_id_policy = FAPIPolicy.new({validate_x_fapi_customer_ip_address=true})
-        transaction_id_policy:access()
+        local fapi_policy = FAPIPolicy.new({validate_x_fapi_customer_ip_address=true})
+        fapi_policy:access()
         assert.stub(ngx.exit).was_not.called_with(403)
     end)
 
     it('Allow request with valid IPv6', function()
         ngx_req_headers['x-fapi-customer-ip-address'] = '2001:db8::123:12:1'
-        local transaction_id_policy = FAPIPolicy.new({validate_x_fapi_customer_ip_address=true})
-        transaction_id_policy:access()
+        local fapi_policy = FAPIPolicy.new({validate_x_fapi_customer_ip_address=true})
+        fapi_policy:access()
         assert.stub(ngx.exit).was_not.called_with(403)
     end)
 
     it('Reject request if header contains more than 1 IP', function()
         ngx_req_headers['x-fapi-customer-ip-address'] = {"2001:db8::123:12:1", "127.0.0.1"}
-        local transaction_id_policy = FAPIPolicy.new({validate_x_fapi_customer_ip_address=true})
-        transaction_id_policy:access()
+        local fapi_policy = FAPIPolicy.new({validate_x_fapi_customer_ip_address=true})
+        fapi_policy:access()
         assert.same(ngx.status, 403)
         assert.stub(ngx.print).was.called_with('{"error": "invalid_request"}')
         assert.stub(ngx.exit).was.called_with(403)
     end)
+  end)
+end)
+
+describe('fapi_1 advance profile', function()
+  local context = {}
+  before_each(function()
+    context = {
+      jwt = {},
+      service = {
+        id = 4,
+        auth_failed_status = 403,
+        error_auth_failed = 'auth failed',
+        auth_failed_headers = 'text/plain; charset=utf-8'
+      }
+    }
+
+    ngx.header = {}
+    stub(ngx, 'print')
+    stub(ngx, 'exit')
+    context.jwt = {}
+  end)
+
+  it('accepts when the digest equals cnf claim', function()
+      ngx.var = { ssl_client_raw_cert = clientCert }
+      context.jwt.cnf = jwt_cnf()
+
+      local fapi_policy = FAPIPolicy.new({validate_oauth2_certificate_bound_access_token=true})
+      fapi_policy:access(context)
+      assert.stub(ngx.exit).was_not.called_with(403)
+  end)
+
+  it('rejects when the client certificate not found', function()
+    ngx.var = { ssl_client_raw_cert = nil }
+    context.jwt.cnf = jwt_cnf()
+
+    local fapi_policy = FAPIPolicy.new({validate_oauth2_certificate_bound_access_token=true})
+    fapi_policy:access(context)
+
+    assert.stub(ngx.exit).was_called_with(ngx.HTTP_UNAUTHORIZED)
+    assert.stub(ngx.print).was_called_with('{"error": "invalid_token"}')
+  end)
+
+  it('rejects when the cnf claim not defined', function()
+    ngx.var = { ssl_client_raw_cert = clientCert }
+
+    local fapi_policy = FAPIPolicy.new({validate_oauth2_certificate_bound_access_token=true})
+    fapi_policy:access(context)
+
+    assert.stub(ngx.exit).was_called_with(ngx.HTTP_UNAUTHORIZED)
+    assert.stub(ngx.print).was_called_with('{"error": "invalid_token"}')
+  end)
+
+  it('rejects when context.service is nil', function()
+    ngx.var = { ssl_client_raw_cert = clientCert }
+
+    local fapi_policy = FAPIPolicy.new({validate_oauth2_certificate_bound_access_token=true})
+    context.service = nil
+    fapi_policy:access(context)
+
+    assert.stub(ngx.exit).was_called_with(ngx.HTTP_UNAUTHORIZED)
+    assert.stub(ngx.print).was_called_with('{"error": "invalid_token"}')
+  end)
+
+  it('rejects when the digest not equals cnf claim', function()
+    ngx.var = { ssl_client_raw_cert = clientCert }
+
+    context.jwt.cnf = {}
+    context.jwt.cnf[header_parameter] = 'invalid_digest'
+
+    local fapi_policy = FAPIPolicy.new({validate_oauth2_certificate_bound_access_token=true})
+    context.service = nil
+    fapi_policy:access(context)
+
+    assert.stub(ngx.exit).was_called_with(ngx.HTTP_UNAUTHORIZED)
+    assert.stub(ngx.print).was_called_with('{"error": "invalid_token"}')
   end)
 end)

--- a/t/apicast-policy-fapi.t
+++ b/t/apicast-policy-fapi.t
@@ -1,8 +1,23 @@
 use lib 't';
 use Test::APIcast::Blackbox 'no_plan';
+use Crypt::JWT qw(encode_jwt);
 
-# Test::Nginx does not allow to grep access logs, so we redirect them to
-# stderr to be able to use "grep_error_log" by setting APICAST_ACCESS_LOG_FILE
+our $private_key = `cat t/fixtures/rsa.pem`;
+our $public_key = `cat t/fixtures/rsa.pub`;
+
+sub authorization_bearer_jwt (@) {
+    my ($aud, $payload, $kid) = @_;
+
+    my $jwt = encode_jwt(payload => {
+        aud => $aud,
+        sub => 'someone',
+        iss => 'https://example.com/auth/realms/apicast',
+        exp => time + 3600,
+        %$payload,
+    }, key => \$private_key, alg => 'RS256', extra_headers => { kid => $kid });
+
+    return "Bearer $jwt";
+}
 
 run_tests();
 
@@ -308,3 +323,327 @@ GET /?user_key=value
 {"error": "invalid_request"}
 --- no_error_log
 [error]
+
+
+
+=== TEST 7: With oauth2_mtls enabled and digest of TLS Client Certificate equals to cnf claim
+--- env random_port eval
+(
+  'APICAST_HTTPS_PORT' => "$Test::Nginx::Util::ServerPortForClient",
+  'APICAST_HTTPS_CERTIFICATE' => "$Test::Nginx::Util::ServRoot/html/server.crt",
+  'APICAST_HTTPS_CERTIFICATE_KEY' => "$Test::Nginx::Util::ServRoot/html/server.key",
+  'BACKEND_ENDPOINT_OVERRIDE' => '' # disable override by Test::APIcast::Blackbox
+)
+--- configuration env
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": { "id_token_signing_alg_values_supported": [ "RS256" ] },
+      "keys": { "somekid": { "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----", "alg": "RS256" } }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
+        "api_backend": "http://test_backend:$TEST_NGINX_RANDOM_PORT",
+        "backend": {
+          "endpoint": "http://test_backend:$TEST_NGINX_RANDOM_PORT/",
+          "host": "localhost"
+        },
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.fapi",
+            "configuration": {
+              "validate_oauth2_certificate_bound_access_token": true
+            }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend random_port env
+  listen $TEST_NGINX_RANDOM_PORT;
+  location /transactions/oauth_authrep.xml {
+    content_by_lua_block {
+      ngx.exit(200)
+    }
+  }
+  location /t {
+        content_by_lua_block {
+          ngx.say('yay, api backend')
+        }
+    }
+--- test eval
+my $jwt = ::authorization_bearer_jwt('audience', {
+    cnf => { 'x5t#S256' => "Y4_LVlkpE6qkscPbtoKm3iiKBgfwbOfbdKBEdnZ6ZPY"
+}}, 'somekid');
+<<EOF
+    proxy_ssl_verify on;
+    proxy_ssl_trusted_certificate $Test::Nginx::Util::ServRoot/html/ca.crt;
+    proxy_ssl_certificate $Test::Nginx::Util::ServRoot/html/client.crt;
+    proxy_ssl_certificate_key $Test::Nginx::Util::ServRoot/html/client.key;
+    proxy_pass https://\$server_addr:\$apicast_port/t;
+    proxy_set_header Host localhost;
+    proxy_set_header Authorization "$jwt";
+    log_by_lua_block { collectgarbage() }
+EOF
+--- error_code: 200
+--- no_error_log
+[error]
+--- user_files fixture=CA/files.pl eval
+
+
+
+=== TEST 8: With oauth2_mtls enabled and TLS Client Certificate is not provided
+--- env random_port eval
+(
+  'APICAST_HTTPS_PORT' => "$Test::Nginx::Util::ServerPortForClient",
+  'APICAST_HTTPS_CERTIFICATE' => "$Test::Nginx::Util::ServRoot/html/server.crt",
+  'APICAST_HTTPS_CERTIFICATE_KEY' => "$Test::Nginx::Util::ServRoot/html/server.key",
+  'BACKEND_ENDPOINT_OVERRIDE' => '' # disable override by Test::APIcast::Blackbox
+)
+--- configuration env
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": { "id_token_signing_alg_values_supported": [ "RS256" ] },
+      "keys": { "somekid": { "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----", "alg": "RS256" } }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
+        "api_backend": "http://test_backend:$TEST_NGINX_RANDOM_PORT",
+        "backend": {
+          "endpoint": "http://test_backend:$TEST_NGINX_RANDOM_PORT/",
+          "host": "localhost"
+        },
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.fapi",
+            "configuration": {
+              "validate_oauth2_certificate_bound_access_token": true
+            }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend random_port env
+  listen $TEST_NGINX_RANDOM_PORT;
+  location /transactions/oauth_authrep.xml {
+    content_by_lua_block {
+      ngx.exit(200)
+    }
+  }
+  location /t {
+        content_by_lua_block {
+          ngx.say('yay, api backend')
+        }
+    }
+--- test eval
+my $jwt = ::authorization_bearer_jwt('audience', {
+    cnf => { 'x5t#S256' => "Y4_LVlkpE6qkscPbtoKm3iiKBgfwbOfbdKBEdnZ6ZPY"
+}}, 'somekid');
+<<EOF
+    proxy_ssl_verify on;
+    proxy_ssl_trusted_certificate $Test::Nginx::Util::ServRoot/html/ca.crt;
+    proxy_pass https://\$server_addr:\$apicast_port/t;
+    proxy_set_header Host localhost;
+    proxy_set_header Authorization "$jwt";
+    log_by_lua_block { collectgarbage() }
+EOF
+--- error_code: 401
+--- response_body chomp
+{"error": "invalid_token"}
+--- no_error_log
+[error]
+--- user_files fixture=CA/files.pl eval
+
+
+
+=== TEST 9: With oauth2_mtls enabled and missing cnf claim
+--- env random_port eval
+(
+  'APICAST_HTTPS_PORT' => "$Test::Nginx::Util::ServerPortForClient",
+  'APICAST_HTTPS_CERTIFICATE' => "$Test::Nginx::Util::ServRoot/html/server.crt",
+  'APICAST_HTTPS_CERTIFICATE_KEY' => "$Test::Nginx::Util::ServRoot/html/server.key",
+  'BACKEND_ENDPOINT_OVERRIDE' => '' # disable override by Test::APIcast::Blackbox
+)
+--- configuration env
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": { "id_token_signing_alg_values_supported": [ "RS256" ] },
+      "keys": { "somekid": { "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----", "alg": "RS256" } }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
+        "api_backend": "http://test_backend:$TEST_NGINX_RANDOM_PORT",
+        "backend": {
+          "endpoint": "http://test_backend:$TEST_NGINX_RANDOM_PORT/",
+          "host": "localhost"
+        },
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.fapi",
+            "configuration": {
+              "validate_oauth2_certificate_bound_access_token": true
+            }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend random_port env
+  listen $TEST_NGINX_RANDOM_PORT;
+  location /transactions/oauth_authrep.xml {
+    content_by_lua_block {
+      ngx.exit(200)
+    }
+  }
+  location /t {
+        content_by_lua_block {
+          ngx.say('yay, api backend')
+        }
+    }
+--- test eval
+my $jwt = ::authorization_bearer_jwt('audience', {
+    foo => "1",
+}, 'somekid');
+<<EOF
+    proxy_ssl_verify on;
+    proxy_ssl_trusted_certificate $Test::Nginx::Util::ServRoot/html/ca.crt;
+    proxy_ssl_certificate $Test::Nginx::Util::ServRoot/html/client.crt;
+    proxy_ssl_certificate_key $Test::Nginx::Util::ServRoot/html/client.key;
+    proxy_pass https://\$server_addr:\$apicast_port/t;
+    proxy_set_header Host localhost;
+    proxy_set_header Authorization "$jwt";
+    log_by_lua_block { collectgarbage() }
+EOF
+--- error_code: 401
+--- response_body chomp
+{"error": "invalid_token"}
+--- no_error_log
+[error]
+--- user_files fixture=CA/files.pl eval
+
+
+
+=== TEST 10: Digest of TLS Client Certificate does not equal cnf claim
+--- env random_port eval
+(
+  'APICAST_HTTPS_PORT' => "$Test::Nginx::Util::ServerPortForClient",
+  'APICAST_HTTPS_CERTIFICATE' => "$Test::Nginx::Util::ServRoot/html/server.crt",
+  'APICAST_HTTPS_CERTIFICATE_KEY' => "$Test::Nginx::Util::ServRoot/html/server.key",
+  'BACKEND_ENDPOINT_OVERRIDE' => '' # disable override by Test::APIcast::Blackbox
+)
+--- configuration env
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": { "id_token_signing_alg_values_supported": [ "RS256" ] },
+      "keys": { "somekid": { "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----", "alg": "RS256" } }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
+        "api_backend": "http://test_backend:$TEST_NGINX_RANDOM_PORT",
+        "backend": {
+          "endpoint": "http://test_backend:$TEST_NGINX_RANDOM_PORT/",
+          "host": "localhost"
+        },
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 1 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.fapi",
+            "configuration": {
+              "validate_oauth2_certificate_bound_access_token": true
+            }
+          },
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend random_port env
+  listen $TEST_NGINX_RANDOM_PORT;
+  location /transactions/oauth_authrep.xml {
+    content_by_lua_block {
+      ngx.exit(200)
+    }
+  }
+  location /t {
+        content_by_lua_block {
+          ngx.say('yay, api backend')
+        }
+    }
+--- test eval
+my $jwt = ::authorization_bearer_jwt('audience', {
+    cnf => { 'x5t#S256' => "invalid"
+}}, 'somekid');
+<<EOF
+    proxy_ssl_verify on;
+    proxy_ssl_trusted_certificate $Test::Nginx::Util::ServRoot/html/ca.crt;
+    proxy_ssl_certificate $Test::Nginx::Util::ServRoot/html/client.crt;
+    proxy_ssl_certificate_key $Test::Nginx::Util::ServRoot/html/client.key;
+    proxy_pass https://\$server_addr:\$apicast_port/t;
+    proxy_set_header Host localhost;
+    proxy_set_header Authorization "$jwt";
+    log_by_lua_block { collectgarbage() }
+EOF
+--- error_code: 401
+--- response_body chomp
+{"error": "invalid_token"}
+--- no_error_log
+[error]
+--- user_files fixture=CA/files.pl eval


### PR DESCRIPTION
## What
This PR support https://issues.redhat.com/browse/THREESCALE-11019. 

> 
> * shall support the provisions specified in clause 6.2.1 [Financial-grade API Security Profile 1.0 - Part 1: Baseline](https://openid.net/specs/openid-financial-api-part-1-1_0.html); and
> * shall adhere to the requirements in [MTLS](https://tools.ietf.org/html/rfc8705).

## Verification steps:
* Build new runtime-image
```
make runtime-image IMAGE_NAME=apicast-test
```
* Move into keycloak dev-environment
```
cd dev-environments/keycloak-env
```
### Prepare certificates

```
mkdir certs && cd certs
```

#### Generate CA certificate
```
openssl genrsa -out rootCA.key 2048
openssl req -batch -new -x509 -nodes -key rootCA.key -sha256 -days 1024 -out rootCA.pem
```
* Generate a private key for the HTTPS keystore. Provide `changeit` as keystore password
```
keytool -genkeypair -keyalg RSA -keysize 2048 -dname "CN=keycloak" -alias jboss -keystore keystore.jks -storepass changeit -keypass changeit
```
Generate a certificate signing request (CSR) for the HTTPS keystore.
```
keytool -certreq -keyalg rsa -alias jboss -keystore keystore.jks -file sso.csr -storepass changeit
```
3. Sign the CSR with the CA certificate..
```
openssl x509 -req -extfile  <(printf "subjectAltName=DNS:keycloak") -CA rootCA.pem -CAkey rootCA.key -in sso.csr -out sso.crt -days 365 -CAcreateserial
```
4. Import the CA certificate into the HTTPS keystore. Reply `yes` to `Trust this certificate? [no]:` question
```
keytool -import -file rootCA.pem -alias rootCA.ca -keystore keystore.jks -storepass changeit -noprompt
```
5. Import the signed CSR into the HTTPS keystore.
```
keytool -import -file sso.crt -alias jboss -keystore keystore.jks -storepass changeit
```
We can verify the certificates are imported with below command.
```
keytool -v -list -storepass changeit \  
  -alias jboss -keystore keystore.jks
```
7. Import CA certificate into the truststore
```
keytool -import -file rootCA.pem -alias rootCA.ca -keystore truststore.jks -storepass changeit -noprompt
```
#### Generate client certificate
Generate APIcast certificates
```
$ openssl req -subj '/CN=apicast'  -newkey rsa:4096 -nodes \
      -sha256 \
      -days 3650 \
      -keyout apicast.key \
      -out apicast.csr
$ chmod +r apicast.key
$ openssl x509 -req -in apicast.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out apicast.crt -days 500 -sha256
$ cat apicast.key apicast.crt >apicast.pem
```
Repeat the step above and generate the client certificate
```
$ openssl req -subj '/CN=client'  -newkey rsa:4096 -nodes \
      -sha256 \
      -days 3650 \
      -keyout client.key \
      -out client.csr
$ chmod +r client.key
$ openssl x509 -req -in client.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out client.crt -days 500 -sha256
$ cat client.key client.crt >client.pem
```
Once the certificate are generated, we are ready to deploy Keycloak
### Deploy
* Update apicast-config.json
```diff
diff --git a/dev-environments/keycloak-env/apicast-config.json b/dev-environments/keycloak-env/apicast-config.json
index 071296cd..bab21204 100644
--- a/dev-environments/keycloak-env/apicast-config.json
+++ b/dev-environments/keycloak-env/apicast-config.json
@@ -61,7 +61,7 @@
         "api_test_path": "/",
         "api_test_success": null,
         "apicast_configuration_driven": true,
-        "oidc_issuer_endpoint": "http://oidc-issuer-for-3scale:oidc-issuer-for-3scale-secret@keycloak:8080/realms/basic",
+        "oidc_issuer_endpoint": "https://oidc-issuer-for-3scale:oidc-issuer-for-3scale-secret@keycloak:8443/realms/basic",
         "lock_version": 4,
         "authentication_method": "oidc",
         "oidc_issuer_type": "keycloak",
@@ -84,10 +84,10 @@
         },
         "policy_chain": [
           {
-            "name": "token_introspection",
+            "name": "fapi",
             "version": "builtin",
             "configuration": {
-              "auth_type": "use_3scale_oidc_issuer_endpoint"
+              "validate_oauth2_certificate_bound_access_token": true
             }
           },
           {
```
* Update docker-compose.yaml with the following
```diff
diff --git a/dev-environments/keycloak-env/docker-compose.yml b/dev-environments/keycloak-env/docker-compose.yml
index 3fdbd011..a0904272 100644
--- a/dev-environments/keycloak-env/docker-compose.yml
+++ b/dev-environments/keycloak-env/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     - two.upstream
     - keycloak
     environment:
+      APICAST_HTTPS_PORT: 8443
+      APICAST_HTTPS_CERTIFICATE: /var/run/secrets/apicast/apicast.crt
+      APICAST_HTTPS_CERTIFICATE_KEY: /var/run/secrets/apicast/apicast.key
       THREESCALE_CONFIG_FILE: /tmp/config.json
       THREESCALE_DEPLOYMENT_ENV: staging
       APICAST_CONFIGURATION_LOADER: lazy
@@ -22,6 +25,7 @@ services:
       - "8090:8090"
+      - "8443:8443" 
     volumes:
       - ./apicast-config.json:/tmp/config.json
+      - ./certs:/var/run/secrets/apicast
   example.com:
     image: alpine/socat:1.7.4.4
     container_name: example.com
@@ -39,9 +43,20 @@ services:
     command: "start-dev"
     expose:
       - "8080"
+      - "8443"
     ports:
       - "9090:8080"
+      - "9443:8443"
+    volumes:
+      - ./certs/keystore.jks:/etc/x509/https/keystore.jks
+      - ./certs/truststore.jks:/etc/x509/https/truststore.jks
     restart: unless-stopped
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: adminpass
+      KC_HTTPS_CLIENT_AUTH: request
+      KC_HTTPS_KEY_STORE_FILE: /etc/x509/https/keystore.jks
+      KC_HTTPS_KEY_STORE_PASSWORD: changeit
+      KC_HTTPS_TRUST_STORE_FILE: /etc/x509/https/truststore.jks
+      KC_HTTPS_TRUST_STORE_PASSWORD: changeit
(END)
```
* Start APIcast
```
make gateway IMAGE_NAME=apicast-test
```
* Bootstrap keycloak
```
make keycloak-data
```
* We should be able to access keycloak UI via `https://localhost:9443`
* Login as admin user `admin:adminpass`
* Switch to `basic` realm
* Create new client `Clients -> Create client` 
```
Client type: OpenID Connect
Client ID: mtls_client_demo
```
* Click Next
```
Client authentication: On
Authorization: On
```
* Click Next -> then Save
* Once the new client is created, go to `Credentials` tab and select `X509 Certificate` as `Client Authenticator`
* Next put in your `Subject DN`, in this test we use `(.*?)(?:$)`. Then click `Save`
* Go to `Advanced` tab, and then scroll down to `Advance settings` and enable `OAuth 2.0 Mutual TLS Certificate Bound Access Token` -> click `Save`

### Request token
Now we have everything set up, we can use curl to authenticate with the client certificate to get the access token.
```
ACCESS_TOKEN=$(docker compose -p keycloak-env exec gateway curl -k -v -H "Content-Type: application/x-www-form-urlencoded" \
   -d 'grant_type=client_credentials' \
   -d 'client_id=mtls_client_demo' \
   --cert /var/run/secrets/apicast/client.crt \
   --key /var/run/secrets/apicast/client.key \
   --cacert /var/run/secrets/apicast/rootCA.pem \
   "https://keycloak:8443/realms/basic/protocol/openid-connect/token" | jq -r '.access_token')
```

* Validate that token has cnf claim. 
If we decode this token using jwt.io, we can see the payload has the `cnf` claim and its value is certificate sha256 thumbprint.  The resource server (APIcast) will use this thumbprint to validate if the same user is making the request. For example:

```
"cnf": {
    "x5t#S256": "3hhTJwX93ZWWyuuKOzm1k4qo-MH0dfhDC7jgg8ZyR6U"
  },
```
Now we are ready to test 

* Send request
```
curl -v --resolve stg.example.com:8080:127.0.0.1 -H "Authorization: Bearer ${ACCESS_TOKEN}" "http://stg.example.com:8080"
```
Request should failed with `{"error": "invalid_token"}`

* Send request again with client certificates
```
curl -v -k --resolve stg.example.com:8080:127.0.0.1  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
   --cert certs/client.crt \
   --key certs/client.key \
  "http://stg.example.com:8443"
```
Request should return 200

```
< HTTP/2 200
< server: openresty
< date: Fri, 14 Jun 2024 06:50:11 GMT
< content-type: application/json
< content-length: 1756
< access-control-allow-origin: *
< access-control-allow-credentials: true
< x-fapi-transaction-id: 83688fb6-0ca9-44d3-9e9f-3b31bcdefd8a
<
```
