### PR TITLE
[THREESCALE-8410] Add support to set proxy buffer size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support Financial-grade API (FAPI) - Baseline profile [PR #1465](https://github.com/3scale/APIcast/pull/1465) [THREESCALE-10973](https://issues.redhat.com/browse/THREESCALE-10973)
 
-- Added `APICAST_PROXY_BUFFER_SIZE` variable to allow configure the size of the buffer used for handling the response received from the proxied server. [PR #1473](https://github.com/3scale/APIcast/pull/1473), [THREESCALE-8410](https://issues.redhat.com/browse/THREESCALE-8410)
+- Added the `APICAST_PROXY_BUFFER_SIZE` variable to allow configuration of the buffer size for handling response from the proxied servers. [PR #1473](https://github.com/3scale/APIcast/pull/1473), [THREESCALE-8410](https://issues.redhat.com/browse/THREESCALE-8410)
 
 ## [3.15.0] 2024-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support Financial-grade API (FAPI) - Baseline profile [PR #1465](https://github.com/3scale/APIcast/pull/1465) [THREESCALE-10973](https://issues.redhat.com/browse/THREESCALE-10973)
 
+- Added `APICAST_PROXY_BUFFER_SIZE` variable to allow configure the size of the buffer used for handling the response received from the proxied server. [PR #1473](https://github.com/3scale/APIcast/pull/1473), [THREESCALE-8410](https://issues.redhat.com/browse/THREESCALE-8410)
+
 ## [3.15.0] 2024-04-04
 
 ### Fixed

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -529,7 +529,7 @@ Sets the maximum size of shared memory used by batcher policy. The accepted [siz
 **Default:** 4k|8k;
 **Value:** string
 
-Sets the size of the buffer used for handling the response received from the proxied server. This variable will set both [`proxy_buffer` NGINX directive](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) and [`proxy_buffer_size` NGINX directive](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size). By default, the buffer size is equal to one memory page. This is either 4K or 8K, depending on a platform.
+Sets the size of the buffer used for handling the response received from the proxied server. This variable sets both [`proxy_buffer` NGINX directive](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) and [`proxy_buffer_size` NGINX directive](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size). By default, the buffer size is equal to one memory page. This is either 4 KiB or 8 KiB, depending on a platform.
 
 ### `OPENTELEMETRY`
 

--- a/doc/parameters.md
+++ b/doc/parameters.md
@@ -524,6 +524,13 @@ directive](https://nginx.org/en/docs/http/ngx_http_core_module.html#large_client
 
 Sets the maximum size of shared memory used by batcher policy. The accepted [size units](https://github.com/openresty/lua-nginx-module?tab=readme-ov-file#lua_shared_dict) are k and m.
 
+### `APICAST_PROXY_BUFFER_SIZE`
+
+**Default:** 4k|8k;
+**Value:** string
+
+Sets the size of the buffer used for handling the response received from the proxied server. This variable will set both [`proxy_buffer` NGINX directive](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffers) and [`proxy_buffer_size` NGINX directive](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size). By default, the buffer size is equal to one memory page. This is either 4K or 8K, depending on a platform.
+
 ### `OPENTELEMETRY`
 
 This environment variable enables NGINX instrumentation using OpenTelemetry tracing library.

--- a/gateway/apicast.d/buffers.conf
+++ b/gateway/apicast.d/buffers.conf
@@ -1,0 +1,5 @@
+{%- assign proxy_buffer_size = env.APICAST_PROXY_BUFFER_SIZE %}
+{% if proxy_buffer_size -%}
+  proxy_buffers 8 {{ proxy_buffer_size }};
+  proxy_buffer_size {{ proxy_buffer_size }};
+{%- endif %}

--- a/t/proxy-buffers.t
+++ b/t/proxy-buffers.t
@@ -1,0 +1,86 @@
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: reject with 502 when upstream return large header (the header exceed the size
+of proxy_buffer_size)
+--- configuration env
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+  location / {
+    content_by_lua_block {
+        ngx.header["X-Large-Header"] = string.rep("a", 2^12)
+    }
+  }
+--- request
+GET /?user_key=value
+--- error_code: 502
+--- error_log eval
+qr/upstream sent too big header while reading response header from upstream/
+
+
+=== TEST 2: large utream header with APICAST_PROXY_BUFFER_SIZE set to 8k
+--- env eval
+(
+  'APICAST_PROXY_BUFFER_SIZE' => '8k',
+)
+--- configuration env
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+  location / {
+    content_by_lua_block {
+        ngx.header["X-Large-Header"] = string.rep("a", 2^12)
+    }
+  }
+--- request
+GET /?user_key=value
+--- response_headers eval
+"X-Large-Header: " . ("a" x 4096) . "\r\n\r\n"
+--- error_code: 200
+--- no_error_log
+[error]


### PR DESCRIPTION
## What
Fix https://issues.redhat.com/browse/THREESCALE-8410

## Notes
### What are the differences between buffers?
* `proxy_buffers`: this is the total size of the buffer that Nginx can use to hold the response from upstream. If the size of the response larger then the total size of the proxy_buffers Nginx will write response to disk
* `proxy_buffer_size`: mainly used to hold the response header.
* `proxy_busy_buffer_size`: size of the buffer can be used for delivering the response to clients while it was not fully read from the upstream server. 

### What are the correct values for the buffers?
* `proxy_buffers`: 
  * Default: 8 4k|8k;
  * Min: must be at least 2 buffers
  * Max: no limit
* `proxy_buffer_size`:
  * Min: No limit, can be set to smaller default value (4k|8k) but it's not recommend.
  * Max: No limit, but should be no less than the maximum possible size of response HTTP headers 
  * Default: one memory page size (4k|8k)
* `proxy_busy_buffer_size`:
  * Min: can't be smaller than a single proxy_buffers and must be equal to or greater than the maximum of the value of `proxy_buffer_size` and one of the `proxy_buffers`.

  * Max: must be less than the total value of proxy_buffers minus one buffer.  (ie 8*4 = 32k - 4k = 28k)
  * Default: if not explicitly defined, the value for proxy_busy_buffer_size is "the bigger of: twice proxy_buffer_size and the size of two proxy_buffers".   This also mean if you set bigger proxy_buffer_size, you are implicitly increasing proxy_busy_buffer_size as well. 

Reference: https://github.com/nginx/nginx/blob/master/src/http/modules/ngx_http_proxy_module.c#L3442

### Why 4k|8k?
This is equal to one memory page size, ie either 4K or 8K, depending on a platform. 

### How to check my pagesize
```
$ getconf PAGE_SIZE
```

### Would increase buffer size also increase the memory consumption?
Yes the buffer is allocated per connection. How much you may ask? I honestly don't know, once I get the profiling tool sorted I'll run a few benchmark tests.

### Increase the buffer number vs increase the buffer size
The difference between a bigger number of smaller buffers, or a smaller number of bigger buffers, may depend on each user use case, ie a lot of small size response vs a lot of big response. As well as how much memory they have and how much memory they want to be wasted. So it's hard to provide one solution to fit all.

Due to the above complex rule, I personally think we should just provide one setting and increase the buffer size instead of messing around with the number and size of the buffer. And memory is cheap.

The downside of this approach is if user set a really big buffer size, ie `proxy_buffers: 8 1024k` ie allocating a 1MB buffer for every buffered connection even the response can fit in the default memory page size (4k|8k). However from my initial test, nginx allow allocate needed memory, again I will need to get those profiling tools sorted so I can peek into what is allocated. 

### Does this setting apply per product?
No this setting is global. 

## Common errors:

```
upstream sent too big header while reading response header from upstream 
```
proxy_buffer_size is the only directive that needs tuning in order to solve the error. However due to the rule described above, proxy_busy_buffer_size also needs adjustment 

## Verification steps
* Checkout this branch
* Edit `docker-compose-devel.yaml` as follow
```diff
diff --git a/docker-compose-devel.yml b/docker-compose-devel.yml
index 6e118560..a5ddbb2d 100644
--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -23,3 +23,7 @@ services:
       GIT_COMMITTER_EMAIL: ${GIT_COMMITTER_EMAIL:-""}
   redis:
     image: redis
+  my-upstream:
+    image: mccutchen/go-httpbin
+    expose:
+      - "8080"
````
* Create a `apicast-config.json` file with the following content
```diff 
cat <<EOF >apicast-config.json
{
    "services": [
        {
            "id": "1",
            "backend_version": "1",
            "proxy": {
                "hosts": [
                    "one"
                ],
                "api_backend": "http://my-upstream:8080/response-headers",
                "backend": {
                    "endpoint": "http://127.0.0.1:8081",
                    "host": "backend"
                },
                "policy_chain": [
                    {
                        "name": "apicast.policy.apicast"
                    }
                ],
                "proxy_rules": [
                    {
                        "http_method": "GET",
                        "pattern": "/",
                        "metric_system_name": "hits",
                        "delta": 1,
                        "parameters": [],
                        "querystring_parameters": {}
                    }
                ]
            }
        }
    ]
} 
EOF
```

* Checkout this branch and start dev environment
```
make development
make dependencies
```
* Run apicast locally
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=debug APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=lazy APICAST_CONFIGURATION_CACHE=0 THREESCALE_CONFIG_FILE=apicast-config.json ./bin/apicast
```

* Capture apicast IP
```
APICAST_IP=$(docker inspect apicast_build_0-development-1 | yq e -P '.[0].NetworkSettings.Networks.apicast_build_0_default.IPAddress' -)
```

* Generate big header
```
LARGE_HEADER=$(for i in {1..1024}; do echo -n 'ABCDE'; done)
```

* Send request with big header
```
curl -i -k -H "Host: one" -H "Accept: application/json" "http://${APICAST_IP}:8080/?key=${LARGE_HEADER}&user_key="
```

It should return 502
```
HTTP/1.1 502 Bad Gateway
Server: openresty
Date: Thu, 20 Jun 2024 08:31:46 GMT
Content-Type: text/html
Content-Length: 154
Connection: keep-alive
```
and this line from the log

```
upstream sent too big header while reading response header from upstream
```
* Stop the gateway
```
CTRL-C
```
* Start gateway again with APICAST_PROXY_BUFFER_SIZE=8k
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=debug APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=lazy APICAST_CONFIGURATION_CACHE=0 THREESCALE_CONFIG_FILE=apicast-config.json APICAST_PROXY_BUFFER_SIZE="8k" ./bin/apicast
```
* Send request again 
```
curl -i -k -H "Host: one" -H "Accept: application/json" "http://${APICAST_IP}:8080/?key=${LARGE_HEADER}&user_key="
```

This time it should return HTTP/1.1 200 OK

```
HTTP/1.1 200 OK
Server: openresty
Date: Thu, 20 Jun 2024 09:04:58 GMT
Content-Type: application/json; charset=utf-8
Transfer-Encoding: chunked
```