### PR TITLE
[THREESCALE-10981] - Update profiling tools

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,8 +4,8 @@
 Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "fedora/26-cloud-base"
-  config.vm.box_version = "20170705"
+  config.vm.box = "centos/stream8"
+  config.vm.box_url = "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-latest.x86_64.vagrant-libvirt.box"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
@@ -33,27 +33,28 @@ Vagrant.configure("2") do |config|
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:
   #
-   config.vm.provider "virtualbox" do |vb|
-     vb.memory = "1024"
-     vb.cpus = 2
-   end
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "1024"
+    vb.cpus = 2
+  end
+
+  config.vm.provider "libvirt" do |vb|
+    vb.memory = "1024"
+    vb.cpus = 2
+  end
+
+  # Disable default sync folder
+  config.vm.synced_folder ".", "/vagrant", disabled: true
 
   # View the documentation for the provider you are using for more
   # information on available options.
-  config.vm.synced_folder ".", "/vagrant", type: 'virtualbox'
-
-  config.vm.synced_folder ".", "/home/vagrant/app", type: 'rsync',
-    rsync__exclude: %w[lua_modules .git .vagrant node_modules t/servroot t/servroot* ],
+  config.vm.synced_folder ".", "/opt/app-root", type: 'rsync',
+    rsync__exclude: %w[lua_modules .git .vagrant node_modules t/servroot t/servroot* .cpanm],
     rsync__args: %w[--verbose --archive --delete -z --links ]
 
   config.vm.provision "shell", path: 'script/install/centos.sh'
+  config.vm.provision "shell", path: 'script/install/openresty.sh'
+  config.vm.provision "shell", path: 'script/install/luarocks.sh'
   config.vm.provision "shell", path: 'script/install/utilities.sh'
-  
-  config.vm.provision "shell", inline: <<~'SHELL'
-     systemctl start redis
-     systemctl disable openresty
-     systemctl stop openresty
-  SHELL
 
-  config.vm.provision "shell", privileged: false, name: "Install APIcast dependencies", path: 'script/install/apicast.sh', args: %w[app]
 end

--- a/doc/profiling.md
+++ b/doc/profiling.md
@@ -1,5 +1,10 @@
 # Profiling
 
+## Prerequisite
+* Vagrant
+* QEMU or virtualbox
+* At least 20GB of free space
+
 There is a Vagrantfile with performance inspection tools like SystemTap.
 
 ```shell
@@ -7,10 +12,18 @@ vagrant up
 vagrant ssh
 ```
 
-APIcast is mounted into `/home/vagrant/app` so you can start it by:
+Install [vagrant-libvirt](https://github.com/vagrant-libvirt/vagrant-libvirt) plugin if using `libvirt`
+
+```
+vagrant plugin install vagrant-libvirt
+vagrant up --provider=libvirt
+vagrant ssh
+```
+
+APIcast is mounted into `/opt/app-src` so you can start it by:
 
 ```shell
-cd app
+cd /opt/app-src
 bin/apicast
 ```
 

--- a/script/install/centos.sh
+++ b/script/install/centos.sh
@@ -2,19 +2,23 @@
 
 set -x -e
 
-dnf -y install dnf-plugins-core
+# Old Centos packages are moved to vault.centos.org
+sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Stream-*
+sed -i 's/mirrorlist/#mirrorlist/g'  /etc/yum.repos.d/CentOS-*
 
-dnf config-manager --add-repo https://openresty.org/package/fedora/openresty.repo
+yum install -y yum-utils
+yum-config-manager --enable "powertools"
 
-yum -y install rsync
-yum -y install openresty-resty openresty-debug openresty-debug-debuginfo openresty-pcre-debuginfo
-yum -y install systemtap git httpd-tools
-yum -y install luarocks
-yum -y install perl-local-lib perl-App-cpanminus redis perl-open expect
+# Remove lua 5.3
+yum remove -y lua
 
-yum -y groupinstall 'Development Tools'
-yum -y install openssl-devel libev-devel
+# install build and runtime dependencies
+yum -y install gcc gcc-c++ make m4 git which iputils bind-utils expat-devel m4\
+    wget tar unzip libyaml libyaml-devel \
+    perl-local-lib perl-App-cpanminus \
+    openssl-devel libev-devel \
+    kernel-headers kernel-devel kernel-debug \
+    redis systemtap \
+    python2-pip elfutils-devel
 
-dnf debuginfo-install -y "kernel-core-$(uname -r)"
-
-yum -y install python2-pip
+dnf --enablerepo="debuginfo" debuginfo-install -y "kernel-core-$(uname -r)"

--- a/script/install/luarocks.sh
+++ b/script/install/luarocks.sh
@@ -1,0 +1,40 @@
+set -x -e
+
+LUAROCKS_VER="3.8.0"
+OPENRESTY_PREFIX="/usr/local/openresty"
+WITH_LUA_OPT="--with-lua=${OPENRESTY_PREFIX}/luajit"
+APP_ROOT=/opt/app-root
+
+export PATH=$PATH:/usr/local/bin
+
+wget -q https://github.com/luarocks/luarocks/archive/v"$LUAROCKS_VER".tar.gz
+tar -xf v"$LUAROCKS_VER".tar.gz
+cd luarocks-"$LUAROCKS_VER" || exit
+./configure $WITH_LUA_OPT
+
+make && make install
+cd ..
+rm -rf luarocks-"$LUAROCKS_VER"
+rm -f v"$LUAROCKS_VER".tar.gz
+
+cp ${APP_ROOT}/site_config.lua /usr/local/share/lua/5.1/luarocks/site_config.lua
+cp ${APP_ROOT}/config-*.lua /usr/local/openresty/config-5.1.lua
+
+luarocks install luaossl 20200709 --tree ${APP_ROOT}/lua_modules CFLAGS="-O2 -fPIC -DHAVE_EVP_KDF_CTX=1"
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/pintsized/lua-resty-http-0.17.1-0.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/kikito/router-2.1-0.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/kikito/inspect-3.1.1-0.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/cdbattags/lua-resty-jwt-0.2.0-0.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/3scale/lua-resty-url-0.3.5-1.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/3scale/lua-resty-env-0.4.0-1.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/3scale/liquid-0.2.0-2.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/tieske/date-2.2-2.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/tieske/penlight-1.13.1-1.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/mpeterv/argparse-0.6.0-1.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/3scale/lua-resty-execvp-0.1.1-1.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/hisham/luafilesystem-1.8.0-1.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/3scale/lua-resty-jit-uuid-0.0.7-1.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/knyar/nginx-lua-prometheus-0.20181120-2.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/hamish/lua-resty-iputils-0.3.0-1.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/golgote/net-url-0.9-1.src.rock
+luarocks install --deps-mode=none --tree /usr/local https://luarocks.org/manifests/membphis/lua-resty-ipmatcher-0.6.1-0.src.rock

--- a/script/install/openresty.sh
+++ b/script/install/openresty.sh
@@ -1,0 +1,35 @@
+set -x -e
+
+OPENRESTY_YUM_REPO="https://openresty.org/package/centos/openresty.repo"
+THREESCALE_YUM_REPO="http://packages.dev.3sca.net/dev_packages_3sca_net.repo"
+OPENRESTY_RPM_VERSION="1.21.4-1.el8"
+JAEGERTRACING_CPP_CLIENT_RPM_VERSION="0.3.1-13.el8"
+
+APP_ROOT=/opt/app-root
+HOME=/opt/app-root/src
+PATH=/opt/app-root/src/bin:/opt/app-root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+## add openresty and 3scale rpm repo
+yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
+yum-config-manager --add-repo http://packages.dev.3sca.net/dev_packages_3sca_net.repo
+
+yum -y install \
+    openresty-${OPENRESTY_RPM_VERSION} \
+    openresty-resty-${OPENRESTY_RPM_VERSION} \
+    openresty-debuginfo-${OPENRESTY_RPM_VERSION} \
+    openresty-debugsource-${OPENRESTY_RPM_VERSION} \
+    openresty-opentelemetry-${OPENRESTY_RPM_VERSION} \
+    openresty-opentracing-${OPENRESTY_RPM_VERSION} \
+    opentracing-cpp-devel-1.3.0 \
+    libopentracing-cpp1-1.3.0 \
+    jaegertracing-cpp-client-${JAEGERTRACING_CPP_CLIENT_RPM_VERSION}\
+
+export PATH="./lua_modules/bin:/usr/local/openresty/luajit/bin/:${PATH}"
+export LUA_PATH="./lua_modules/share/lua/5.1/?.lua;./lua_modules/share/lua/5.1/?/init.lua;/usr/lib64/lua/5.1/?.lua;/usr/share/lua/5.1/?.lua;/opt/app-root/lua_modules/share/lua/5.1/?.lua;/opt/app-root/lua_modules/share/lua/5.1/?/?.lua"
+export LUA_CPATH="./lua_modules/lib/lua/5.1/?.so;/opt/app-root/lua_modules/lib64/lua/5.1/?.so;/opt/app-root/lua_modules/lib64/lua/5.1/?/?.so;;"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/app-root/lib"
+
+ln -sf /dev/stdout /usr/local/openresty/nginx/logs/access.log
+ln -sf /dev/stderr /usr/local/openresty/nginx/logs/error.log
+mkdir -p /usr/local/openresty/nginx/client_body_temp/
+chmod 777 /usr/local/openresty/nginx/client_body_temp/

--- a/script/install/utilities.sh
+++ b/script/install/utilities.sh
@@ -5,6 +5,7 @@ user=${SUDO_USER:-${CIRCLECI_USER:-vagrant}}
 
 # CircleCI forces use of SSH protocol everywhere, we need to reset it.
 export HOME="/tmp"
+export PATH=$PATH:/usr/local/bin
 
 # Clone various utilities
 git clone https://github.com/openresty/stapxx.git /usr/local/stapxx || (cd /usr/local/stapxx && git pull)
@@ -19,9 +20,9 @@ git clone https://github.com/lighttpd/weighttp.git /usr/local/weighttp || (cd /u
 ( cd /usr/local/weighttp && gcc -O2 -DPACKAGE_VERSION='"0.4"' src/*.c -o weighttp -lev -lpthread && ln -sf "$(pwd)/weighttp" /usr/local/bin/ )
 
 # Utility to resolve builtin functions
-echo '#!/usr/bin/env luajit' > /usr/local/bin/ljff
-curl -L https://raw.githubusercontent.com/openresty/openresty-devel-utils/master/ljff.lua >> /usr/local/bin/ljff
-chmod +x /usr/local/bin/ljff
+# echo '#!/usr/bin/env luajit' > /usr/local/bin/ljff
+# curl -L https://raw.githubusercontent.com/openresty/openresty-devel-utils/master/ljff.lua >> /usr/local/bin/ljff
+# chmod +x /usr/local/bin/ljff
 
 # Create stap++ executable always pointing to its proper location
 echo '#!/bin/sh' > /usr/local/bin/stap++
@@ -41,10 +42,6 @@ if [ -n "${CIRCLE_SHELL_ENV:-}" ]; then
     cat /etc/profile.d/perl.sh >> "${CIRCLE_SHELL_ENV}"
 fi
 
-mkdir -p /usr/share/lua/5.1/luarocks/ /usr/share/lua/5.3/luarocks/
-curl -L https://raw.githubusercontent.com/3scale/s2i-openresty/ffb1c55533be866a97466915d7ef31c12bae688c/site_config.lua > /usr/share/lua/5.1/luarocks/site_config.lua
-ln -sf /usr/share/lua/5.1/luarocks/site_config.lua /usr/share/lua/5.3/luarocks/site_config.lua
-
 # Add various utilites to the PATH
 ln -sf /usr/local/openresty/luajit/bin/luajit /usr/local/bin/luajit
 ln -sf /usr/local/flamegraph/*.pl /usr/local/bin/
@@ -53,7 +50,7 @@ ln -sf /usr/local/stapxx/samples/*.sxx /usr/local/bin/
 ln -sf $(find /usr/local/openresty-systemtap-toolkit/ -maxdepth 1 -type f -executable -print) /usr/local/bin/
 
 # Allow vagrant user to use systemtap
-usermod -a -G stapusr,stapdev "${user}"
+usermod -aG stapusr,stapdev "${user}"
 
 # Raise opened files limit for vagrant user
 # shellcheck disable=SC1117


### PR DESCRIPTION
## What
https://issues.redhat.com/browse/THREESCALE-10981

## Verification steps:
* Install Vagrant https://developer.hashicorp.com/vagrant/docs/installation
* Install QEMU
* Install [vagrant-libvirt](https://github.com/vagrant-libvirt/vagrant-libvirt)
* Start vagrant VM
```
vagrant up --provider=libvirt
``` 

* Test systemtap is installed correctly
```
stap -v -e 'probe vfs.read {printf("read performed\n"); exit()}'
```
The above command should run without any error.

```bash
Pass 1: parsed user script and 488 library scripts using 303940virt/97700res/17212shr/82296data k
b, in 100usr/20sys/119real ms.
Pass 2: analyzed script: 2 probes, 1 function, 5 embeds, 0 globals using 551508virt/346848res/189
36shr/329864data kb, in 1590usr/180sys/1806real ms.
Pass 3: translated to C into "/tmp/stap7kmO08/stap_5af05774dfd7657d11e5162b856c54db_2791_src.c" u
sing 551508virt/346976res/19064shr/329864data kb, in 0usr/0sys/5real ms.
Pass 4: compiled C into "stap_5af05774dfd7657d11e5162b856c54db_2791.ko" in 1500usr/390sys/1749rea
l ms.
Pass 5: starting run.
read performed
Pass 5: run completed in 10usr/20sys/1045real ms.
```
* Get into APIcast directory
```
cd /opt/app-root
```

* Create a apicast-config.json file with the following content
```shell
cat <<EOF >apicast-config.json
{
    "services": [
        {
            "id": "1",
            "backend_version": "1",
            "proxy": {
                "hosts": [
                    "one"
                ],
                "api_backend": "http://my-upstream:8080/response-headers",
                "backend": {
                    "endpoint": "http://127.0.0.1:8081",
                    "host": "backend"
                },
                "policy_chain": [
                    {
                        "name": "apicast.policy.apicast"
                    }
                ],
                "proxy_rules": [
                    {
                        "http_method": "GET",
                        "pattern": "/",
                        "metric_system_name": "hits",
                        "delta": 1,
                        "parameters": [],
                        "querystring_parameters": {}
                    }
                ]
            }
        }
    ]
} 
EOF
```
* Run apicast locally
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=debug APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=lazy APICAST_CONFIGURATION_CACHE=0 THREESCALE_CONFIG_FILE=apicast-config.json ./bin/apicast
```
* Open another terminal
```
vagrant ssh
```
* Get nginx worker pid
```shell
[vagrant@localhost samples]$ ps aux | grep nginx
vagrant     5250  0.0  0.6 183716  6828 pts/0    S+   07:11   0:00 nginx: master process openresty -c /tmp/lua_Ve29ck -g error_log stderr debug; -p /tmp/lua_Pwe8RF
vagrant     5255  0.0  2.1 191936 21128 pts/0    S+   07:11   0:00 nginx: worker process
vagrant     5256  0.0  0.6 175776  6192 pts/0    S+   07:11   0:00 nginx: cache manager process
vagrant     9249  0.0  0.1  12216  1116 pts/2    S+   07:40   0:00 grep --color=auto nginx
```
* Run stap script with pid of nginx worker
```shell
[vagrant@localhost ~]$ ngx-lua-useless-cosockets.sxx -x 5255
Tracing process 5255 (/usr/local/openresty/nginx/sbin/nginx)
Hit Ctrl-C to end.
```
* Open another terminal and send request
```
vagrant ssh
[vagrant@localhost]$ curl -H "Host: one" localhost:8080/?user_key=
```
In the systemtap terminal, press `Ctrl-C` to end the probe. You should see something like the following
```
Found 0 unused ngx_lua TCP cosockets.
```
