### PR TITLE
Prevent APIcast fallback to global proxy settings for direct connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed 3scale Batcher policy unable to handle `app_id`/`access_token` contains special characters [PR #1457](https://github.com/3scale/APIcast/pull/1457) [THREESCALE-10934](https://issues.redhat.com/browse/THREESCALE-10934)
 
+- Fixed APIcast send request through proxy server even when `NO_PROXY` is used [PR #1478](https://github.com/3scale/APIcast/pull/1478) [THREESCALE-11128](https://issues.redhat.com/browse/THREESCALE-11128)
+
 ### Added
 
 - Bump openresty to 1.21.4.3 [PR #1461](https://github.com/3scale/APIcast/pull/1461) [THREESCALE-10601](https://issues.redhat.com/browse/THREESCALE-10601)

--- a/gateway/src/resty/http/proxy.lua
+++ b/gateway/src/resty/http/proxy.lua
@@ -57,10 +57,13 @@ local function connect(request)
     -- openresty treat nil as false, so we need to explicitly set ssl_verify to false if nil
     local ssl_verify = request.options and request.options.ssl and request.options.ssl.verify or false
 
+    -- We need to set proxy_opts to an empty table here otherwise, lua-resty-http will fallback
+    -- to the global proxy options
     local options = {
       scheme = scheme,
       host = host,
-      port = port
+      port = port,
+      proxy_opts = {}
     }
     if scheme == 'https' then
         options.ssl_server_name = host


### PR DESCRIPTION
## What

Fix https://issues.redhat.com/browse/THREESCALE-11128

## Notes

With the newer version of lua-resty-http (0.7.1), if a proxy options is not provided when calling the connect() method, it will fall back to using the global proxy settings set by the "set_proxy_option" function (has no effect in previous versions of the library). This then causes unexpected behavior where the direct connection will now go through the proxy server.

## Verification steps
* Build a new runtime image
```
make runtime-image IMAGE_NAME=apicast-test
```
* Move into dev-environment
```
cd dev-environments/http-proxy-plain-http-upstream
```

* Edit apicast-config.json as follow:

```diff
diff --git a/dev-environments/http-proxy-plain-http-upstream/apicast-config.json b/dev-environments/http-proxy-plain-http-upstream/apicast-config.json
index daa6967c..0e404d45 100644
--- a/dev-environments/http-proxy-plain-http-upstream/apicast-config.json
+++ b/dev-environments/http-proxy-plain-http-upstream/apicast-config.json
@@ -11,12 +11,6 @@
           "host": "backend"
         },
         "policy_chain": [
-          {
-            "name": "apicast.policy.http_proxy",
-            "configuration": {
-              "http_proxy": "http://proxy:8080/"
-            }
-          },
           {
             "name": "apicast.policy.apicast"
           }
```
* Update docker-compose.yml
```diff
diff --git a/dev-environments/http-proxy-plain-http-upstream/docker-compose.yml b/dev-environments/http-proxy-plain-http-upstream/docker-compose.yml
index f1e461fb..c25fa61d 100644
--- a/dev-environments/http-proxy-plain-http-upstream/docker-compose.yml
+++ b/dev-environments/http-proxy-plain-http-upstream/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       APICAST_WORKERS: 1
       APICAST_LOG_LEVEL: debug
       APICAST_CONFIGURATION_CACHE: "0"
+      HTTP_PROXY: "http://proxy:8080"
+      NO_PROXY: "127.0.0.1,localhost"
     expose:
       - "8080"
       - "8090"
```
* Start APIcast
```
make gateway IMAGE_NAME=apicast-test
```
* Send a request 
```
curl --resolve get.example.com:8080:127.0.0.1 -v "http://get.example.com:8080/?user_key=123"
```
APIcast should response with 200

```
< HTTP/1.1 200 OK
< Server: openresty
< Date: Thu, 27 Jun 2024 02:59:58 GMT
< Content-Type: application/json
< Content-Length: 249
< Connection: keep-alive
< Via: 1.1 tinyproxy (tinyproxy/1.11.2)
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Credentials: true
```

