### PR TITLE
[THREESCALE-9320] Conditional policy evaluating incorrectly: second policy in policy chain that implement export() always triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed confusing log display when APIcast listens on HTTPS and path routing is enabled [PR #1486](https://github.com/3scale/APIcast/pull/1486/files) [THREESCALE #8486](https://issues.redhat.com/browse/THREESCALE-8486)
 
+- Fixed Conditional policy evaluating incorrectly: second policy in policy chain that implement export() always triggers [PR #1485](https://github.com/3scale/APIcast/pull/1485) [THREESCALE-9320](https://issues.redhat.com/browse/THREESCALE-9320)
+
 ### Added
 
 - Bump openresty to 1.21.4.3 [PR #1461](https://github.com/3scale/APIcast/pull/1461) [THREESCALE-10601](https://issues.redhat.com/browse/THREESCALE-10601)

--- a/gateway/src/apicast/policy/camel/camel.lua
+++ b/gateway/src/apicast/policy/camel/camel.lua
@@ -45,17 +45,15 @@ function _M:access(context)
   upstream:set_skip_https_connect_on_proxy()
 end
 
-function _M:export()
+function _M:rewrite(context)
   -- This get_http_proxy function will be called in upstream just in case if a
   -- proxy is defined.
-  return  {
-    get_http_proxy = function(uri)
-      if not uri.scheme then
-        return nil
-      end
-      return find_proxy(self, uri.scheme)
+  context.get_http_proxy = function(uri)
+    if not uri.scheme then
+      return nil
     end
-  }
+    return find_proxy(self, uri.scheme)
+  end
 end
 
 return _M

--- a/gateway/src/apicast/policy/http_proxy/proxy.lua
+++ b/gateway/src/apicast/policy/http_proxy/proxy.lua
@@ -34,15 +34,15 @@ local function find_proxy(self, scheme)
   return self.proxies[scheme]
 end
 
-function _M:export()
-  return  {
-    get_http_proxy = function(uri)
-      if not uri.scheme then
-        return nil
-      end
-      return find_proxy(self, uri.scheme)
+function _M:rewrite(context)
+  -- APIcast reads this flag in the access phase, that's why we need to set it
+  -- in rewrite phase.
+  context.get_http_proxy = function(uri)
+    if not uri.scheme then
+      return nil
     end
-  }
+    return find_proxy(self, uri.scheme)
+  end
 end
 
 return _M

--- a/gateway/src/apicast/policy/request_unbuffered/request_unbuffered.lua
+++ b/gateway/src/apicast/policy/request_unbuffered/request_unbuffered.lua
@@ -13,10 +13,8 @@ function _M.new(config)
   return self
 end
 
-function _M:export()
-  return {
-    request_unbuffered = true,
-  }
+function _M:rewrite(context)
+  context.request_unbuffered = true
 end
 
 return _M

--- a/gateway/src/apicast/policy/retry/retry.lua
+++ b/gateway/src/apicast/policy/retry/retry.lua
@@ -13,8 +13,8 @@ function _M.new(config)
   return self
 end
 
-function _M:export()
-  return { upstream_retries = self.retries }
+function _M:rewrite(context)
+  context.upstream_retries = self.retries
 end
 
 return _M

--- a/gateway/src/apicast/policy/upstream_connection/apicast-policy.json
+++ b/gateway/src/apicast/policy/upstream_connection/apicast-policy.json
@@ -9,7 +9,7 @@
     "properties": {
       "connect_timeout": {
         "description": "Timeout for establishing a connection (in seconds).",
-        "type": "integer"
+        "type": "number"
       },
       "send_timeout": {
         "description": "Timeout between two successive write operations (in seconds).",

--- a/gateway/src/apicast/policy/upstream_connection/upstream_connection.lua
+++ b/gateway/src/apicast/policy/upstream_connection/upstream_connection.lua
@@ -18,13 +18,11 @@ function _M.new(config)
   return self
 end
 
-function _M:export()
-  return {
-    upstream_connection_opts = {
-      connect_timeout = self.connect_timeout,
-      send_timeout = self.send_timeout,
-      read_timeout = self.read_timeout
-    }
+function _M:rewrite(context)
+  context.upstream_connection_opts = {
+    connect_timeout = self.connect_timeout,
+    send_timeout = self.send_timeout,
+    read_timeout = self.read_timeout
   }
 end
 

--- a/spec/policy/camel/camel_spec.lua
+++ b/spec/policy/camel/camel_spec.lua
@@ -8,15 +8,20 @@ describe('Camel policy', function()
 
   local http_uri = {scheme="http"}
   local https_uri = {scheme="https"}
+  local context
+
+  before_each(function()
+    context = {}
+  end)
 
   it("http[s] proxies are defined if all_proxy is in there", function()
     local proxy = camel_policy.new({
       all_proxy = all_proxy_val
     })
-    local callback = proxy:export()
+    proxy:rewrite(context)
 
-    assert.same(callback.get_http_proxy(http_uri), resty_url.parse(all_proxy_val))
-    assert.same(callback.get_http_proxy(https_uri), resty_url.parse(all_proxy_val))
+    assert.same(context.get_http_proxy(http_uri), resty_url.parse(all_proxy_val))
+    assert.same(context.get_http_proxy(https_uri), resty_url.parse(all_proxy_val))
   end)
 
   it("all_proxy does not overwrite http/https proxies", function()
@@ -25,34 +30,35 @@ describe('Camel policy', function()
       http_proxy = http_proxy_val,
       https_proxy = https_proxy_val
     })
-    local callback = proxy:export()
+    proxy:rewrite(context)
 
-    assert.same(callback.get_http_proxy(http_uri), resty_url.parse(http_proxy_val))
-    assert.same(callback.get_http_proxy(https_uri), resty_url.parse(https_proxy_val))
+    assert.same(context.get_http_proxy(http_uri), resty_url.parse(http_proxy_val))
+    assert.same(context.get_http_proxy(https_uri), resty_url.parse(https_proxy_val))
   end)
 
   it("empty config return all nil", function()
     local proxy = camel_policy.new({})
-    local callback = proxy:export()
+    proxy:rewrite(context)
 
-    assert.is_nil(callback.get_http_proxy(https_uri))
-    assert.is_nil(callback.get_http_proxy(http_uri))
+    assert.is_nil(context.get_http_proxy(https_uri))
+    assert.is_nil(context.get_http_proxy(http_uri))
   end)
 
   describe("get_http_proxy callback", function()
-    local callback = camel_policy.new({
+    local proxy = camel_policy.new({
         all_proxy = all_proxy_val
-    }):export()
+    })
 
     it("Valid protocol", function()
-
-      local result = callback.get_http_proxy(
+      proxy:rewrite(context)
+      local result = context.get_http_proxy(
         resty_url.parse("http://google.com"))
       assert.same(result, resty_url.parse(all_proxy_val))
     end)
 
     it("invalid protocol", function()
-      local result = callback:get_http_proxy(
+      proxy:rewrite(context)
+      local result = context:get_http_proxy(
         {}, {scheme="invalid"})
       assert.is_nil(result)
     end)

--- a/spec/policy/retry/retry_spec.lua
+++ b/spec/policy/retry/retry_spec.lua
@@ -5,10 +5,11 @@ describe('Retry policy', function()
     it('returns the the number of retries', function()
       local policy_config = { retries = 5, }
       local policy = RetryPolicy.new(policy_config)
+      local context = {}
 
-      local exported = policy:export()
+      policy:rewrite(context)
 
-      assert.same(policy_config.retries, exported.upstream_retries)
+      assert.same(policy_config.retries, context.upstream_retries)
     end)
   end)
 end)

--- a/spec/policy/upstream_connection/upstream_connection_spec.lua
+++ b/spec/policy/upstream_connection/upstream_connection_spec.lua
@@ -8,20 +8,20 @@ describe('Upstream connection policy', function()
         send_timeout = 2,
         read_timeout = 3
       }
+      local context = {}
       local policy = UpstreamConnectionPolicy.new(config_timeouts)
+      policy:rewrite(context)
 
-      local exported = policy:export()
-
-      assert.same(config_timeouts, exported.upstream_connection_opts)
+      assert.same(config_timeouts, context.upstream_connection_opts)
     end)
 
     it('does not return timeout params that is not in the config', function()
       local config_timeouts = { connect_timeout = 1 } -- Missing send and read
+      local context = {}
       local policy = UpstreamConnectionPolicy.new(config_timeouts)
+      policy:rewrite(context)
 
-      local exported = policy:export()
-
-      assert.same(config_timeouts, exported.upstream_connection_opts)
+      assert.same(config_timeouts, context.upstream_connection_opts)
     end)
   end)
 end)

--- a/t/apicast-policy-upstream-connection.t
+++ b/t/apicast-policy-upstream-connection.t
@@ -421,9 +421,9 @@ should receive the whole response back
                 {
                   "name": "apicast.policy.upstream_connection",
                   "configuration": {
-                    "connect_timeout": 1,
-                    "send_timeout": 1,
-                    "read_timeout": 1
+                    "connect_timeout": 0.1,
+                    "send_timeout": 0.1,
+                    "read_timeout": 0.1
                   }
                 }
               ]
@@ -449,7 +449,7 @@ should receive the whole response back
     content_by_lua_block {
       ngx.say("first part")
       ngx.flush(true)
-      ngx.sleep(3)
+      ngx.sleep(0.2)
       ngx.say("yay, second part")
     }
   }

--- a/t/apicast-policy-upstream-connection.t
+++ b/t/apicast-policy-upstream-connection.t
@@ -308,3 +308,155 @@ ETag: foobar
 using proxy: $TEST_NGINX_HTTPS_PROXY
 err: timeout
 --- user_files fixture=tls.pl eval
+
+
+
+=== TEST 5: upstream_connection policy inside conditional policy
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.conditional",
+            "configuration": {
+              "condition": {
+                "operations": [
+                  {
+                    "left": "{{ uri }}",
+                    "left_type": "liquid",
+                    "op": "==",
+                    "right": "/test",
+                    "right_type": "plain"
+                  }
+                ]
+              },
+              "policy_chain": [
+                {
+                  "name": "apicast.policy.upstream_connection",
+                  "configuration": {
+                    "connect_timeout": 1,
+                    "send_timeout": 1,
+                    "read_timeout": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+  server_name test-upstream.lvh.me;
+  location /test {
+    content_by_lua_block {
+      ngx.say("first part")
+      ngx.flush(true)
+      ngx.sleep(3)
+      ngx.say("yay, second part")
+    }
+  }
+--- request
+GET /test?user_key=value
+--- ignore_response
+--- error_log
+upstream timed out
+
+
+
+=== TEST 6: upstream_connection policy inside conditional policy with false condition
+In this test the upstream returns part of the response, then waits 3s and after
+that, it returns the rest of the response. We set timeouts to 1s inside the conditional
+policy but due to false condition, the default timeout of 60s should take effect and we
+should receive the whole response back
+--- configuration
+{
+  "services": [
+    {
+      "id": 42,
+      "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "api_backend": "http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          {
+            "name": "apicast.policy.conditional",
+            "configuration": {
+              "condition": {
+                "operations": [
+                  {
+                    "left": "{{ uri }}",
+                    "left_type": "liquid",
+                    "op": "==",
+                    "right": "/invalid",
+                    "right_type": "plain"
+                  }
+                ]
+              },
+              "policy_chain": [
+                {
+                  "name": "apicast.policy.upstream_connection",
+                  "configuration": {
+                    "connect_timeout": 1,
+                    "send_timeout": 1,
+                    "read_timeout": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "apicast.policy.apicast"
+          }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      ngx.exit(ngx.OK)
+    }
+  }
+--- upstream
+  server_name test-upstream.lvh.me;
+  location /test {
+    content_by_lua_block {
+      ngx.say("first part")
+      ngx.flush(true)
+      ngx.sleep(3)
+      ngx.say("yay, second part")
+    }
+  }
+--- request
+GET /test?user_key=value
+--- response_body eval
+"first part\x{0a}yay, second part\x{0a}"
+--- error_code: 200
+--- no_error_log
+[error]


### PR DESCRIPTION
## What
Fix https://issues.redhat.com/browse/THREESCALE-9320

An interesting side effect of this PR is that it also fixes the following problems
https://issues.redhat.com/browse/THREESCALE-8146
https://issues.redhat.com/browse/THREESCALE-8149

## Why

When included in the policy chain, conditional policy will [construct](https://github.com/3scale/APIcast/blob/master/gateway/src/apicast/policy/conditional/conditional.lua#L15) an internal policy chain with a list of policies. 

When APIcast build a shared context,  it will then call [export()](https://github.com/3scale/APIcast/blob/master/gateway/src/apicast/executor.lua#L36) on the chain, including the chain constructed by the conditional policy. This means that any policy that implements export function will be triggered regardless of what the user sets the conditions for.

We can avoid this by moving the context export to a different phase. But first let check their current phases

| Policy | Executed by | executed in phase | Phases in official docs | Order in the chain | Proposed phase change | Order in the chain after change |
| ---- | ---- | ---- | ---- | ---- | ---- | ---- |
| upstream_connection | apicast/upstream.lua | content -> balancer | not documented | the position of this policy does not matter. | rewrite | the position of this policy does not matter. |
| retry | apicast/upstream.lua | content -> balancer | not documented | the position of this policy does not matter. | rewrite | the position of this policy does not matter. |
| camel | apicast/upstream.lua | access -> content -> balancer | access | access | rewrite | the position of this policy does not matter. |
| on_failed | apicast/policy_chain.lua | every phase | not documented | not documented | I prefer to keep the current behavior |  |
| caching | policy/3scale_batcher/3scale_batcher.lua </br> apicast/apicast.lua </br> apicast/proxy.lua | rewrite-> access | not documented | the position of this policy does not matter. | I prefer to keep the current behavior |  |
| http_proxy | apicast/upstream.lua | content -> balancer | not documented | the position of this policy does not matter. | rewrite | the position of this policy does not matter. |
| request_unbuffered | apicast/upstream.lua | content -> balancer | not documented | the position of this policy does not matter. | rewrite | the position of this policy does not matter. |

## Verification steps

### Upstream connection policy

<details>

* Checkout this branch
* Start development environment
```
make development
make dependencies
```
* Create apicast-config.json
```json
{
  "services": [
    {
      "backend_version": "1",
      "id": "1",
      "proxy": {
        "hosts": [
          "one"
        ],
        "api_backend": "https://httpbingo.org/delay/",
        "backend": {
          "endpoint": "http://127.0.0.1:8081",
          "host": "backend"
        },
        "policy_chain": [
          {
            "name": "apicast.policy.conditional",
            "configuration": {
              "condition": {
                "operations": [
                  {
                    "left": "{{ uri }}",
                    "left_type": "liquid",
                    "op": "==",
                    "right": "/2",
                    "right_type": "plain"
                  }
                ]
              },
              "policy_chain": [
                {
                  "name": "apicast.policy.upstream_connection",
                  "configuration": {
                    "connect_timeout": 1,
                    "send_timeout": 1,
                    "read_timeout": 1
                  }
                }
              ]
            }
          },
          {
            "name": "apicast.policy.apicast"
          }
        ],
        "proxy_rules": [
          {
            "http_method": "GET",
            "pattern": "/",
            "metric_system_name": "hits",
            "delta": 1,
            "parameters": [],
            "querystring_parameters": {}
          }
        ]
      }
    }
  ]
}
```
* Start APIcast
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=warn APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=lazy APICAST_CONFIGURATION_CACHE=0 THREESCALE_CONFIG_FILE=apicast-config.json ./bin/apicast
```
* Capture APIcast IP
```
APICAST_IP=$(docker inspect apicast_build_0-development-1 | yq e -P '.[0].NetworkSettings.Networks.apicast_build_0_default.IPAddress' -)
```
* Send first request 
```
curl -i -k -H "Host: one" "http://${APICAST_IP}:8080/?user_key="
```
You should receive `HTTP/1.1 200 OK`
* Send second request, this will trigger the conditional policy
```
curl -i -k -H "Host: one" "http://${APICAST_IP}:8080/2?user_key="
```
You should receive `HTTP/1.1 504 Gateway Time-out`
```
HTTP/1.1 504 Gateway Time-out
Server: openresty
Date: Wed, 24 Jul 2024 05:31:47 GMT
Content-Type: text/plain
Transfer-Encoding: chunked
Connection: keep-alive
```
* Stop APIcast
```
CTRL-C
```

</details>

### Retry policy

<details>

* Modify apicast-config.json as follow
```diff
diff --git a/apicast-config.json b/apicast-config.json
index 28744dd0..eda557b7 100644
--- a/apicast-config.json
+++ b/apicast-config.json
@@ -7,7 +7,7 @@
         "hosts": [
           "one"
         ],
-        "api_backend": "https://httpbingo.org/delay/",
+        "api_backend": "https://httpbingo.org/status/",
         "backend": {
           "endpoint": "http://127.0.0.1:8081",
           "host": "backend"
@@ -22,7 +22,7 @@
                     "left": "{{ uri }}",
                     "left_type": "liquid",
                     "op": "==",
-                    "right": "/2",
+                    "right": "/503",
                     "right_type": "plain"
                   }
                 ]
@@ -31,9 +31,7 @@
                 {
                   "name": "apicast.policy.retry",
                   "configuration": {
-                    "connect_timeout": 1,
-                    "send_timeout": 1,
-                    "read_timeout": 1
+                    "retries": 3
                   }
                 }
               ]
```
* Start APIcast with `APICAST_UPSTREAM_RETRY_CASES="error http_503 http_504"`
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=warn APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=lazy APICAST_CONFIGURATION_CACHE=0 APICAST_UPSTREAM_RETRY_CASES="error http_503 http_504" THREESCALE_CONFIG_FILE=apicast-config.json ./bin/apicast
```
* Send first request 
```
curl -i -k -H "Host: one" "http://${APICAST_IP}:8080/504?user_key="
```
You should receive `HTTP/1.1 504 Gateway Time-out` immediately
* Send second request, this will trigger the conditional policy
```
curl -i -k -H "Host: one" "http://${APICAST_IP}:8080/503?user_key="
```
Check the log and confirm that APIcast retry the request 3 times
* Stop APIcast
```
CTRL-C
```

</details>

### Camel proxy

<details>

* Build a new run-time image
```
make runtime-image IMAGE_NAME=apicast-test
```
* Move into camel-proxy dev-environment
```
cd dev-environments/camel-proxy
```
* Edit apicast-config.json as follow
```diff
diff --git a/dev-environments/camel-proxy/apicast-config.json b/dev-environments/camel-proxy/apicast-config.json
index 91201afa..6cee023a 100644
--- a/dev-environments/camel-proxy/apicast-config.json
+++ b/dev-environments/camel-proxy/apicast-config.json
@@ -5,16 +5,34 @@
       "backend_version": "1",
       "proxy": {
         "hosts": ["http-proxy.example.com"],
-        "api_backend": "http://example.com:80/get",
+        "api_backend": "http://example.com:80/",
         "backend": {
           "endpoint": "http://127.0.0.1:8081",
           "host": "backend"
         },
         "policy_chain": [
           {
-            "name": "apicast.policy.camel",
+            "name": "apicast.policy.conditional",
             "configuration": {
-              "http_proxy": "http://proxy.socat:8080/"
+              "condition": {
+                "operations": [
+                  {
+                    "left": "{{ uri }}",
+                    "left_type": "liquid",
+                    "op": "==",
+                    "right": "/headers",
+                    "right_type": "plain"
+                  }
+                ]
+              },
+              "policy_chain": [
+                  {
+                    "name": "apicast.policy.camel",
+                    "configuration": {
+                      "http_proxy": "http://proxy.socat:8080/"
+                    }
+                  }
+              ]
             }
           },
           {
```
* Generate certs
```
make certs
```
* Start APIcast
```
make gateway IMAGE_NAME=apicast-test
```
* Send first request
```
curl --resolve http-proxy.example.com:8080:127.0.0.1 -v "http://http-proxy.example.com:8080/get?user_key=123"
```
Expected response
```
< HTTP/1.1 200 OK
< Server: openresty
< Date: Wed, 24 Jul 2024 06:19:48 GMT
< Content-Type: application/json
< Content-Length: 221
< Connection: keep-alive
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Credentials: true
<
{
  "args": {
    "user_key": "123"
  },
  "headers": {
    "Accept": "*/*",
    "Host": "example.com",
    "User-Agent": "curl/7.61.1"
  },
  "origin": "172.20.0.4",
  "url": "http://example.com/get?user_key=123"
}
* Connection #0 to host http-proxy.example.com left intact
```
* Send second request that will trigger camel proxy
```
curl --resolve http-proxy.example.com:8080:127.0.0.1 -v "http://http-proxy.example.com:8080/headers?user_key=123"
```
Expected response
```
< HTTP/1.1 200 OK
< Server: openresty
< Date: Wed, 24 Jul 2024 06:19:54 GMT
< Content-Type: application/json
< Content-Length: 138
< Connection: keep-alive
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Origin: *
<
{
  "HEADERS": {
    "ACCEPT": "*/*",
    "CONNECTION": "KEEP-ALIVE",
    "HOST": "EXAMPLE.COM",
    "USER-AGENT": "CURL/7.61.1"
  }
}
* Connection #0 to host http-proxy.example.com left intact
```
* Stop APIcast
```
CTRL-C
```

</details>

### HTTP Proxy policy

<details>

* Move into http proxy dev-environment
```
cd http-proxy-plain-http-upstream
```
* Edit apicast-config.json as follow

```diff
diff --git a/dev-environments/http-proxy-plain-http-upstream/apicast-config.json b/dev-environments/http-proxy-plain-http-upstream/apicast-config.json
index daa6967c..60231ba4 100644
--- a/dev-environments/http-proxy-plain-http-upstream/apicast-config.json
+++ b/dev-environments/http-proxy-plain-http-upstream/apicast-config.json
@@ -5,16 +5,34 @@
       "backend_version": "1",
       "proxy": {
         "hosts": ["get.example.com"],
-        "api_backend": "http://example.com/get",
+        "api_backend": "http://example.com/",
         "backend": {
           "endpoint": "http://127.0.0.1:8081",
           "host": "backend"
         },
         "policy_chain": [
           {
-            "name": "apicast.policy.http_proxy",
+            "name": "apicast.policy.conditional",
             "configuration": {
-              "http_proxy": "http://proxy:8080/"
+              "condition": {
+                "operations": [
+                  {
+                    "left": "{{ uri }}",
+                    "left_type": "liquid",
+                    "op": "==",
+                    "right": "/headers",
+                    "right_type": "plain"
+                  }
+                ]
+              },
+              "policy_chain": [
+                {
+                  "name": "apicast.policy.http_proxy",
+                  "configuration": {
+                    "http_proxy": "http://proxy:8080/"
+                  }
+                }
+              ]
             }
           },
           {
```

* Start APIcast
```
make gateway IMAGE_NAME=apicast-test
```
* Send first request
```
curl --resolve get.example.com:8080:127.0.0.1 -v "http://get.example.com:8080/get?user_key=123"
```
* Check proxy logs and make sure that no request goes through the proxy
```
docker compose -p http-proxy-plain-http-upstream logs -f proxy
```

* Send second request that will trigger camel proxy
```
curl --resolve get.example.com:8080:127.0.0.1 -v "http://get.example.com:8080/headers?user_key=123"
```
* Check proxy logs again and this time we should see a new request in the log

<details>

```bash
 ▲ APIcast/dev-environments/http-proxy-plain-http-upstream docker compose -p http-proxy-plain-http-upstream logs -f proxy
proxy  | 2024/07/24 06:57:01 socat[1] N listening on AF=2 0.0.0.0:8080
proxy  | 2024/07/24 06:59:07 socat[1] N accepting connection from AF=2 172.22.0.6:56794 on AF=2 172.22.0.2:8080
proxy  | 2024/07/24 06:59:07 socat[1] N forked off child process 7
proxy  | 2024/07/24 06:59:07 socat[1] N listening on AF=2 0.0.0.0:8080
proxy  | 2024/07/24 06:59:07 socat[7] N opening connection to AF=2 172.22.0.4:443
proxy  | 2024/07/24 06:59:07 socat[7] N successfully connected from local address AF=2 172.22.0.2:46212
proxy  | 2024/07/24 06:59:07 socat[7] N starting data transfer loop with FDs [6,6] and [5,5]
proxy  | > 2024/07/24 06:59:07.000640505  length=136 from=0 to=135
proxy  | GET http://example.com/headers?user_key=123 HTTP/1.1\r
proxy  | X-Real-IP: 172.22.0.1\r
proxy  | Host: example.com\r
proxy  | User-Agent: curl/7.61.1\r
proxy  | Accept: */*\r
proxy  | \r
proxy  | < 2024/07/24 06:59:07.000643512  length=17 from=0 to=16
proxy  | HTTP/1.1 200 OK\r
proxy  | < 2024/07/24 06:59:07.000643558  length=64 from=17 to=80
proxy  | Via: 1.1 tinyproxy (tinyproxy/1.11.2)\r
proxy  | Server: gunicorn/19.9.0\r
proxy  | < 2024/07/24 06:59:07.000643618  length=69 from=81 to=149
proxy  | Date: Wed, 24 Jul 2024 06:59:07 GMT\r
proxy  | Content-Type: application/json\r
proxy  | < 2024/07/24 06:59:07.000643686  length=95 from=150 to=244
proxy  | Content-Length: 133\r
proxy  | Access-Control-Allow-Origin: *\r
proxy  | Access-Control-Allow-Credentials: true\r
proxy  | \r
proxy  | < 2024/07/24 06:59:07.000643763  length=133 from=245 to=377
proxy  | {
proxy  |   "headers": {
proxy  |     "Accept": "*/*",
proxy  |     "Connection": "close",
proxy  |     "Host": "example.com",
proxy  |     "User-Agent": "curl/7.61.1"
proxy  |   }
proxy  | }
proxy  | 2024/07/24 06:59:07 socat[7] N socket 2 (fd 5) is at EOF
proxy  | 2024/07/24 06:59:07 socat[7] N socket 1 (fd 6) is at EOF
proxy  | 2024/07/24 06:59:07 socat[7] N exiting with status 0
proxy  | 2024/07/24 06:59:07 socat[1] N childdied(): handling signal 17
```

</details>

* Stop APIcast
```
CTRL-C
```

</details>

### Request unbuffered policy

<details>

* Move to plain-http-upstream dev-env
```
cd dev-environments/plain-http-upstream
```

* Edit apicast-config.json  as follow

```diff
diff --git a/dev-environments/plain-http-upstream/apicast-config.json b/dev-environments/plain-http-upstream/apicast-config.json
index 30c2db39..f832a2ca 100644
--- a/dev-environments/plain-http-upstream/apicast-config.json
+++ b/dev-environments/plain-http-upstream/apicast-config.json
@@ -38,6 +38,27 @@
           "host": "backend"
         },
         "policy_chain": [
+          {
+            "name": "apicast.policy.conditional",
+            "configuration": {
+              "condition": {
+                "operations": [
+                  {
+                    "left": "{{ headers['Foo'] }}",
+                    "left_type": "liquid",
+                    "op": "==",
+                    "right": "test",
+                    "right_type": "plain"
+                  }
+                ]
+              },
+              "policy_chain": [
+                {
+                   "name": "apicast.policy.request_unbuffered"
+                 }
+              ]
+            }
+          },
           {
             "name": "apicast.policy.apicast"
           }
```

* Start APIcast
```
make gateway IMAGE_NAME=apicast-test
```

* Generate a big enough file
```
fallocate -l 1M bigfile
```
* Open another terminal to inspect traffic between APIcast and upstream
```
docker compose -p plain-http-upstream logs -f example.com
```

* Send a request to APIcast
```
curl --resolve post.example.com:8080:127.0.0.1 -v -X POST -H "Transfer-Encoding: chunked" -F file=@bigfile "http://post.example.com:8080/?user_key=123"
```

The upstream returns 200, and checking `example` service log, you should see that APIcast send request with Content-Lenght header

```
example.com  | POST /post?user_key=123 HTTP/1.1\r
example.com  | X-Real-IP: 192.168.32.1\r
example.com  | Host: example.com\r
example.com  | Content-Length: 4295\r
example.com  | User-Agent: curl/7.61.1\r
example.com  | Accept: */*\r
example.com  | Content-Type: multipart/form-data; boundary=------------------------b5ca507060dd316c\r
```

*  Send a second request with extra header
```
curl --resolve post.example.com:8080:127.0.0.1 -v -X POST -H "Transfer-Encoding: chunked" -F file=@bigfile -H "Foo: test" "http://post.example.com:8080/?user_key=123"
```
This time we can see that upstream return 200 and APIcast send request to upstream with `Transfer-encoding:  chunked` header

```
example.com  | POST /post?user_key=123 HTTP/1.1\r
example.com  | X-Real-IP: 192.168.32.1\r
example.com  | Host: example.com\r
example.com  | Transfer-Encoding: chunked\r
example.com  | User-Agent: curl/7.61.1\r
example.com  | Accept: */*\r
example.com  | Foo: test\r
example.com  | Content-Type: multipart/form-data; boundary=------------------------b0d2db867787e304\r
```

</details>