### PR TITLE
[THREESCALE-8486] TLS and path routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed config reloading even when reloading is disabled [PR #1468](https://github.com/3scale/APIcast/pull/1468)
 
+- Fixed confusing log display when APIcast listens on HTTPS and path routing is enabled [PR #1486](https://github.com/3scale/APIcast/pull/1486/files) [THREESCALE #8486](https://issues.redhat.com/browse/THREESCALE-8486)
+
 ### Added
 
 - Bump openresty to 1.21.4.3 [PR #1461](https://github.com/3scale/APIcast/pull/1461) [THREESCALE-10601](https://issues.redhat.com/browse/THREESCALE-10601)

--- a/gateway/src/apicast/policy/find_service/find_service.lua
+++ b/gateway/src/apicast/policy/find_service/find_service.lua
@@ -52,11 +52,11 @@ _M.rewrite = find_service
 -- ssl_certificate is the first phase executed when request arrives on HTTPS
 -- therefore it needs to find a service to build a policy chain.
 -- The method and the path are not available in the ssl_certificate phase, so
--- path-based routing does not work. It should always find the service by host.
+-- path-based routing does not compatible with this phase.
 function _M:ssl_certificate(context)
   if self.find_service ~= host_based_finder.find_service then
-    ngx.log(ngx.WARN, 'Configured to do path-based routing, but it is not',
-                      'compatible with TLS. Falling back to routing by host.')
+    ngx.log(ngx.DEBUG, 'Configured to do path-based routing, but it is not',
+                      ' compatible with ssl_certificate phase. Skipping ssl_certificate phase...')
     return
   end
   context.service = context.service or

--- a/gateway/src/apicast/policy/tls/README.md
+++ b/gateway/src/apicast/policy/tls/README.md
@@ -8,6 +8,7 @@ certificate to the given service.
 For this policy `APICAST_HTTPS_PORT` variable need to be defined to be able to
 listen in TLS in any port.
 
+NOTE: This policy is not compatible with `APICAST_PATH_ROUTING` or `APICAST_PATH_ROUTING_ONLY`
 
 ### Embedded certificate:
 

--- a/t/listen-https.t
+++ b/t/listen-https.t
@@ -132,7 +132,7 @@ VZ5Wr10wCgYIKoZIzj0EAwIDSAAwRQIhAPRkfbxowt0H7p5xZYpwoMKanUXz9eKQ
 Regression test. APIcast was crashing because path-based routing needs the http
 method and the path. However, those are not available when trying to find the
 service in the ssl_certificate phase.
-This test checks that APIcast falls back to finding the service by host.
+This test checks that APIcast able to route request to correct service in rewrite phase.
 --- env eval
 (
     'APICAST_HTTPS_PORT' => "$Test::Nginx::Util::ServerPortForClient",
@@ -217,10 +217,10 @@ connected: 1
 ssl handshake: cdata
 HTTP/1.1 202 Accepted
 --- error_code: 200
---- grep_error_log eval: qr/Falling back to routing by host/
+--- grep_error_log eval: qr/Skipping ssl_certificate phase/
 --- grep_error_log_out
-Falling back to routing by host
-Falling back to routing by host
+Skipping ssl_certificate phase
+Skipping ssl_certificate phase
 --- no_error_log
 [error]
 --- user_files


### PR DESCRIPTION
## What
Fix https://issues.redhat.com/browse/THREESCALE-8486
and 
https://issues.redhat.com/browse/THREESCALE-11036

## Verification steps
* Check out this branch
* Build runtime image
```
make runtime-image IMAGE_NAME=apicast-test
```
* Modify listen-tls environment as follow
```diff
diff --git a/dev-environments/listen-tls/docker-compose.yml b/dev-environments/listen-tls/docker-compose.yml
index 6d89464f..ce6ea12b 100644
--- a/dev-environments/listen-tls/docker-compose.yml
+++ b/dev-environments/listen-tls/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       THREESCALE_CONFIG_FILE: /tmp/config.json
       THREESCALE_DEPLOYMENT_ENV: staging
       APICAST_CONFIGURATION_LOADER: lazy
+      APICAST_PATH_ROUTING:true
       APICAST_WORKERS: 1
       APICAST_LOG_LEVEL: debug
       APICAST_CONFIGURATION_CACHE: "0"
``` 
* Run local apicast
```
make gateway IMAGE_NAME=apicast-test
```
* Test with a request
```
curl --resolve example.com:8443:127.0.0.1 -v --cacert cert/rootCA.pem "https://example.com:8443/?user_key=123"
```

This line should appear as debug log
```
[debug] 943340#943340: *3 find_service.lua:58: Configured to do path-based routing, but it is not compatible with ssl_certificate phase. Skipping.
```