### PR TITLE
[THREESCALE-10130] APIcast using stale configuration for a deleted Product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed confusing log display when APIcast listens on HTTPS and path routing is enabled [PR #1486](https://github.com/3scale/APIcast/pull/1486/files) [THREESCALE #8486](https://issues.redhat.com/browse/THREESCALE-8486)
 
 - Fixed Conditional policy evaluating incorrectly: second policy in policy chain that implement export() always triggers [PR #1485](https://github.com/3scale/APIcast/pull/1485) [THREESCALE-9320](https://issues.redhat.com/browse/THREESCALE-9320)
+- Fix APIcast using stale configuration for deleted products [PR #1488](https://github.com/3scale/APIcast/pull/1488) [THREESCALE-10130](https://issues.redhat.com/browse/THREESCALE-10130)
 
 ### Added
 

--- a/gateway/src/apicast/configuration_loader.lua
+++ b/gateway/src/apicast/configuration_loader.lua
@@ -235,7 +235,9 @@ local function lazy_load_config(configuration, host)
     if not config then
       ngx.log(ngx.WARN, 'failed to get config for host: ', host)
     end
-    _M.configure(configuration, config, host)
+    -- Lazy load will never returned stale data, so no need to reset the
+    -- cache
+    _M.configure(configuration, config)
 end
 
 function lazy.rewrite(configuration, host)

--- a/gateway/src/apicast/configuration_loader.lua
+++ b/gateway/src/apicast/configuration_loader.lua
@@ -1,4 +1,4 @@
-local configuration_store = require('apicast.configuration_store')
+local configuration_store = require 'apicast.configuration_store'
 local configuration_parser = require 'apicast.configuration_parser'
 local mock_loader = require 'apicast.configuration_loader.mock'
 local file_loader = require 'apicast.configuration_loader.file'
@@ -75,7 +75,7 @@ function _M.global(contents)
   return _M.configure(context.configuration, contents)
 end
 
-function _M.configure(configuration, contents)
+function _M.configure(configuration, contents, reset_cache)
   if not configuration then
     return nil, 'not initialized'
   end
@@ -90,6 +90,12 @@ function _M.configure(configuration, contents)
   end
 
   if config then
+    -- We have the configuration available at this point so it's safe to purge the
+    -- cache and remove old items (deleted services)
+    if reset_cache then
+      ngx.log(ngx.DEBUG, "flushing caches as part of the configuration reload")
+      configuration:reset()
+    end
     configuration:store(config, ttl())
     collectgarbage()
     return config
@@ -160,7 +166,7 @@ end
 
 local function refresh_configuration(configuration)
   local config = _M.load()
-  local init, err = _M.configure(configuration, config)
+  local init, err = _M.configure(configuration, config, true)
 
   if init then
     ngx.log(ngx.DEBUG, 'updated configuration via timer: ', config)
@@ -229,7 +235,7 @@ local function lazy_load_config(configuration, host)
     if not config then
       ngx.log(ngx.WARN, 'failed to get config for host: ', host)
     end
-    _M.configure(configuration, config)
+    _M.configure(configuration, config, host)
 end
 
 function lazy.rewrite(configuration, host)

--- a/gateway/src/apicast/configuration_store.lua
+++ b/gateway/src/apicast/configuration_store.lua
@@ -165,15 +165,17 @@ function _M.store(self, config, ttl)
   return config
 end
 
-function _M.reset(self, cache_size)
+--- Flush all LRU cache
+function _M.reset(self)
   if not self.services then
     return nil, 'not initialized'
   end
 
-  self.services = lrucache.new(cache_size or _M.cache_size)
-  self.cache = lrucache.new(cache_size or _M.cache_size)
+  self.services:flush_all()
+  self.cache:flush_all()
   self.configured = false
 end
+
 
 function _M.add(self, service, ttl)
   if not self.services then

--- a/gateway/src/apicast/policy/load_configuration/load_configuration.lua
+++ b/gateway/src/apicast/policy/load_configuration/load_configuration.lua
@@ -2,7 +2,7 @@ local _M = require('apicast.policy').new('Load Configuration')
 local ssl = require('ngx.ssl')
 
 local configuration_loader = require('apicast.configuration_loader').new()
-local configuration_store = require('apicast.configuration_store', 'builtin')
+local configuration_store = require('apicast.configuration_store')
 
 local new = _M.new
 

--- a/spec/configuration_loader/remote_v2_spec.lua
+++ b/spec/configuration_loader/remote_v2_spec.lua
@@ -3,7 +3,6 @@ local test_backend_client = require 'resty.http_ng.backend.test'
 local cjson = require 'cjson'
 local user_agent = require 'apicast.user_agent'
 local env = require 'resty.env'
-local format = string.format
 
 local service_generator = function(n)
   local services = {}

--- a/spec/configuration_loader_spec.lua
+++ b/spec/configuration_loader_spec.lua
@@ -90,6 +90,24 @@ insulate('Configuration object', function()
 
       assert.truthy(config:find_by_id('42'))
     end)
+
+    it('should reset cache', function()
+      local config = configuration_store.new()
+
+      assert.truthy(_M.configure(config, cjson.encode({ services = {
+        { id = 42, proxy = { hosts = { 'localhost' } } },
+        { id = 43, proxy = { hosts = { 'localhost' } } }
+      }})))
+
+      assert.truthy(config:find_by_id('42'))
+      assert.truthy(config:find_by_id('43'))
+
+      assert.truthy(_M.configure(config, cjson.encode({ services = {
+        { id = 42, proxy = { hosts = { 'localhost' } } },
+      }}), true))
+      assert.truthy(config:find_by_id('42'))
+      assert.falsy(config:find_by_id('43'))
+    end)
   end)
 
   describe('lazy loader', function()


### PR DESCRIPTION
## What
Fix https://issues.redhat.com/browse/THREESCALE-10130

## Verification steps
* Install 3scale and create two Product A and B
* Checkout this branch
* Start development environment
```
make development
make dependencies
```
* Start APIcast with `THREESCALE_PORTAL_ENDPOINT=https://<token>@<provider domain>`
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=debug APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=boot APICAST_CONFIGURATION_CACHE=60 THREESCALE_PORTAL_ENDPOINT=https://token@3scale-admin.example.com ./bin/apicast
```
* Send requests
```
# capture apicast IP
APICAST_IP=$(docker inspect apicast_build_0-development-1 | yq e -P '.[0].NetworkSettings.Networks.apicast_build_0_default.IPAddress' -)

curl -v -k -H "Host: example.productA.com:443" -H "Accept: application/json" http://${APICAST_IP}:8080/user_key=<user_key>

curl -v -k -H "Host: example.productB.com:443" -H "Accept: application/json" http://${APICAST_IP}:8080/user_key=<user_key>
```
* Both responses should be `HTTP/1.1 200 OK`
* Now visit 3scale admin portal and delete ProductB.
* Wait for APIcast to reload the configuration
* Send request to ProductA, response should be `HTTP/1.1 200 OK`
* Send request to ProductB, response should be `HTTP/1.1 404 Not Found`
```
< HTTP/1.1 404 Not Found
< Server: openresty
< Date: Tue, 23 Jul 2024 04:41:21 GMT
< Content-Type: text/plain
< Transfer-Encoding: chunked
< Connection: keep-alive
```
