### PR TITLE
THREESCALE-10894 concat filtered services into a single log

### DIFF
--- a/gateway/src/apicast/configuration.lua
+++ b/gateway/src/apicast/configuration.lua
@@ -9,6 +9,7 @@ local tostring = tostring
 local next = next
 local lower = string.lower
 local insert = table.insert
+local concat = table.concat
 local setmetatable = setmetatable
 local null = ngx.null
 
@@ -164,13 +165,13 @@ function _M.filter_services(services, subset)
     if service:match_host(service_regexp_filter) or subset[service.id] then
       insert(selected_services, service)
     else
-      table.insert(filtered_services, service.id)
+      insert(filtered_services, service.id)
     end
   end
 
   -- Log all filtered services in a single log
   if #filtered_services > 0 then
-    ngx.log(ngx.WARN, "filtering out services: ", table.concat(filtered_services, ", "))
+    ngx.log(ngx.WARN, "filtering out services: ", concat(filtered_services, ", "))
   end
 
   return selected_services

--- a/gateway/src/apicast/configuration.lua
+++ b/gateway/src/apicast/configuration.lua
@@ -169,13 +169,8 @@ function _M.filter_services(services, subset)
   end
 
   -- Log all filtered services in a single log
-  if #filtered_services > 0 then  
-    local filtered_services_str = {}
-    for _, service_id in ipairs(filtered_services) do
-      table.insert(filtered_services_str, tostring(service_id))
-    end
-  
-    ngx.log(ngx.WARN, "filtering out services: " .. table.concat(filtered_services_str, ", "))
+  if #filtered_services > 0 then
+    ngx.log(ngx.WARN, "filtering out services: ", table.concat(filtered_services, ", "))
   end
 
   return selected_services

--- a/gateway/src/apicast/configuration.lua
+++ b/gateway/src/apicast/configuration.lua
@@ -140,7 +140,8 @@ end
 
 function _M.filter_services(services, subset)
   local selected_services = {}
-  local service_regexp_filter  = env.value("APICAST_SERVICES_FILTER_BY_URL")
+  local filtered_services = {}
+  local service_regexp_filter = env.value("APICAST_SERVICES_FILTER_BY_URL")
 
   if service_regexp_filter then
     -- Checking that the regexp sent is correct, if not an empty service list
@@ -163,9 +164,20 @@ function _M.filter_services(services, subset)
     if service:match_host(service_regexp_filter) or subset[service.id] then
       insert(selected_services, service)
     else
-      ngx.log(ngx.WARN, 'filtering out service ', service.id)
+      table.insert(filtered_services, service.id)
     end
   end
+
+  -- Log all filtered services in a single log
+  if #filtered_services > 0 then  
+    local filtered_services_str = {}
+    for _, service_id in ipairs(filtered_services) do
+      table.insert(filtered_services_str, tostring(service_id))
+    end
+  
+    ngx.log(ngx.WARN, "filtering out services: " .. table.concat(filtered_services_str, ", "))
+  end
+
   return selected_services
 end
 

--- a/spec/configuration_spec.lua
+++ b/spec/configuration_spec.lua
@@ -2,9 +2,10 @@ local configuration = require 'apicast.configuration'
 local env = require 'resty.env'
 local captured_logs = {}
 
-local function capture_log(level, message)
-  print("Captured log level: ", level, " message: ", message)
-  table.insert(captured_logs, {level = level, message = message})
+local function capture_log(level, ...)
+  local message_parts = {...}  -- Capture all message parts
+  local full_message = table.concat(message_parts, "")  -- Concatenate the parts into a full string
+  table.insert(captured_logs, {level = level, message = full_message})
 end
 
 describe('Configuration object', function()
@@ -156,9 +157,9 @@ describe('Configuration object', function()
         env.set('APICAST_SERVICES_LIST', '42,21')
       
         ngx.log = capture_log
-        local filtered_services = filter_services(mockservices, {"21"})
+        local services_returned = filter_services(mockservices, {"21"})
         
-        assert.same(filtered_services, {mockservices[1], mockservices[3]})
+        assert.same(services_returned, {mockservices[1], mockservices[3]})
 
         -- Inspect the captured logs
         assert.is_not_nil(captured_logs)

--- a/spec/configuration_spec.lua
+++ b/spec/configuration_spec.lua
@@ -1,5 +1,11 @@
 local configuration = require 'apicast.configuration'
 local env = require 'resty.env'
+local captured_logs = {}
+
+local function capture_log(level, message)
+  print("Captured log level: ", level, " message: ", message)
+  table.insert(captured_logs, {level = level, message = message})
+end
 
 describe('Configuration object', function()
 
@@ -126,12 +132,40 @@ describe('Configuration object', function()
     end)
 
     describe("with service filter", function()
+      local original_ngx_log
+
+      before_each(function()
+        -- Save original log
+        original_ngx_log = ngx.log
+      end)
+      
+      after_each(function()
+        -- After each test, restore the log
+        ngx.log = original_ngx_log
+      end)
 
       local mockservices = {
         Service.new({id="42", hosts={"test.foo.com", "test.bar.com"}}),
         Service.new({id="12", hosts={"staging.foo.com"}}),
         Service.new({id="21", hosts={"prod.foo.com"}}),
+        Service.new({id="56", hosts={"staging.foo.com"}})
       }
+
+      it("log service list once for all filtered services", function()
+        env.set('APICAST_SERVICES_FILTER_BY_URL', '^test.*')
+        env.set('APICAST_SERVICES_LIST', '42,21')
+      
+        ngx.log = capture_log
+        local filtered_services = filter_services(mockservices, {"21"})
+        
+        assert.same(filtered_services, {mockservices[1], mockservices[3]})
+
+        -- Inspect the captured logs
+        assert.is_not_nil(captured_logs)
+        for _, log in ipairs(captured_logs) do
+          assert.match("filtering out services: 12, 56", log.message)
+        end
+      end)
 
       it("with empty env variable", function()
         env.set('APICAST_SERVICES_FILTER_BY_URL', '')

--- a/t/configuration-loading-from-service-list.t
+++ b/t/configuration-loading-from-service-list.t
@@ -360,13 +360,12 @@ location /transactions/authrep.xml {
   location ~ / {
      echo 'yay, api backend';
   }
---- pipelined_requests eval
-["GET /?user_key=1"]
---- more_headers eval
-["Host: one"]
---- response_body eval
-["yay, api backend\n"]
---- error_code eval
-[200]
---- error_log eval
-[qr/filtering out services: 11, 33, 999/]
+--- request
+GET /?user_key=1
+--- more_headers
+Host: one
+--- response_body
+yay, api backend
+--- error_code: 200
+--- error_log
+filtering out services: 11, 33, 999

--- a/t/configuration-loading-from-service-list.t
+++ b/t/configuration-loading-from-service-list.t
@@ -301,3 +301,72 @@ location /transactions/authrep.xml {
 ["yay, api backend\n","yay, api backend\n","yay, api backend\n",""]
 --- error_code eval
 [200, 200, 200, 404]
+
+=== TEST 5: multi service configuration limited to specific service log messages
+--- env eval
+("APICAST_SERVICES_LIST", "42")
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": 1,
+      "proxy": {
+        "hosts": [
+          "one"
+        ],
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          {
+            "http_method": "GET",
+            "delta": 1,
+            "metric_system_name": "one",
+            "pattern": "/"
+          }
+        ]
+      },
+      "id": 42
+    },
+    {
+      "proxy": {
+        "hosts": [
+          "one"
+        ]
+      },
+      "id": 11
+    },
+    {
+      "proxy": {
+        "hosts": [
+          "one"
+        ]
+      },
+      "id": 33
+    },
+    {
+      "proxy": {
+        "hosts": [
+          "one"
+        ]
+      },
+      "id": 999
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block { ngx.exit(200) }
+  }
+--- upstream
+  location ~ / {
+     echo 'yay, api backend';
+  }
+--- pipelined_requests eval
+["GET /?user_key=1"]
+--- more_headers eval
+["Host: one"]
+--- response_body eval
+["yay, api backend\n"]
+--- error_code eval
+[200]
+--- error_log eval
+[qr/filtering out services: 11, 33, 999/]


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/THREESCALE-10894

Verification:
- Install 3scale and create ProductA, ProductB, ProductC, ProductD
- Promote products to stage -> prod
- checkout this branch
- start development env:
```
make development
make dependencies
```
- Start APIcast with the following:
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=warn APICAST_WORKER=1 APICAST_SERVICES_LIST=<REPLACE WITH: ID OF ProductA, ID OF ProductB> APICAST_CONFIGURATION_LOADER=boot APICAST_CONFIGURATION_CACHE=60 THREESCALE_PORTAL_ENDPOINT=https://<REPLACE WITH: admin access token>@<REPLACE WITH: 3scale-admin.your_domain> ./bin/apicast
```
When the APIcast boots up, confirm the logs to be:
```
2024/09/05 10:28:03 [warn] 107000#107000: [lua] configuration.lua:171: filter_services(): Filtered out services: 5, 6
2024/09/05 10:28:03 [warn] 107000#107000: [lua] configuration.lua:171: filter_services(): Filtered out services: -1
2024/09/05 10:28:04 [warn] 107025#107025: *2 [lua] configuration.lua:171: filter_services(): Filtered out services: 5, 6, context: ngx.timer
```
Fitelered out services should display your ProductC and ProductD IDs
