### PR TITLE
plain-http-upstream is configured with external 3scale backend

### DIFF
--- a/dev-environments/plain-http-upstream/README.md
+++ b/dev-environments/plain-http-upstream/README.md
@@ -18,10 +18,16 @@ Running custom apicast image
 make gateway IMAGE_NAME=quay.io/3scale/apicast:latest
 ```
 
-Traffic between the proxy and upstream can be inspected looking at logs from `example.com` service
+Traffic between apicast and upstream can be inspected looking at logs from `example.com` service
 
 ```
 docker compose -p plain-http-upstream logs -f example.com
+```
+
+Traffic between apicast and backend can be inspected looking at logs from `backend` service
+
+```
+docker compose -p plain-http-upstream logs -f backend
 ```
 
 ## Testing

--- a/dev-environments/plain-http-upstream/apicast-config.json
+++ b/dev-environments/plain-http-upstream/apicast-config.json
@@ -7,7 +7,7 @@
         "hosts": ["get.example.com"],
         "api_backend": "http://example.com/get",
         "backend": {
-          "endpoint": "http://127.0.0.1:8081",
+          "endpoint": "http://backend:80",
           "host": "backend"
         },
         "policy_chain": [
@@ -34,7 +34,7 @@
         "hosts": ["post.example.com"],
         "api_backend": "http://example.com/post",
         "backend": {
-          "endpoint": "http://127.0.0.1:8081",
+          "endpoint": "http://backend:80",
           "host": "backend"
         },
         "policy_chain": [

--- a/dev-environments/plain-http-upstream/docker-compose.yml
+++ b/dev-environments/plain-http-upstream/docker-compose.yml
@@ -26,11 +26,27 @@ services:
   example.com:
     image: alpine/socat:1.7.4.4
     container_name: example.com
-    command: "-d -v -d TCP-LISTEN:80,reuseaddr,fork TCP:two.upstream:80"
+    command: "-d -d -v -d TCP-LISTEN:80,reuseaddr,fork TCP:two.upstream:3000"
     expose:
       - "80"
     restart: unless-stopped
   two.upstream:
-    image: kennethreitz/httpbin
+    image: quay.io/3scale/authorino:echo-api
+    environment:
+      PORT: 3000
+    expose:
+      - "3000"
+  backend:
+    image: alpine/socat:1.7.4.4
+    container_name: backend
+    command: "-d -d -v -d TCP-LISTEN:80,reuseaddr,fork TCP:3scale.backend:3000"
     expose:
       - "80"
+    restart: unless-stopped
+  3scale.backend:
+    image: quay.io/3scale/authorino:echo-api
+    container_name: 3scale.backend
+    environment:
+      PORT: 3000
+    expose:
+      - "3000"


### PR DESCRIPTION
### What

plain-http-upstream is configured with external 3scale backend. Useful to inspect traffic (and connection setup/teardown) between apicast and backend.

