### PR TITLE
[THREESCALE-5105] Adding support for mtls when using proxy policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed Conditional policy evaluating incorrectly: second policy in policy chain that implement export() always triggers [PR #1485](https://github.com/3scale/APIcast/pull/1485) [THREESCALE-9320](https://issues.redhat.com/browse/THREESCALE-9320)
 - Fix APIcast using stale configuration for deleted products [PR #1488](https://github.com/3scale/APIcast/pull/1488) [THREESCALE-10130](https://issues.redhat.com/browse/THREESCALE-10130)
+- Fixed Mutual TLS between APIcast and the Backend API fails when using a Forward Proxy [PR #1499](https://github.com/3scale/APIcast/pull/1499) [THREESCALE-5105](https://issues.redhat.com/browse/THREESCALE-5105)
 
 ### Added
 

--- a/gateway/src/apicast/http_proxy.lua
+++ b/gateway/src/apicast/http_proxy.lua
@@ -143,9 +143,7 @@ local function forward_https_request(proxy_uri, uri, proxy_opts)
         path = format('%s%s%s', ngx.var.uri, ngx.var.is_args, ngx.var.query_string or ''),
         body = body,
         proxy_uri = proxy_uri,
-        proxy_auth = opts.proxy_auth,
-        upstream_connection_opts = opts.upstream_connection_opts,
-        skip_https_connect = opts.skip_https_connect
+        proxy_options = opts
     }
 
     local httpc, err = http_proxy.new(request)
@@ -226,7 +224,8 @@ function _M.request(upstream, proxy_uri)
             proxy_auth = proxy_auth,
             skip_https_connect = upstream.skip_https_connect,
             request_unbuffered = upstream.request_unbuffered,
-            upstream_connection_opts = upstream.upstream_connection_opts
+            upstream_connection_opts = upstream.upstream_connection_opts,
+            upstream_ssl = upstream.upstream_ssl
         }
 
         forward_https_request(proxy_uri, uri, proxy_opts)

--- a/gateway/src/apicast/policy/upstream_mtls/Readme.md
+++ b/gateway/src/apicast/policy/upstream_mtls/Readme.md
@@ -42,3 +42,5 @@ When using http forms and file upload
 This policy overwrites `APICAST_PROXY_HTTPS_CERTIFICATE_KEY` and
 `APICAST_PROXY_HTTPS_CERTIFICATE` values and it uses the certificates set by
 the policy, so those environment variables will have no effect.
+
+This policy is not compatible with Camel proxy.

--- a/gateway/src/apicast/policy/upstream_mtls/upstream_mtls.lua
+++ b/gateway/src/apicast/policy/upstream_mtls/upstream_mtls.lua
@@ -1,27 +1,14 @@
 -- This policy enables MTLS with the upstream API endpoint
 
 local ssl = require('ngx.ssl')
-local ffi = require "ffi"
-local base = require "resty.core.base"
 local data_url = require('resty.data_url')
 local util = require 'apicast.util'
+local tls = require 'resty.tls'
 
-local C = ffi.C
-local get_request = base.get_request
 local pairs = pairs
 
 local X509_STORE = require('resty.openssl.x509.store')
 local X509 = require('resty.openssl.x509')
-
-ffi.cdef([[
-  int ngx_http_apicast_ffi_set_proxy_cert_key(
-    ngx_http_request_t *r, void *cdata_chain, void *cdata_key);
-  int ngx_http_apicast_ffi_set_proxy_ca_cert(
-    ngx_http_request_t *r, void *cdata_ca);
-  int ngx_http_apicast_ffi_set_ssl_verify(
-    ngx_http_request_t *r, int verify, int verify_deph);
-]])
-
 
 local policy = require('apicast.policy')
 local _M = policy.new('mtls', "builtin")
@@ -104,46 +91,21 @@ function _M.new(config)
   return self
 end
 
-
--- Set the certs for the upstream connection. Need to receive the pointers from
--- parse_* functions.
---- Public function to be able to unittest this.
-function _M.set_certs(r, cert, key)
-  local val = C.ngx_http_apicast_ffi_set_proxy_cert_key(r, cert, key)
-  if val ~= ngx.OK then
-    ngx.log(ngx.ERR, "Certificate cannot be set correctly")
-  end
-end
-
-function _M.set_ca_cert(r, store)
-  local val = C.ngx_http_apicast_ffi_set_proxy_ca_cert(r, store)
-  if val ~= ngx.OK then
-    ngx.log(ngx.WARN, "Cannot set a valid trusted CA store")
-    return
-  end
-end
-
 -- All of this happens on balancer because this is subrequest inside APICAst
 --to @upstream, so the request need to be the one that connects to the
 --upstream0
 function _M:balancer(context)
-  local r = get_request()
-  if not r then
-    ngx.log(ngx.WARN, "Invalid request")
-    return
-  end
-
   if self.cert and self.cert_key then
-    self.set_certs(r, self.cert, self.cert_key)
+    self.set_certs(self.cert, self.cert_key)
   end
 
   if not self.verify then
     return
   end
 
-  local val = C.ngx_http_apicast_ffi_set_ssl_verify(r, ffi.new("int", 1), ffi.new("int", 1))
-  if val ~= ngx.OK then
-    ngx.log(ngx.WARN, "Cannot verify SSL upstream connection")
+  local ok, err = tls.set_upstream_ssl_verify(true, 1)
+  if ok ~= nil then
+    ngx.log(ngx.WARN, "Cannot verify SSL upstream connection, err: ", err)
   end
 
   if not self.ca_store then
@@ -151,7 +113,7 @@ function _M:balancer(context)
     return
   end
 
-  self.set_ca_cert(r, self.ca_store)
+  self.set_ca_cert(self.ca_store)
 end
 
 return _M

--- a/gateway/src/apicast/upstream.lua
+++ b/gateway/src/apicast/upstream.lua
@@ -233,6 +233,11 @@ function _M:call(context)
 
         self.request_unbuffered = context.request_unbuffered
         self.upstream_connection_opts = context.upstream_connection_opts
+        self.upstream_ssl = {
+          ssl_verify = context.upstream_verify,
+          ssl_client_cert = context.upstream_certificate,
+          ssl_client_priv_key = context.upstream_key
+        }
         http_proxy.request(self, proxy_uri)
     else
         local err = self:rewrite_request()

--- a/gateway/src/resty/tls.lua
+++ b/gateway/src/resty/tls.lua
@@ -1,0 +1,91 @@
+local base = require "resty.core.base"
+
+local type = type
+local tostring = tostring
+
+local get_request = base.get_request
+local ffi = require "ffi"
+local C = ffi.C
+
+local _M = {}
+
+local NGX_OK = ngx.OK
+
+local ngx_http_apicast_ffi_set_proxy_cert_key;
+local ngx_http_apicast_ffi_set_proxy_ca_cert;
+local ngx_http_apicast_ffi_set_ssl_verify
+
+ffi.cdef([[
+  int ngx_http_apicast_ffi_set_proxy_cert_key(
+    ngx_http_request_t *r, void *cdata_chain, void *cdata_key);
+  int ngx_http_apicast_ffi_set_proxy_ca_cert(
+    ngx_http_request_t *r, void *cdata_ca);
+  int ngx_http_apicast_ffi_set_ssl_verify(
+    ngx_http_request_t *r, int verify, int verify_deph);
+]])
+
+ngx_http_apicast_ffi_set_proxy_cert_key = C.ngx_http_apicast_ffi_set_proxy_cert_key
+ngx_http_apicast_ffi_set_proxy_ca_cert = C.ngx_http_apicast_ffi_set_proxy_ca_cert
+ngx_http_apicast_ffi_set_ssl_verify = C.ngx_http_apicast_ffi_set_ssl_verify
+
+-- Set the certs for the upstream connection. Need to receive the pointers from
+-- parse_* functions.
+function _M.set_upstream_cert_and_key(cert, key)
+  local r = get_request()
+  if not r then
+      error("no request found")
+  end
+
+  if not cert or not key then
+    return nil, "cert and key must not be nil"
+  end
+
+  local ret = ngx_http_apicast_ffi_set_proxy_cert_key(r, cert, key)
+  if ret ~= NGX_OK then
+    return nil, "error while setting upstream client certificate and key"
+  end
+end
+
+-- Set the trusted store for the upstream connection.
+function _M.set_upstream_ca_cert(store)
+  local r = get_request()
+  if not r then
+      error("no request found")
+  end
+
+  if not store then
+    return nil, "trusted store must not be nil"
+  end
+
+  local ret = ngx_http_apicast_ffi_set_proxy_ca_cert(r, store)
+  if ret ~= NGX_OK then
+    return nil, "error while setting upstream trusted CA store"
+  end
+end
+
+-- Verify upstream connection
+function _M.set_upstream_ssl_verify(verify, verify_deph)
+  local r = get_request()
+  if not r then
+      error("no request found")
+  end
+
+  if type(verify) ~= 'boolean' then
+    return nil, "verify expects a boolean but found " .. type(verify)
+  end
+
+  if type(verify_deph) ~= 'number' then
+    return nil, "verify depth expects a number but found " .. type(verify)
+  end
+
+  if verify_deph < 0 then
+    return nil, "verify_deph expects a non-negative interger but found" .. tostring(verify_deph)
+  end
+
+  local val = ngx_http_apicast_ffi_set_ssl_verify(r, verify, verify_deph)
+  if val ~= NGX_OK then
+    return nil, "error while setting upstream verify"
+  end
+end
+
+return _M

--- a/spec/policy/upstream_mtls/upstream_mtls_spec.lua
+++ b/spec/policy/upstream_mtls/upstream_mtls_spec.lua
@@ -1,21 +1,13 @@
 local upstream_mtls = require("apicast.policy.upstream_mtls")
 local ssl = require('ngx.ssl')
-local open = io.open
-
-local function read_file(path)
-    local file = open(path, "rb")
-    if not file then return nil end
-    local content = file:read "*a" -- *a or *all reads the whole file
-    file:close()
-    return content
-end
+local util = require("apicast.util")
 
 describe('Upstream MTLS policy', function()
 
   local certificate_path = 't/fixtures/CA/root-ca.crt'
   local certificate_key_path = 't/fixtures/CA/root-ca.key'
 
-  local certificate_content = read_file(certificate_path)
+  local certificate_content = util.read_file(certificate_path)
   -- Set here the const to not use the pakcage ones, if not test will not fail
   -- if changes0
   local path_type = "path"
@@ -43,9 +35,10 @@ describe('Upstream MTLS policy', function()
       assert.truthy(object.cert)
       assert.truthy(object.cert_key)
 
-      spy.on(object, "set_certs")
-      object:balancer(context)
-      assert.spy(object.set_certs).was.called()
+      local context = {}
+      object:access(context)
+      assert.truthy(context.upstream_certificate)
+      assert.truthy(context.upstream_key)
     end)
 
 
@@ -62,9 +55,10 @@ describe('Upstream MTLS policy', function()
       assert.is_falsy(object.cert)
       assert.is_falsy(object.cert_key)
 
-      spy.on(object, "set_certs")
-      object:balancer(context)
-      assert.spy(object.set_certs).was_not_called()
+      local context = {}
+      object:access(context)
+      assert.is_falsy(context.upstream_certificate)
+      assert.is_falsy(context.upstream_key)
     end)
   end)
 
@@ -86,9 +80,10 @@ describe('Upstream MTLS policy', function()
       assert.truthy(object.cert)
       assert.truthy(object.cert_key)
 
-      spy.on(object, "set_certs")
-      object:balancer(context)
-      assert.spy(object.set_certs).was.called()
+      local context = {}
+      object:access(context)
+      assert.truthy(context.upstream_certificate)
+      assert.truthy(context.upstream_key)
     end)
 
     it("Nil certificate", function()
@@ -103,10 +98,10 @@ describe('Upstream MTLS policy', function()
       assert.spy(ssl.parse_pem_priv_key).was_not_called()
       assert.falsy(object.cert)
       assert.falsy(object.cert_key)
-
-      spy.on(object, "set_certs")
-      object:balancer(context)
-      assert.spy(object.set_certs).was_not_called()
+      local context = {}
+      object:access(context)
+      assert.is_falsy(context.upstream_certificate)
+      assert.is_falsy(context.upstream_key)
     end)
 
     it("Invalid certificate", function()
@@ -122,9 +117,10 @@ describe('Upstream MTLS policy', function()
       assert.falsy(object.cert)
       assert.falsy(object.cert_key)
 
-      spy.on(object, "set_certs")
-      object:balancer(context)
-      assert.spy(object.set_certs).was_not_called()
+      local context = {}
+      object:access(context)
+      assert.is_falsy(context.upstream_certificate)
+      assert.is_falsy(context.upstream_key)
     end)
 
   end)
@@ -159,30 +155,6 @@ describe('Upstream MTLS policy', function()
       config.ca_certificates = { certificate_content}
       local object = upstream_mtls.new(config)
       assert.same(type(object.ca_store), "cdata")
-    end)
-
-    it("CA certificate is not used if verify is not enabled", function()
-      config.ca_certificates = { certificate_content}
-      config.verify = false
-
-      local object = upstream_mtls.new(config)
-      assert.same(type(object.ca_store), "cdata")
-
-      spy.on(object, "set_ca_cert")
-      object:balancer({})
-      assert.spy(object.set_ca_cert).was_not.called()
-    end)
-
-    it("CA certificate is used if verify is enabled", function()
-      config.ca_certificates = { certificate_content}
-      config.verify = true
-
-      local object = upstream_mtls.new(config)
-      assert.same(type(object.ca_store), "cdata")
-
-      spy.on(object, "set_ca_cert")
-      object:balancer({})
-      assert.spy(object.set_ca_cert).was.called()
     end)
   end)
 end)


### PR DESCRIPTION
## What
Fix https://issues.redhat.com/browse/THREESCALE-5105

## NOTE
Please ignore codecov report. I will move tls.lua to apicast-nginx-module in the future commit.

## Verification steps:
* Build runtime image
```
make runtime-image IMAGE_NAME=apicast-test
```
* Get into the dev-environments
```
cd dev-environments/https-proxy-upstream-tlsv1.3
```
* Update `apicast-config.json` file as follow
```diff
diff --git a/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json b/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json 
index 5227c5aa..09fb1ab9 100644                                                                                                                    
--- a/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json                                                                            
+++ b/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json                                                                            
@@ -11,6 +11,15 @@                                                                                                                                 
           "host": "backend"                                                                                                                       
         },                                                                                                                                        
         "policy_chain": [                                                                                                                         
+          {                                                                                                                                       
+            "name": "apicast.policy.upstream_mtls",                                                                                               
+            "configuration": {                                                                                                                    
+                "certificate": "/tmp/example.com.crt",                                                                                            
+                "certificate_type": "path",                                                                                                       
+                "certificate_key": "/tmp/example.com.key",                                                                                        
+                "certificate_key_type": "path"                                                                                                    
+            }                                                                                                                                     
+          },                                                                                                                                      
           {                                                                                                                                       
             "name": "apicast.policy.http_proxy",                                                                                                  
             "configuration": {                                                                                                                    
```
* Update docker-compose file as follow
```diff
diff --git a/dev-environments/https-proxy-upstream-tlsv1.3/docker-compose.yml b/dev-environments/https-proxy-upstream-tlsv1.3/docker-compose.yml
index af418aca..b5b42341 100644
--- a/dev-environments/https-proxy-upstream-tlsv1.3/docker-compose.yml
+++ b/dev-environments/https-proxy-upstream-tlsv1.3/docker-compose.yml
@@ -24,6 +24,9 @@ services:
       - "8090:8090"
     volumes:
       - ./apicast-config.json:/tmp/config.json
+      - ./cert/example.com.crt:/tmp/example.com.crt
+      - ./cert/example.com.key:/tmp/example.com.key
+      - ./cert/rootCA.pem:/tmp/rootCA.pem
   proxy:
     build:
       dockerfile: ./tinyproxy.Dockerfile
@@ -35,12 +38,13 @@ services:
   example.com:
     image: alpine/socat:1.7.4.4
     container_name: example.com
-    command: "-v openssl-listen:443,reuseaddr,fork,cert=/etc/pki/example.com.pem,verify=0,openssl-min-proto-version=TLS1.3,openssl-max-proto-version=TLS1.3 TCP:two.upstream:80"
+    command: "-v openssl-listen:443,reuseaddr,fork,cert=/etc/pki/example.com.pem,cafile=/etc/pki/rootCA.pem,verify=1,openssl-min-proto-version=TLS1.3,openssl-max-proto-version=TLS1.3 TCP:two.upstream:80"
     expose:
       - "443"
     restart: unless-stopped
     volumes:
       - ./cert/example.com.pem:/etc/pki/example.com.pem
+      - ./cert/rootCA.pem:/etc/pki/rootCA.pem
   two.upstream:
     image: kennethreitz/httpbin
     expose:
```
* Start APIcast gateway
```
make certs
make gateway IMAGE_NAME=apicast-test
```
* Send a request to APIcast
```
curl --resolve get.example.com:8080:127.0.0.1 -v "http://get.example.com:8080/?user_key=123"

...
< HTTP/1.1 200 OK                        
< Content-Type: application/json         
< Transfer-Encoding: chunked             
< Connection: keep-alive                 
< Server: gunicorn/19.9.0                
< Access-Control-Allow-Credentials: true 
< Access-Control-Allow-Origin: *         
```