### PR TITLE
[THREESCALE-11435] Check for nil value when decode based64 value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix APIcast using stale configuration for deleted products [PR #1488](https://github.com/3scale/APIcast/pull/1488) [THREESCALE-10130](https://issues.redhat.com/browse/THREESCALE-10130)
 - Fixed Mutual TLS between APIcast and the Backend API fails when using a Forward Proxy [PR #1499](https://github.com/3scale/APIcast/pull/1499) [THREESCALE-5105](https://issues.redhat.com/browse/THREESCALE-5105)
 - Fixed dns cache miss [PR #1500](https://github.com/3scale/APIcast/pull/1500) [THEESCALE-9301](https://issues.redhat.com/browse/THREESCALE-9301)
+- Fixed APIcast panic when parsing invalid base64 encoded value [PR #1505](https://github.com/3scale/APIcast/pull/1505) [THEESCALE-11435](https://issues.redhat.com/browse/THREESCALE-11435)
 
 ### Added
 

--- a/gateway/src/resty/http_authorization.lua
+++ b/gateway/src/resty/http_authorization.lua
@@ -9,8 +9,11 @@ local _M = {
 local mt = { __index = _M }
 
 function _M.parsers.Basic(param)
+  local userid, password
   local user_pass = ngx.decode_base64(param)
-  local userid, password = match(user_pass, '^(.*):(.*)$')
+  if user_pass then
+    userid, password = match(user_pass, '^(.*):(.*)$')
+  end
 
   return {
     userid = userid,

--- a/spec/resty/http_authorization_spec.lua
+++ b/spec/resty/http_authorization_spec.lua
@@ -60,6 +60,13 @@ describe('HTTP Authorization', function()
         assert.equal('', auth.userid)
         assert.equal('pass', auth.password)
       end)
+
+      it('do not panic with invalid header', function()
+        local auth = authorization.new('Basic !123!')
+
+        assert.equal(nil, auth.userid)
+        assert.equal(nil, auth.password)
+      end)
     end)
 
     describe('Bearer', function()

--- a/t/apicast.t
+++ b/t/apicast.t
@@ -786,3 +786,527 @@ Authentication failed
 --- no_error_log
 [error]
 
+
+
+=== TEST 24: with user_key in header
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": "1",
+      "id": 42,
+      "proxy": {
+        "credentials_location": "headers",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- more_headers
+user_key: value
+--- request
+GET /
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+
+
+=== TEST 25: with invalid user_key in header
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": "1",
+      "id": 42,
+      "proxy": {
+        "credentials_location": "headers",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- more_headers
+user_key: !123!
+--- request
+GET /
+--- response_body chomp
+Authentication failed
+--- error_code: 403
+
+
+
+=== TEST 26: with user_key in query parameters
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": "1",
+      "id": 42,
+      "proxy": {
+        "credentials_location": "query",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /?user_key=value
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+
+
+=== TEST 27: with invalid user_key in query parameters
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": "1",
+      "id": 42,
+      "proxy": {
+        "credentials_location": "query",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /?user_key=
+--- response_body chomp
+Authentication failed
+--- error_code: 403
+
+
+
+=== TEST 28: with user_key in Basic Authorization header
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": "1",
+      "id": 42,
+      "proxy": {
+        "credentials_location": "authorization",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- more_headers
+Authorization: Basic dmFsdWU6Cg==
+--- request
+GET /
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+
+
+=== TEST 29: with invalid user_key in Basic Authorization header
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": "1",
+      "id": 42,
+      "proxy": {
+        "credentials_location": "query",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- more_headers
+Authorization: Basic !123!
+--- request
+GET /
+--- response_body chomp
+Authentication parameters missing
+--- error_code: 401
+
+
+
+=== TEST 30: with app_id and app_key in header
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": "2",
+      "id": 42,
+      "proxy": {
+        "credentials_location": "headers",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_id=42&usage%5Bhits%5D=2&app_id=foo&app_key=bar"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- more_headers
+app_id: foo
+app_key: bar
+--- request
+GET /
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+
+
+=== TEST 31: with invalid app_key and app_id in header
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": "2",
+      "id": 42,
+      "proxy": {
+        "credentials_location": "headers",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_id=42&usage%5Bhits%5D=2&app_id=foo&app_key=bar"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- more_headers
+app_id: foo
+app_key: !123!
+--- request
+GET /
+--- response_body chomp
+Authentication failed
+--- error_code: 403
+
+
+
+=== TEST 32: with app_key and app_id in query parameters
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": "2",
+      "id": 42,
+      "proxy": {
+        "credentials_location": "query",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_id=42&usage%5Bhits%5D=2&app_id=foo&app_key=bar"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /?app_id=foo&app_key=bar
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+
+
+=== TEST 33: with invalid app_id and app_key in query parameters
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": "2",
+      "id": 42,
+      "proxy": {
+        "credentials_location": "query",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_id=42&usage%5Bhits%5D=2&app_id=foo&app_key=bar"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- request
+GET /?app_id=foo&app_key=!123!
+--- response_body chomp
+Authentication failed
+--- error_code: 403
+
+
+
+=== TEST 34: with app_id and app_key in Basic Authorization header
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": "2",
+      "id": 42,
+      "proxy": {
+        "credentials_location": "authorization",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_id=42&usage%5Bhits%5D=2&app_id=foo&app_key=bar"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- more_headers
+Authorization: Basic Zm9vOmJhcg==
+--- request
+GET /
+--- response_body
+yay, api backend
+--- error_code: 200
+--- no_error_log
+[error]
+
+
+
+=== TEST 35: with invalid app_key/app_id in Basic Authorization header
+--- configuration
+{
+  "services": [
+    {
+      "backend_version": "1",
+      "id": 42,
+      "proxy": {
+        "credentials_location": "query",
+        "api_backend": "http://test:$TEST_NGINX_SERVER_PORT/",
+        "proxy_rules": [
+          { "pattern": "/", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
+        ],
+        "policy_chain": [
+          { "name": "apicast.policy.apicast" }
+        ]
+      }
+    }
+  ]
+}
+--- backend
+  location /transactions/authrep.xml {
+    content_by_lua_block {
+      local expected = "service_id=42&usage%5Bhits%5D=2&user_key=value"
+      require('luassert').same(ngx.decode_args(expected), ngx.req.get_uri_args(0))
+    }
+  }
+--- upstream
+  location / {
+     content_by_lua_block {
+       ngx.say('yay, api backend');
+     }
+  }
+--- more_headers
+Authorization: Basic !123!
+--- request
+GET /
+--- response_body chomp
+Authentication parameters missing
+--- error_code: 401
+
+
+


### PR DESCRIPTION
## What

Fix [THREESCALE-11435](https://issues.redhat.com/browse/THREESCALE-11435)

## Verification steps:
* Checkout this branch
* Create apicast-config.json with the following
```
cat <<EOF >apicast-config.json
{
  "services": [
    {
      "backend_version": "2",
      "id": "1",
      "proxy": {
        "credentials_location": "authorization",
        "hosts": [
          "one"
        ],
        "api_backend": "https://echo-api.3scale.net:443",
        "backend": {
          "endpoint": "http://localhost:8081",
          "host": "backend"                   
        },
        "policy_chain": [
          {
            "name": "routing",
            "version": "builtin",
            "enabled": true,
            "configuration": {
              "rules": [
                {
                  "url": "https://echo-api.3scale.net:443",
                  "owner_id": 119084,
                  "owner_type": "BackendApi",
                  "condition": {
                      "operations": [
                          {
                              "match": "path",
                              "op": "matches",
                              "value": "^(/test/.*|/test/?)"
                          }
                      ]
                  },
                  "replace_path": "{{uri | remove_first: '/test'}}"
                }
              ]
            }
          },
          {
            "name": "apicast.policy.apicast"
          }
        ],
        "proxy_rules": [
          {
            "http_method": "GET",
            "pattern": "/test",
            "metric_system_name": "hits",
            "delta": 1,
            "parameters": [],
            "querystring_parameters": {}
          }
        ]
      }
    }
  ]
}
EOF
```
* Start development env
```
make development
```
* Start APIcast
```
THREESCALE_DEPLOYMENT_ENV=staging APICAST_LOG_LEVEL=debug APICAST_WORKER=1 APICAST_CONFIGURATION_LOADER=lazy APICAST_CONFIGURATION_CACHE=0  THREESCALE_CONFIG_FILE=apicast-config.json  ./bin/apicast
```
* Capture APIcast IP
```
APICAST_IP=$(docker inspect apicast_build_0-development-1 | yq e -P '.[0].NetworkSettings.Networks.apicast_build_0_default.IPAddress' -)
```
* Send request
```
curl -i -k -H "Host: one" -H "Accept: application/json" "http://${APICAST_IP}:8080/?user_key="
```
* You should get 401 response back
```
HTTP/1.1 401 Unauthorized              
Server: openresty                      
Date: Wed, 06 Nov 2024 03:25:13 GMT    
Content-Type: text/plain; charset=utf-8
Transfer-Encoding: chunked             
Connection: keep-alive                 
                                       
Authentication parameters missing%
```