### PR TITLE
Move base image to registry and remove docker hub images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ executors:
   docker:
     working_directory: /opt/app-root/apicast
     docker:
-    - image: docker:23.0.2-cli-alpine3.17
+    - image: mirror.gcr.io/library/docker:23.0.2-cli-alpine3.17
     environment:
       COMPOSE_TLS_VERSION: "TLSv1_2"
 
@@ -106,7 +106,7 @@ executors:
     working_directory: /opt/app-root/apicast
     docker:
       - image: quay.io/3scale/apicast-ci:openresty-1.21.4-1
-      - image: redis:3.2.8-alpine
+      - image: mirror.gcr.io/library/redis
     environment:
       TEST_NGINX_BINARY: openresty
       LUA_BIN_PATH: /opt/app-root/bin

--- a/dev-environments/camel-proxy/Makefile
+++ b/dev-environments/camel-proxy/Makefile
@@ -24,12 +24,12 @@ $(WORKDIR)/cert/keystore.jks: ## use same JVM version as camel-netty-proxy, curr
 	$(DOCKER) run -t --rm \
 		-v $(WORKDIR)/cert:/tmp/cert \
 		--user $(USER):$(GROUP) \
-		openjdk:11.0.9 \
+		registry.access.redhat.com/ubi8/openjdk-11:1.21-1.1733300800 \
 		keytool -genkeypair -keystore /tmp/cert/keystore.jks -dname "CN=tls.camel.proxy" -keypass changeit -storepass changeit -alias camel -keyalg RSA -ext SAN=dns:tls.camel.proxy
 	$(DOCKER) run -t --rm \
 		-v $(WORKDIR)/cert:/tmp/cert \
 		--user $(USER):$(GROUP) \
-		openjdk:11.0.9 \
+		registry.access.redhat.com/ubi8/openjdk-11:1.21-1.1733300800 \
 		keytool -list -v -keystore /tmp/cert/keystore.jks -storepass changeit
 
 .PHONY: certs

--- a/dev-environments/camel-proxy/docker-compose.yml
+++ b/dev-environments/camel-proxy/docker-compose.yml
@@ -27,12 +27,12 @@ services:
     volumes:
       - ./apicast-config.json:/tmp/config.json
   proxy.socat:
-    image: alpine/socat:1.7.4.4
+    image: quay.io/openshift-logging/alpine-socat:1.8.0.0
     container_name: proxy
     restart: unless-stopped
     command: "-d -v -d TCP-LISTEN:8080,reuseaddr,fork TCP:camel.proxy:8080"
   camel.proxy:
-    image: zregvart/camel-netty-proxy
+    image: quay.io/zregvart/camel-netty-proxy
     container_name: camel.proxy
     expose:
       - "8080:8080"
@@ -50,14 +50,14 @@ services:
     volumes:
       - ./cert/keystore.jks:/tls/keystore.jks
   example.com:
-    image: alpine/socat:1.7.4.4
+    image: quay.io/openshift-logging/alpine-socat:1.8.0.0
     container_name: example.com
-    command: "-d -v -d TCP-LISTEN:80,reuseaddr,fork TCP:actual.upstream:80"
+    command: "-d -v -d TCP-LISTEN:80,reuseaddr,fork TCP:actual.upstream:8080"
     expose:
       - "443"
     restart: unless-stopped
   actual.upstream:
-    image: kennethreitz/httpbin
+    image: quay.io/kuadrant/authorino-examples:talker-api
     container_name: actual.upstream
     expose:
-      - "80"
+      - "8080"

--- a/dev-environments/grpc/docker-compose.yml
+++ b/dev-environments/grpc/docker-compose.yml
@@ -37,6 +37,8 @@ services:
     volumes:
       - ./upstream-cert/upstream.example.com.pem:/etc/pki/upstream.example.com.pem
   two.upstream:
-    image: kalmhq/echoserver
+    container_name: two.upstream
+    build:
+      dockerfile: ./echoserver.Dockerfile
     expose:
       - "8005"

--- a/dev-environments/grpc/docker-compose.yml
+++ b/dev-environments/grpc/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - ./apicast-config.json:/tmp/config.json
       - ./gateway-cert:/var/run/secrets/apicast
   one.upstream:
-    image: alpine/socat:1.7.4.4
+    image: quay.io/openshift-logging/alpine-socat:1.8.0.0
     container_name: one.upstream
     command: "-v openssl-listen:443,reuseaddr,fork,cert=/etc/pki/upstream.example.com.pem,verify=0,openssl-max-proto-version=TLS1.3 ssl:two.upstream:8005,verify=0"
     expose:

--- a/dev-environments/grpc/echoserver.Dockerfile
+++ b/dev-environments/grpc/echoserver.Dockerfile
@@ -1,0 +1,23 @@
+FROM registry.access.redhat.com/ubi8/go-toolset:1.13.4 as builder
+
+WORKDIR /workspace
+
+RUN cd /tmp \
+    && curl -fSL https://github.com/kalmhq/echoserver/archive/refs/tags/v0.1.1.tar.gz -o echoserver-v0.1.1.tar.gz \
+    && tar xzf echoserver-v0.1.1.tar.gz \
+    && cd echoserver-0.1.1 \
+    && go mod download \
+    && GOOS=linux GOARCH=amd64 go build -ldflags "-s -w" -o server . \
+    && cp server /workspace \
+    && cp default.key /workspace \
+    && cp default.pem /workspace
+
+FROM mirror.gcr.io/library/alpine
+RUN apk update && apk add --no-cache curl
+WORKDIR /workspace
+# Collect binaries and assets
+RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+COPY --from=builder /workspace/server .
+COPY --from=builder /workspace/default.key .
+COPY --from=builder /workspace/default.pem .
+CMD /workspace/server

--- a/dev-environments/http-proxy-plain-http-upstream/docker-compose.yml
+++ b/dev-environments/http-proxy-plain-http-upstream/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     volumes:
       - ./apicast-config.json:/tmp/config.json
   proxy:
-    image: alpine/socat:1.7.4.4
+    image: quay.io/openshift-logging/alpine-socat:1.8.0.0
     container_name: proxy
     command: "-d -v -d TCP-LISTEN:8080,reuseaddr,fork TCP:actual.proxy:443"
     expose:
@@ -42,13 +42,13 @@ services:
     volumes:
       - ./tinyproxy.conf:/etc/tinyproxy/tinyproxy.conf
   example.com:
-    image: alpine/socat:1.7.4.4
+    image: quay.io/openshift-logging/alpine-socat:1.8.0.0
     container_name: example.com
-    command: "-d -v -d TCP-LISTEN:80,reuseaddr,fork TCP:two.upstream:80"
+    command: "-d -v -d TCP-LISTEN:80,reuseaddr,fork TCP:two.upstream:8080"
     expose:
       - "443"
     restart: unless-stopped
   two.upstream:
-    image: kennethreitz/httpbin
+    image: quay.io/kuadrant/authorino-examples:talker-api
     expose:
-      - "80"
+      - "8080"

--- a/dev-environments/http-proxy-plain-http-upstream/tinyproxy.Dockerfile
+++ b/dev-environments/http-proxy-plain-http-upstream/tinyproxy.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM mirror.gcr.io/library/alpine:3
 
 LABEL summary="Forward proxy based on tinyproxy for development purposes" \
       description="Forward proxy based on tinyproxy for development purposes" \

--- a/dev-environments/https-proxy-upstream-tlsv1.3/docker-compose.yml
+++ b/dev-environments/https-proxy-upstream-tlsv1.3/docker-compose.yml
@@ -33,15 +33,15 @@ services:
     volumes:
       - ./tinyproxy.conf:/etc/tinyproxy/tinyproxy.conf
   example.com:
-    image: alpine/socat:1.7.4.4
+    image: quay.io/openshift-logging/alpine-socat:1.8.0.0
     container_name: example.com
-    command: "-v openssl-listen:443,reuseaddr,fork,cert=/etc/pki/example.com.pem,verify=0,openssl-min-proto-version=TLS1.3,openssl-max-proto-version=TLS1.3 TCP:two.upstream:80"
+    command: "-v openssl-listen:443,reuseaddr,fork,cert=/etc/pki/example.com.pem,verify=0,openssl-min-proto-version=TLS1.3,openssl-max-proto-version=TLS1.3 TCP:two.upstream:8080"
     expose:
       - "443"
     restart: unless-stopped
     volumes:
       - ./cert/example.com.pem:/etc/pki/example.com.pem
   two.upstream:
-    image: kennethreitz/httpbin
+    image: quay.io/kuadrant/authorino-examples:talker-api
     expose:
-      - "80"
+      - "8080"

--- a/dev-environments/https-proxy-upstream-tlsv1.3/tinyproxy.Dockerfile
+++ b/dev-environments/https-proxy-upstream-tlsv1.3/tinyproxy.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM mirror.gcr.io/library/alpine:3
 
 LABEL summary="Forward proxy based on tinyproxy for development purposes" \
       description="Forward proxy based on tinyproxy for development purposes" \

--- a/dev-environments/keycloak-env/docker-compose.yml
+++ b/dev-environments/keycloak-env/docker-compose.yml
@@ -25,16 +25,16 @@ services:
     volumes:
       - ./apicast-config.json:/tmp/config.json
   example.com:
-    image: alpine/socat:1.7.4.4
+    image: quay.io/openshift-logging/alpine-socat:1.8.0.0
     container_name: example.com
-    command: "-d -v -d TCP-LISTEN:80,reuseaddr,fork TCP:two.upstream:80"
+    command: "-d -v -d TCP-LISTEN:80,reuseaddr,fork TCP:two.upstream:8080"
     expose:
       - "80"
     restart: unless-stopped
   two.upstream:
-    image: kennethreitz/httpbin
+    image: quay.io/kuadrant/authorino-examples:talker-api
     expose:
-      - "80"
+      - "8080"
   keycloak:
     image: quay.io/keycloak/keycloak:23.0.4
     container_name: keycloak

--- a/dev-environments/listen-tls/docker-compose.yml
+++ b/dev-environments/listen-tls/docker-compose.yml
@@ -28,13 +28,13 @@ services:
       - ./apicast-config.json:/tmp/config.json
       - ./cert:/var/run/secrets/apicast
   one.upstream:
-    image: alpine/socat:1.7.4.4
+    image: quay.io/openshift-logging/alpine-socat:1.8.0.0
     container_name: one.upstream
-    command: "-d -v -d TCP-LISTEN:80,reuseaddr,fork TCP:two.upstream:80"
+    command: "-d -v -d TCP-LISTEN:80,reuseaddr,fork TCP:two.upstream:8080"
     expose:
       - "80"
     restart: unless-stopped
   two.upstream:
-    image: kennethreitz/httpbin
+    image: quay.io/kuadrant/authorino-examples:talker-api
     expose:
-      - "80"
+      - "8080"

--- a/dev-environments/opentelemetry-instrumented-gateway/docker-compose.yml
+++ b/dev-environments/opentelemetry-instrumented-gateway/docker-compose.yml
@@ -28,18 +28,18 @@ services:
       - ./apicast-config.json:/tmp/config.json
       - ./otel.toml:/opt/app-root/src/tracing-configs/otel.toml
   example.com:
-    image: alpine/socat:1.7.4.4
+    image: quay.io/openshift-logging/alpine-socat:1.8.0.0
     container_name: example.com
-    command: "-d -v -d TCP-LISTEN:80,reuseaddr,fork TCP:two.upstream:80"
+    command: "-d -v -d TCP-LISTEN:80,reuseaddr,fork TCP:two.upstream:8080"
     expose:
       - "80"
     restart: unless-stopped
   two.upstream:
-    image: kennethreitz/httpbin
+    image: quay.io/kuadrant/authorino-examples:talker-api
     expose:
-      - "80"
+      - "8080"
   jaeger:
-    image: jaegertracing/all-in-one:latest
+    image: quay.io/ducna/jaegertracing/all-in-one:1.60
     environment:
       JAEGER_DISABLED: "false"
       COLLECTOR_OTLP_ENABLED: "true"

--- a/dev-environments/plain-http-upstream/docker-compose.yml
+++ b/dev-environments/plain-http-upstream/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - ./apicast-config.json:/tmp/config.json
   example.com:
-    image: alpine/socat:1.7.4.4
+    image: quay.io/openshift-logging/alpine-socat:1.8.0.0
     container_name: example.com
     command: "-d -d -v -d TCP-LISTEN:80,reuseaddr,fork TCP:two.upstream:3000"
     expose:
@@ -37,7 +37,7 @@ services:
     expose:
       - "3000"
   backend:
-    image: alpine/socat:1.7.4.4
+    image: quay.io/openshift-logging/alpine-socat:1.8.0.0
     container_name: backend
     command: "-d -d -v -d TCP-LISTEN:80,reuseaddr,fork TCP:3scale.backend:3000"
     expose:

--- a/dev-environments/upstream-tlsv1.3/docker-compose.yml
+++ b/dev-environments/upstream-tlsv1.3/docker-compose.yml
@@ -24,15 +24,15 @@ services:
     volumes:
       - ./apicast-config.json:/tmp/config.json
   example.com:
-    image: alpine/socat:1.7.4.4
+    image: quay.io/openshift-logging/alpine-socat:1.8.0.0
     container_name: example.com
-    command: "-v openssl-listen:443,reuseaddr,fork,cert=/etc/pki/example.com.pem,verify=0,openssl-min-proto-version=TLS1.3,openssl-max-proto-version=TLS1.3 TCP:two.upstream:80"
+    command: "-v openssl-listen:443,reuseaddr,fork,cert=/etc/pki/example.com.pem,verify=0,openssl-min-proto-version=TLS1.3,openssl-max-proto-version=TLS1.3 TCP:two.upstream:8080"
     expose:
       - "443"
     restart: unless-stopped
     volumes:
       - ./cert/example.com.pem:/etc/pki/example.com.pem
   two.upstream:
-    image: kennethreitz/httpbin
+    image: quay.io/kuadrant/authorino-examples:talker-api
     expose:
-      - "80"
+      - "8080"

--- a/docker-compose-devel.yml
+++ b/docker-compose-devel.yml
@@ -22,4 +22,4 @@ services:
       GIT_COMMITTER_NAME: ${GIT_COMMITTER_NAME:-${USER}}
       GIT_COMMITTER_EMAIL: ${GIT_COMMITTER_EMAIL:-""}
   redis:
-    image: redis
+    image: mirror.gcr.io/library/redis

--- a/docker-compose.benchmark.yml
+++ b/docker-compose.benchmark.yml
@@ -10,7 +10,7 @@ services:
     cpuset: "0"
     cpu_count: 1
   wrk:
-    image: skandyla/wrk
+    image: quay.io/skupper/wrk
     environment:
       - WRK_REPORT=/tmp/wrk/${WRK_REPORT:-report.csv}
     depends_on:
@@ -23,7 +23,7 @@ services:
     command: "--script /tmp/wrk/report.lua --threads ${THREADS:-10} --connections ${CONNECTIONS:-100} --duration ${DURATION:-60} -H 'Host: localhost' http://apicast:8080/echo?user_key=foo"
 
   curl:
-    image: byrnedo/alpine-curl
+    image: quay.io/curl/curl
     links:
       - apicast
     depends_on:

--- a/docker-compose.prove.yml
+++ b/docker-compose.prove.yml
@@ -10,4 +10,4 @@ services:
     depends_on:
       - redis
   redis:
-    image: redis
+    image: mirror.gcr.io/library/redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,12 +45,12 @@ services:
     dns_search:
       - example.com
   redis:
-    image: redis
+    image: mirror.gcr.io/library/redis
   keycloak:
-    image: jboss/keycloak:3.1.0.Final
+    image: quay.io/keycloak/keycloak:23.0.4
     environment:
-      KEYCLOAK_USER: keycloak
-      KEYCLOAK_PASSWORD: keycloak
+      KEYCLOAK_ADMIN: keycloak
+      KEYCLOAK_ADMIN_PASSWORD: keycloak
       KEYCLOAK_LOGLEVEL: INFO
     ports:
       - "8080"
@@ -70,7 +70,7 @@ services:
       - ./examples/opentracing/apicast-config.json:/tmp/config.json
       - ./examples/opentracing/jaeger-config.json:/opt/app-root/src/tracing-configs/tracing-config-jaeger-jaeger-config.json
   jaeger:
-    image: jaegertracing/all-in-one:latest
+    image: quay.io/ducna/jaegertracing/all-in-one:1.60
     environment:
       JAEGER_DISABLED: "false"
       COLLECTOR_OTLP_ENABLED: "true"


### PR DESCRIPTION
# What
Remove dockerhub images from our build

| Image                            | Replace with                                       |
| -------------------------------- | -------------------------------------------------- |
| alpine/socat:1.7.4.4             | quay.io/openshift-logging/alpine-socat:1.8.0.0     |
| kalmhq/echoserver                |     build from source                                               |
| kennethreitz/httpbin<br>         | quay.io/kuadrant/authorino-examples:talker-api     |
| jaegertracing/all-in-one:latest  | quay.io/ducna/jaegertracing/all-in-one:1.60        |
| jboss/keycloak:3.1.0.Final                                 | quay.io/keycloak/keycloak:23.0.                    |
| alpine:3                         |  mirror.gcr.io/library/alpine:3                                                  |
| redis                            | mirror.gcr.io/library/redis                        |
| byrnedo/alpine-curl              | quay.io/curl/curl                                  |
| skandyla/wrk                     | quay.io/skupper/wrk                                |
| docker:23.0.2-cli-alpine3.17<br> | mirror.gcr.io/library/docker:23.0.2-cli-alpine3.17 |
| openjdk:11.0.9<br> | registry.access.redhat.com/ubi8/openjdk-11:1.21-1.1733300800 |