### PR TITLE
[THREESCALE-6116] Conditional policy: disable UI field

### DIFF
--- a/doc/policies_list/3.15.0/policies.json
+++ b/doc/policies_list/3.15.0/policies.json
@@ -2726,7 +2726,7 @@
     ],
     "conditional": [
       {
-        "name": "Conditional Policy [Tech preview]",
+        "name": "Conditional Policy",
         "$schema": "http://apicast.io/policy-v1.1/schema#manifest#",
         "configuration": {
           "required": [
@@ -2734,11 +2734,11 @@
           ],
           "properties": {
             "policy_chain": {
-              "items": {
-                "type": "object"
-              },
-              "type": "array",
-              "description": "The policy chain to execute when the condition is true"
+              "type": "object",
+              "description": [
+                "The policy chain to execute when the condition is true. ",
+                "This field is managed by the operator and can't be edited."
+              ]
             },
             "condition": {
               "$ref": "#/definitions/condition"


### PR DESCRIPTION
[THREESCALE-6116](https://issues.redhat.com/browse/THREESCALE-6116) is assigned to porta but I think it belongs to here.

I don't think we'll be able to edit the `conditional` policy from UI because this is a corner case where we need to recursively add a jsonschema form inside another. I'm not sure that's possible but in any case it would take much more resources than the issue deserves IMO.

After a discussion in the comments, it was agreed to just add a notice about this policy being managed by operator. In my opinion, the right place to do this is the policy schema in Apicast.

After taking a look, I think we don't actually need to disable the whole policy from UI, only the recursive field `policy_chain`. I tested the `condition` field and it works fine and can be edited from UI without problems.

Since I already made some changes in the policy locally, I thought it would be good to share them.

This is how the form looks now:

![image](https://github.com/user-attachments/assets/9b8e872a-311d-4d7f-a199-d573765f25ac)
