### PR TITLE
[THREESCALE-10708] JWT Parser Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Remove opentracing support [PR #1520](https://github.com/3scale/APIcast/pull/1520) [THREESCALE-11603](https://issues.redhat.com/browse/THREESCALE-11603)
 - JWT signature verification, support for ES256/ES512 #1533 [PR #1533](https://github.com/3scale/APIcast/pull/1533) [THREESCALE-11474](https://issues.redhat.com/browse/THREESCALE-11474)
 - Add `enable_extended_context` to allow JWT Claim Check access full request context [PR #1535](https://github.com/3scale/APIcast/pull/1535) [THREESCALE-9510](https://issues.redhat.com/browse/THREESCALE-9510)
+- JWT signature verification, support for ES256/ES512 [PR #1533](https://github.com/3scale/APIcast/pull/1533) [THREESCALE-11474](https://issues.redhat.com/browse/THREESCALE-11474)
+- JWT Parser policy [PR #1536](https://github.com/3scale/APIcast/pull/1536) [THREESCALE-10708](https://issues.redhat.com/browse/THREESCALE-10708)
 
 ## [3.15.0] 2024-04-04
 

--- a/gateway/src/apicast/policy/jwt_parser/README.md
+++ b/gateway/src/apicast/policy/jwt_parser/README.md
@@ -1,0 +1,64 @@
+# JWT Parser
+
+JWT Parser is used to parse the JSON Web Token (JWT) in the `Authorization` header and stores it in the request context that can be shared with other policies.
+
+If `required` flag is set to true and no JWT token is sent, APIcast will reject the request and send HTTP ``WWW-Authenticate`` response header.
+
+NOTE: Not compatible with OIDC authentication mode. When this policy is added to a service configured with OIDC authentication mode, APIcast will print a warning about the incompatibility and ignore the policy.
+
+## Example usage
+
+With `JWT Claim Check` policy
+
+```
+"policy_chain": [
+  {
+    "name": "apicast.policy.jwt_parser",
+    "configuration": {
+      "issuer_endpoint": "http://red_hat_single_sign-on/auth/realms/foo",
+    }
+  },
+  {
+    "name": "apicast.policy.jwt_claim_check",
+    "configuration": {
+      "error_message": "Invalid JWT check",
+      "rules": [
+        {
+            "operations": [
+                {"op": "==", "jwt_claim": "role", "jwt_claim_type": "plain", "value": "admin"}
+            ],
+            "combine_op":"and",
+            "methods": ["GET"],
+            "resource": "/resource",
+            "resource_type": "plain"
+        }
+      ]
+    }
+  }
+]
+```
+
+With `Keycloak Role Check` policy
+
+```
+"policy_chain": [
+  {
+    "name": "apicast.policy.jwt_parser",
+    "configuration": {
+      "issuer_endpoint": "http://red_hat_single_sign-on/auth/realms/foo",
+      "required": true
+    }
+  },
+  {
+    "name": "apicast.policy.keycloak_role_check",
+    "configuration": {
+      "scopes": [
+        {
+          "realm_roles": [ { "name": "foo" } ],
+          "resource": "/confidential"
+        }
+      ]
+    }
+  },
+]
+```

--- a/gateway/src/apicast/policy/jwt_parser/apicast-policy.json
+++ b/gateway/src/apicast/policy/jwt_parser/apicast-policy.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "JWT Parser",
+  "summary": "Parse JWT",
+  "description": ["This policy parse JWT token from Authorization header"],
+  "version": "builtin",
+  "configuration": {
+    "type": "object",
+    "properties": {
+      "issuer_endpoint": {
+        "description": "URL of OpenID Provider. The format of this endpoint is determined on your OpenID Provider setup.",
+        "type": "string"
+      },
+      "required": {
+        "description": "when enabled, rejected request if no JWT token present in Authorization header",
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/gateway/src/apicast/policy/jwt_parser/init.lua
+++ b/gateway/src/apicast/policy/jwt_parser/init.lua
@@ -1,0 +1,1 @@
+return require('jwt_parser')

--- a/gateway/src/apicast/policy/jwt_parser/jwt_parser.lua
+++ b/gateway/src/apicast/policy/jwt_parser/jwt_parser.lua
@@ -1,4 +1,4 @@
--- OpenID Connect Authentication policy
+-- JWT Parser policy
 -- It will verify JWT signature against a list of public keys
 -- discovered through OIDC Discovery from the IDP.
 
@@ -8,7 +8,7 @@ local oidc_discovery = require('resty.oidc.discovery')
 local http_authorization = require('resty.http_authorization')
 local resty_url = require('resty.url')
 local policy = require('apicast.policy')
-local _M = policy.new('oidc_authentication', 'builtin')
+local _M = policy.new('jwt_parser', 'builtin')
 
 local tostring = tostring
 
@@ -23,7 +23,7 @@ local function valid_issuer_endpoint(endpoint)
 end
 
 local new = _M.new
---- Initialize a oidc_authentication
+--- Initialize jwt_parser policy
 -- @tparam[opt] table config Policy configuration.
 function _M.new(config)
   local self = new(config)

--- a/gateway/src/apicast/policy/oidc_authentication/init.lua
+++ b/gateway/src/apicast/policy/oidc_authentication/init.lua
@@ -1,1 +1,0 @@
-return require('oidc_authentication')

--- a/spec/policy/jwt_parser/jwt_parser_spec.lua
+++ b/spec/policy/jwt_parser/jwt_parser_spec.lua
@@ -1,4 +1,4 @@
-local _M = require('apicast.policy.oidc_authentication')
+local _M = require('apicast.policy.jwt_parser')
 local JWT = require('resty.jwt')
 local certs = require('fixtures.certs')
 local OIDC = require('apicast.oauth.oidc')
@@ -14,7 +14,7 @@ local access_token = setmetatable({
   },
 }, { __tostring = function(jwt) return JWT:sign(certs.rsa_private_key, jwt) end })
 
-describe('oidc_authentication policy', function()
+describe('jwt_parser policy', function()
   describe('.new', function()
     it('works without configuration', function()
       assert(_M.new())

--- a/spec/policy/jwt_parser/jwt_parser_spec.lua
+++ b/spec/policy/jwt_parser/jwt_parser_spec.lua
@@ -97,30 +97,77 @@ describe('jwt_parser policy', function()
       policy:rewrite(context)
 
       assert.is_table(context.jwt)
-      assert.same(access_token.payload, context.jwt.payload)
+      assert.same(access_token.payload, context.jwt)
     end)
 
     it('handles invalid token', function()
+      spy.on(ngx, 'exit')
       local policy = _M.new()
-      local context = { }
+      local context = {
+          service = {
+            auth_failed_status = 403,
+            error_auth_failed = "auth failed"
+          }
+      }
 
       ngx.var.http_authorization = 'Bearer ' .. 'invalid token value'
 
       policy:rewrite(context)
 
-      assert.is_table(context.jwt)
-      assert.contains({reason = 'invalid jwt string', valid = false }, context.jwt)
-    end)
-  end)
-
-  describe(':access', function()
-
-    it('works without config', function()
-      _M.new():access({})
+      -- assert.spy(ngx.exit).was_called_with(403)
+      assert.same(ngx.status, 403)
+      assert.stub(ngx.exit).was.called_with(403)
     end)
 
-    it('works with empty config', function()
-      _M.new({}):access({})
+    it('handles invalid token with required set to true', function()
+      spy.on(ngx, 'exit')
+      local policy = _M.new{required = true}
+      local context = {
+          service = {
+            auth_failed_status = 403,
+            error_auth_failed = "auth failed"
+          }
+      }
+
+      ngx.var.http_authorization = 'Bearer ' .. 'invalid token value'
+
+      policy:rewrite(context)
+
+      assert.spy(ngx.exit).was_called_with(403)
+    end)
+
+    it('ignore when authenticate mode is oidc', function()
+      spy.on(ngx, 'exit')
+      local policy = _M.new()
+      local context = {
+        service = {
+          authentication_method = "oidc"
+        }
+      }
+
+      ngx.var.http_authorization = 'Bearer ' .. tostring(access_token)
+
+      policy:rewrite(context)
+
+      assert.falsy(context.jwt)
+      assert.spy(ngx.exit).was_not_called()
+    end)
+
+    it('ignore when backend_version is oauth', function()
+      spy.on(ngx, 'exit')
+      local policy = _M.new()
+      local context = {
+        service = {
+          backend_version = "oauth"
+        }
+      }
+
+      ngx.var.http_authorization = 'Bearer ' .. 'invalid token value'
+
+      policy:rewrite(context)
+
+      assert.falsy(context.jwt)
+      assert.spy(ngx.exit).was_not_called()
     end)
 
     context('when OIDC is required', function ()
@@ -134,19 +181,38 @@ describe('jwt_parser policy', function()
         spy.on(ngx, 'exit')
 
         ngx.header = { }
-        policy:access({})
+        policy:rewrite({
+          service = {
+            auth_failed_status = 403,
+            error_auth_failed = "auth failed"
+          }
+        })
 
-        assert.spy(ngx.exit).was_called_with(ngx.HTTP_UNAUTHORIZED)
         assert.same('Bearer', ngx.header.www_authenticate)
+        assert.same(ngx.status, 403)
+        assert.stub(ngx.exit).was.called_with(403)
       end)
 
       it('returns forbidden on invalid token', function()
         spy.on(ngx, 'exit')
-        local jwt = { token = 'invalid' }
-        local context = { [policy] = jwt }
+        ngx.var.http_authorization = 'Bearer ' .. tostring(access_token)
+
+        local oidc = OIDC.new{
+          issuer = access_token.payload.iss,
+          config = { id_token_signing_alg_values_supported = { access_token.header.alg } },
+          keys = { [access_token.header.kid] = { pem = certs.rsa_public_key, alg = "ES256" }  },
+        }
+
+        policy.oidc = oidc
+        local context = {
+          service = {
+            auth_failed_status = 403,
+            error_auth_failed = "auth failed"
+          }
+        }
 
         ngx.header = { }
-        policy:access(context)
+        policy:rewrite(context)
 
         assert.spy(ngx.exit).was_called_with(ngx.HTTP_FORBIDDEN)
       end)
@@ -162,25 +228,40 @@ describe('jwt_parser policy', function()
       it('does nothing when token is not sent', function()
         spy.on(ngx, 'exit')
 
-        policy:access({})
+        policy:rewrite({})
 
         assert.spy(ngx.exit).was_not_called()
       end)
 
-      it('returns forbidden on invalid token', function()
+      it('returns forbidden on invalid token, jwk.alg does not match jwt.header.alg', function()
         spy.on(ngx, 'exit')
-        local jwt = { token = 'invalid' }
-        local context = { [policy] = jwt }
 
-        ngx.header = { }
-        policy:access(context)
+        ngx.var.http_authorization = 'Bearer ' .. tostring(access_token)
+        local oidc = OIDC.new{
+          issuer = access_token.payload.iss,
+          config = { id_token_signing_alg_values_supported = { access_token.header.alg } },
+          keys = { [access_token.header.kid] = { pem = certs.rsa_public_key, alg = "ES256" }  },
+        }
 
-        assert.spy(ngx.exit).was_called_with(ngx.HTTP_FORBIDDEN)
+        local policy = _M.new{ oidc = oidc }
+
+        local context = {
+          service = {
+            auth_failed_status = 403,
+            error_auth_failed = "auth failed"
+          }
+        }
+
+        policy:rewrite(context)
+
+        assert.falsy(context.jwt)
       end)
     end)
 
     it('continues on valid token', function()
       spy.on(ngx, 'exit')
+
+      ngx.var.http_authorization = 'Bearer ' .. tostring(access_token)
 
       local oidc = OIDC.new{
         issuer = access_token.payload.iss,
@@ -188,11 +269,11 @@ describe('jwt_parser policy', function()
         keys = { [access_token.header.kid] = { pem = certs.rsa_public_key, alg = access_token.header.alg }  },
       }
       local policy = _M.new{ oidc = oidc }
-      local jwt = oidc:parse(access_token)
-      local context = { [policy] = jwt }
+      local context = {}
 
-      assert.is_true(policy:access(context))
+      policy:rewrite(context)
 
+      assert.is_table(context.jwt)
       assert.spy(ngx.exit).was_not_called()
     end)
   end)

--- a/t/apicast-policy-jwt_parser.t
+++ b/t/apicast-policy-jwt_parser.t
@@ -7,14 +7,14 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: oidc_authentication accepts configuration
+=== TEST 1: jwt_parser accepts configuration
 --- configuration
 {
   "services": [
     {
       "proxy": {
         "policy_chain": [
-          { "name": "apicast.policy.oidc_authentication",
+          { "name": "apicast.policy.jwt_parser",
             "configuration": { } },
           { "name": "apicast.policy.echo" }
         ]
@@ -65,7 +65,7 @@ location = /jwks {
     {
       "proxy": {
         "policy_chain": [
-            { "name": "apicast.policy.oidc_authentication",
+            { "name": "apicast.policy.jwt_parser",
                 "configuration": {
                     "issuer_endpoint": "http://test_backend:$TEST_NGINX_SERVER_PORT/realm" } },
             { "name": "apicast.policy.echo" }

--- a/t/apicast-policy-jwt_parser.t
+++ b/t/apicast-policy-jwt_parser.t
@@ -89,3 +89,79 @@ my $jwt = encode_jwt(payload => {
 GET /echo HTTP/1.1
 --- no_error_log
 [error]
+
+
+
+=== TEST 3: Uses OIDC Discovery to load OIDC configuration but ignore due to
+incompatible authentication method
+--- env eval
+( 'APICAST_CONFIGURATION_LOADER' => 'lazy' )
+--- backend
+location = /realm/.well-known/openid-configuration {
+  content_by_lua_block {
+    local base = "http://" .. ngx.var.host .. ':' .. ngx.var.server_port
+    ngx.header.content_type = 'application/json;charset=utf-8'
+    ngx.say(require('cjson').encode {
+        issuer = 'https://example.com/auth/realms/apicast',
+        id_token_signing_alg_values_supported = { 'RS256' },
+        jwks_uri = base .. '/jwks',
+    })
+  }
+}
+
+location = /jwks {
+  content_by_lua_block {
+    ngx.header.content_type = 'application/json;charset=utf-8'
+    ngx.say([[
+        { "keys": [
+            { "kty":"RSA","kid":"somekid",
+              "n":"sKXP3pwND3rkQ1gx9nMb4By7bmWnHYo2kAAsFD5xq0IDn26zv64tjmuNBHpI6BmkLPk8mIo0B1E8MkxdKZeozQ","e":"AQAB",
+              "alg":"RS256" }
+        ] }
+    ]])
+  }
+}
+--- configuration
+{
+  "oidc": [
+    {
+      "issuer": "https://example.com/auth/realms/apicast",
+      "config": { "id_token_signing_alg_values_supported": [ "RS256" ] },
+      "keys": { "somekid": { "pem": "-----BEGIN PUBLIC KEY-----\nMFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALClz96cDQ965ENYMfZzG+Acu25lpx2K\nNpAALBQ+catCA59us7+uLY5rjQR6SOgZpCz5PJiKNAdRPDJMXSmXqM0CAwEAAQ==\n-----END PUBLIC KEY-----", "alg": "RS256" } }
+    }
+  ],
+  "services": [
+    {
+      "id": 42,
+      "backend_version": "oauth",
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
+      "proxy": {
+        "authentication_method": "oidc",
+        "oidc_issuer_endpoint": "https://example.com/auth/realms/apicast",
+        "policy_chain": [
+            { "name": "apicast.policy.jwt_parser",
+                "configuration": {
+                    "issuer_endpoint": "http://test_backend:$TEST_NGINX_SERVER_PORT/realm" } },
+            { "name": "apicast.policy.echo" }
+         ]
+      }
+    }
+  ]
+}
+--- request
+GET /echo
+--- more_headers eval
+use Crypt::JWT qw(encode_jwt);
+my $jwt = encode_jwt(payload => {
+  aud => 'the_token_audience',
+  sub => 'someone',
+  iss => 'https://example.com/auth/realms/apicast',
+  exp => time + 3600 }, key => \$::rsa, alg => 'RS256', extra_headers => { kid => 'somekid' });
+"Authorization: Bearer $jwt"
+--- error_code: 200
+--- response_body
+GET /echo HTTP/1.1
+--- error_log
+jwt_parser is incompatible with OIDC authentication mode
+


### PR DESCRIPTION
## What

Fix https://issues.redhat.com/browse/THREESCALE-10708

This is mostly a rename of oidc_authentication policy with an extra bit a logic on top to handle potential conflict with existing service configured with OIDC. 

See https://github.com/3scale/APIcast/pull/904#issuecomment-425832879

## Verification steps
1. Check out this branch and build a new runtime-image
```
make runtime-image IMAGE_NAME=apicast-test
```
2. Move into dev-environments
```
cd dev-environments/keycloak-env
```
3. Modify `apicast-config.json` as follow
```
diff --git a/dev-environments/keycloak-env/apicast-config.json b/dev-environments/keycloak-env/apicast-config.json 
index 071296cd..d5ca17ca 100644                                                                                    
--- a/dev-environments/keycloak-env/apicast-config.json                                                            
+++ b/dev-environments/keycloak-env/apicast-config.json                                                            
@@ -84,10 +84,10 @@                                                                                                
         },                                                                                                        
         "policy_chain": [                                                                                         
           {                                                                                                       
-            "name": "token_introspection",                                                                        
-            "version": "builtin",                                                                                 
+            "name": "apicast.policy.jwt_parser",                                                                  
             "configuration": {                                                                                    
-              "auth_type": "use_3scale_oidc_issuer_endpoint"                                                      
+              "issuer_endpoint": "http://keycloak:8080/realms/basic",                                             
+              "required": true                                                                                    
             }                                                                                                     
           },                                                                                                      
           {                                                                                                       
```
4. Start gateway
```
make gateway IMAGE_NAME=apicast-test
```
5. In another terminal seed keycloak-data
```
make keycloak-data
``` 
6. Send request
```
export ACCESS_TOKEN=$(make token)

curl -v --resolve stg.example.com:8080:127.0.0.1 -H "Authorization: Bearer ${ACCESS_TOKEN}" "http://stg.example.com:8080"
```
7. Check APIcast log for the following message
```
[warn] 19#19: *2 jwt_parser.lua:49: check_compatible(): jwt_parser is incompatible with OIDC authentication mode, requestID=10c3fa9952859b03221ee7085fcaa6b3, client: 172.18.0.1, server: _, request: "GET / HTTP/1.1", host: "stg.example.com:8080"                                                                                                                                                         
```
8. Stop the gateway
```
CTRL-C
```
9. Edit `apicast-config.json`
```diff
diff --git a/dev-environments/keycloak-env/apicast-config.json b/dev-environments/keycloak-env/apicast-config.json                          
index 071296cd..ec3d6532 100644                                                                                                             
--- a/dev-environments/keycloak-env/apicast-config.json                                                                                     
+++ b/dev-environments/keycloak-env/apicast-config.json                                                                                     
@@ -2,7 +2,7 @@                                                                                                                             
   "services": [                                                                                                                            
     {                                                                                                                                      
       "id": 2,                                                                                                                             
-      "backend_version": "oauth",                                                                                                          
+      "backend_version": "1",                                                                                                              
       "account_id": 2,                                                                                                                     
       "name": "API",                                                                                                                       
       "description": null,                                                                                                                 
@@ -63,7 +63,7 @@                                                                                                                           
         "apicast_configuration_driven": true,                                                                                              
         "oidc_issuer_endpoint": "http://oidc-issuer-for-3scale:oidc-issuer-for-3scale-secret@keycloak:8080/realms/basic",                  
         "lock_version": 4,                                                                                                                 
-        "authentication_method": "oidc",                                                                                                   
+        "authentication_method": "1",                                                                                                      
         "oidc_issuer_type": "keycloak",                                                                                                    
         "error_headers_limits_exceeded": "text/plain; charset=us-ascii",                                                                   
         "error_status_limits_exceeded": 429,                                                                                               
@@ -84,10 +84,23 @@                                                                                                                         
         },                                                                                                                                 
         "policy_chain": [                                                                                                                  
           {                                                                                                                                
-            "name": "token_introspection",                                                                                                 
-            "version": "builtin",                                                                                                          
+            "name": "apicast.policy.jwt_parser",                                                                                           
+            "configuration": {                                                                                                             
+              "issuer_endpoint": "http://keycloak:8080/realms/basic",                                                                      
+              "required": true                                                                                                             
+            }                                                                                                                              
+          },                                                                                                                               
+          {                                                                                                                                
+            "name": "apicast.policy.jwt_claim_check",                                                                                      
             "configuration": {                                                                                                             
-              "auth_type": "use_3scale_oidc_issuer_endpoint"                                                                               
+              "rules" : [{                                                                                                                 
+                  "operations": [                                                                                                          
+                    {"op": "==", "jwt_claim": "{{realm_access.roles| first}}", "jwt_claim_type": "liquid", "value": "default-roles-basic"} 
+                  ],                                                                                                                       
+                  "combine_op": "and",                                                                                                     
+                  "methods": ["GET"],                                                                                                      
+                  "resource": "/"                                                                                                          
+              }]                                                                                                                           
             }                                                                                                                              
           },                                                                                                                               
           {                                                                                                                                
```
10. Send a request without Authorization header. You should see 403 Forbidden
```
curl -v --resolve stg.example.com:8080:127.0.0.1  "http://stg.example.com:8080/?user_key=foo" 
```
11. Retrieve access token and send another request
```
export ACCESS_TOKEN=$(make token)

curl -v --resolve stg.example.com:8080:127.0.0.1 -H "Authorization: Bearer ${ACCESS_TOKEN}" "http://stg.example.com:8080/?user_key=foo"
```

You should now see `HTTP/1.1 200 OK`