### PR TITLE
Remove left over  from rate_limit policy schema

### DIFF
--- a/gateway/src/apicast/policy/rate_limit/apicast-policy.json
+++ b/gateway/src/apicast/policy/rate_limit/apicast-policy.json
@@ -101,7 +101,6 @@
         "required": ["left", "op", "right"]
       },
       "condition": {
-        "$id": "#/definitions/condition",
         "type": "object",
         "description": "Condition to be evaluated",
         "properties": {


### PR DESCRIPTION
## What

Remove the $id field from rate_limit policy, somehow I missed this one in #1525