### PR TITLE
THREESCALE-11738 - on_failed policy doesn't work with conditional policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed Financial-grade API (FAPI) policy not showing up in the admin portal [PR #1528](https://github.com/3scale/APIcast/pull/1528) [THREESCALE-11620](https://issues.redhat.com/browse/THREESCALE-11620)
 - Remove Conditional Policy from the UI [PR #1534](https://github.com/3scale/APIcast/pull/1534) [THREESCALE-6116](https://issues.redhat.com/browse/THREESCALE-6116)
 - Remove redis connection error message from response body in edge limiting policy [PR #1537](https://github.com/3scale/APIcast/pull/1537) [THREESCALE-11701](https://issues.redhat.com/browse/THREESCALE-11701)
+- Fix `on_failed` policy doesn't work with `conditional policy` [THREESCALE-11738](https://issues.redhat.com/browse/THREESCALE-11738) [PR #1541](https://github.com/3scale/APIcast/pull/1541)
 
 ### Added
 

--- a/gateway/src/apicast/policy/conditional/README.md
+++ b/gateway/src/apicast/policy/conditional/README.md
@@ -46,6 +46,10 @@ When the request is not a POST, the order of execution for each phase is:
 2) Caching
 3) Upstream
 
+NOTE: when one or more policies in conditional chain are invalid, APIcast will
+skip the invalid policy and load the next policy in the chain, which may lead
+to unexpected behavior. If you want to terminate the chain, add an `on_failed`
+policy to the chain.
 
 ## Conditions
 
@@ -132,6 +136,42 @@ the `Backend` header of the request is `staging`:
                   }
                ]
             }
+         }
+      ]
+   }
+}
+
+```
+
+With `on-failed` policy
+
+```json
+{
+   "name":"conditional",
+   "version":"builtin",
+   "configuration":{
+      "condition":{
+         "operations":[
+            {
+               "left":"{{ headers['Backend'] }}",
+               "left_type":"liquid",
+               "op":"==",
+               "right":"staging"
+            }
+         ]
+      },
+      "policy_chain":[
+         {
+           "name": "example",
+           "version": "1.0",
+           "configuration": {}
+         },
+         {
+           "name": "on_failed",
+           "version": "builtin",
+           "configuration": {
+             "error_status_code": 419
+           }
          }
       ]
    }


### PR DESCRIPTION
## What
Fix https://issues.redhat.com/browse/THREESCALE-11738

## Verification steps:
* Checkout this branch
* Build new runtime-image
```
make runtime-image IMAGE_NAME=apicast-test
```
* Get into dev-environments
```
cd plain-http-upstream 
```
* Update `apicast-config.json`
```diff
diff --git a/dev-environments/plain-http-upstream/apicast-config.json b/dev-environments/plain-http-upstream/apicast-config.json
index ff944273..147a0d51 100644
--- a/dev-environments/plain-http-upstream/apicast-config.json
+++ b/dev-environments/plain-http-upstream/apicast-config.json
@@ -13,6 +13,38 @@
         "policy_chain": [
           {
             "name": "apicast.policy.apicast"
+          },
+          {
+            "name": "conditional",
+            "version": "builtin",
+            "configuration": {
+              "condition": {
+                "operations": [
+                  {
+                    "left": "{{ uri }}",
+                    "left_type": "liquid",
+                    "op": "==",
+                    "right": "/foo",
+                    "right_type": "plain"
+                  }
+                ]
+              },
+              "policy_chain": [
+                {
+                  "name": "example",
+                  "version": "1.0",
+                  "configuration": {}
+                },
+                {
+                  "name": "on_failed",
+                  "version": "builtin",
+                  "configuration": {
+                    "error_status_code": 419
+                  }
+                }
+              ]
+            },
+            "enabled": true
           }
         ],
         "proxy_rules": [
```
* Start APIcast
```
make gateway IMAGE_NAME=apicast-test
```
* Send request
```
curl --resolve get.example.com:8080:127.0.0.1 -v "http://get.example.com:8080/?user_key=123" 
```
You should see `HTTP/1.1 200 OK`
* Send another request to trigger `on_failed` policy
```
curl --resolve get.example.com:8080:127.0.0.1 -v "http://get.example.com:8080/foo?user_key=123" 
```
419 will be returned this time