### PR TITLE
Fix regression

### DIFF
--- a/gateway/src/resty/http_ng/backend/resty.lua
+++ b/gateway/src/resty/http_ng/backend/resty.lua
@@ -37,7 +37,7 @@ backend.send = function(_, request)
   local httpc, err = http_proxy.new(request)
 
   if err then
-    return nil, err
+    return response.error(request, err)
   end
 
   if httpc then

--- a/spec/resty/http_ng/backend/resty_spec.lua
+++ b/spec/resty/http_ng/backend/resty_spec.lua
@@ -37,8 +37,11 @@ describe('resty backend', function()
       local req = { method = method, url = 'http://0.0.0.0:0/' }
       local response, err = backend:send(req)
 
-      assert.falsy(response)
-      assert.equal("connection refused", err)
+      assert.falsy(err)
+      assert.truthy(response.error)
+      assert.equal("connection refused", response.error)
+      assert.falsy(response.ok)
+      assert.same(req, response.request)
     end)
 
     context('http proxy is set', function()

--- a/spec/resty/http_ng_spec.lua
+++ b/spec/resty/http_ng_spec.lua
@@ -224,18 +224,18 @@ describe('http_ng', function()
   end)
 
   describe('when there is error #network', function()
-    local response, err
+    local response
     before_each(function()
       http = http_ng.new{ backend = resty_backend }
-      response, err = http.get('http://127.0.0.1:1')
+      response = http.get('http://127.0.0.1:1')
     end)
 
     it('is not ok', function()
-      assert.falsy(response)
+      assert.equal(false, response.ok)
     end)
 
     it('has error', function()
-      assert.equal("connection refused", err)
+      assert.equal("connection refused", response.error)
     end)
   end)
 


### PR DESCRIPTION
## What
Discovered this regression while investigate [THREESCALE-11741](https://issues.redhat.com/browse/THREESCALE-11741)

In PR #1503 we return nil and error in case of an error, however some code paths do not handle the error but instead check the error field of the response object and lead to unexpected behavior (bypass backend-listener authrep call).

The return value of http_ng backends is also inconsistent, some backends return errors while others return response objects with error fields. This leads to some code paths checking for errors (always nil for resty backends) while others check the response object for errors or ignore errors altogether. This needs to be investigated

## Verification steps
* Checkout this branch
* Build a new runtime image
```
make runtime-image IMAGE_NAME=apicast-test
``` 
* Get into dev-env
```
dev-environments/plain-http-upstream
```
* Edit `docker-compose.yml` as follow
```
diff --git a/dev-environments/plain-http-upstream/docker-compose.yml b/dev-environments/plain-http-upstream/docker-compose.yml
index ebf84ebc..182a6294 100644
--- a/dev-environments/plain-http-upstream/docker-compose.yml
+++ b/dev-environments/plain-http-upstream/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       APICAST_WORKERS: 1
       APICAST_LOG_LEVEL: debug
       APICAST_CONFIGURATION_CACHE: "0"
+      BACKEND_ENDPOINT_OVERRIDE: "http://invalid-backend"
     expose:
       - "8080"
       - "8090"
```
* Start gateway
```
make gateway IMAGE_NAME=apicast-test
```
* Send request
```
curl --resolve get.example.com:8080:127.0.0.1 -v "http://get.example.com:8080/?user_key=123"
```
You should get  HTTP/1.1 403 Forbidden
