### PR TITLE
[fapi] Correct boolean value in the schema

### DIFF
--- a/gateway/src/apicast/policy/fapi/apicast-policy.json
+++ b/gateway/src/apicast/policy/fapi/apicast-policy.json
@@ -12,13 +12,13 @@
         "description": "Validate x-fapi-customer-ip-address header. If the verification fails, the request will be rejected with 403",
         "title": "Validate x-fapi-customer-ip-address header",
         "type": "boolean",
-        "default": "false"
+        "default": false
       },
       "validate_oauth2_certificate_bound_access_token ": {
         "description": "Validate OAuth 2.0 Mutual TLS Certificate Bound access token. If enable, all tokens are verified and must contain the certificate hash claim (cnf). If the verification fails, the request will be rejected with 401.",
         "title": "Validate OAuth 2.0 Mutual TLS Certificate Bound access token",
         "type": "boolean",
-        "default": "false"
+        "default": false
       }
     }
   }


### PR DESCRIPTION
## What
Fix https://issues.redhat.com/browse/THREESCALE-11796

## Verification steps
* Checkout this branch
* Open `fapi/apicast-policy.json` and copy everything inside the `configuration` including the curly brackets
* Head to https://rjsf-team.github.io/react-jsonschema-form/
* Paste the content to `JSONSchema` text area, you should see the form render on the right hand

![fapi](https://github.com/user-attachments/assets/89fee4f2-a1cd-4fe5-8529-7aab0f19b37b)

* Toggle the checkbox and click submit, you should see a popup with `Form submited` 

