### PR TITLE
perf(3scale_batcher): replace regex with string operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Logging Policy: construct all templates at init time [PR #1587](https://github.com/3scale/APIcast/pull/1587)
 - Routing Policy: eliminate unnecessary TemplateString allocation per request [PR #1585](https://github.com/3scale/APIcast/pull/1585)
 - Headers Policy: don't render template string when delete header [PR #1586](https://github.com/3scale/APIcast/pull/1586)
+- 3scale Batcher Policy: replace regex with string operations [PR #1583](https://github.com/3scale/APIcast/pull/1583)
 
 ### Fixed
 - Correct FAPI header to `x-fapi-interaction-id` [PR #1557](https://github.com/3scale/APIcast/pull/1557) [THREESCALE-11957](https://issues.redhat.com/browse/THREESCALE-11957)

--- a/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
@@ -203,7 +203,7 @@ function _M:access(context)
 
 
   if cached_auth then
-    handle_cached_auth(self, cached_auth, service, transaction)
+    return handle_cached_auth(self, cached_auth, service, transaction)
   else
     local formatted_usage = usage:format()
     local backend_res = backend:authorize(formatted_usage, credentials)
@@ -218,12 +218,12 @@ function _M:access(context)
     end
 
     if backend_status == 200 then
-      handle_backend_ok(self, transaction)
+      return handle_backend_ok(self, transaction)
     elseif backend_status >= 400 and backend_status < 500 then
-      handle_backend_denied(
+      return handle_backend_denied(
         self, service, transaction, backend_status, backend_res.headers)
     else
-      handle_backend_error(self, service, transaction, cache_handler)
+      return handle_backend_error(self, service, transaction, cache_handler)
     end
   end
 end

--- a/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/3scale_batcher.lua
@@ -151,11 +151,11 @@ local function handle_backend_error(self, service, transaction, cache_handler)
   end
 end
 
-local function handle_cached_auth(self, cached_auth, service, transaction)
-  if cached_auth.status == 200 then
+local function handle_cached_auth(self, cached_status, rejection_reason, service, transaction)
+  if cached_status == 200 then
     self.reports_batcher:add(transaction)
   else
-    return error(service, cached_auth.rejection_reason)
+    return error(service, rejection_reason)
   end
 end
 
@@ -197,13 +197,13 @@ function _M:access(context)
 
   ensure_timer_task_created(self, service_id, backend)
 
-  local cached_auth = self.auths_cache:get(transaction)
-  local auth_is_cached = (cached_auth and true) or false
+  local cached_status, rejection_reason = self.auths_cache:get(transaction)
+  local auth_is_cached = cached_status ~= nil
   metrics.update_cache_counters(auth_is_cached)
 
 
-  if cached_auth then
-    return handle_cached_auth(self, cached_auth, service, transaction)
+  if cached_status then
+    return handle_cached_auth(self, cached_status, rejection_reason, service, transaction)
   else
     local formatted_usage = usage:format()
     local backend_res = backend:authorize(formatted_usage, credentials)

--- a/gateway/src/apicast/policy/3scale_batcher/auths_cache.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/auths_cache.lua
@@ -41,13 +41,11 @@ function _M:get(transaction)
 
   local colon = str_find(cached_value, ':', 1, true)
   if colon then
-    return {
-      status = tonumber(str_sub(cached_value, 1, colon - 1)),
-      rejection_reason = str_sub(cached_value, colon + 1)
-    }
+    return tonumber(str_sub(cached_value, 1, colon - 1)),
+      str_sub(cached_value, colon + 1)
   end
 
-  return { status = tonumber(cached_value) }
+  return tonumber(cached_value)
 end
 
 --- Store an authorization in the cache.

--- a/gateway/src/apicast/policy/3scale_batcher/auths_cache.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/auths_cache.lua
@@ -1,7 +1,7 @@
 local keys_helper = require('apicast.policy.3scale_batcher.keys_helper')
 
-local re = require('ngx.re')
-local re_split = re.split
+local str_find = string.find
+local str_sub = string.sub
 
 local setmetatable = setmetatable
 local format = string.format
@@ -39,8 +39,15 @@ function _M:get(transaction)
 
   if not cached_value then return nil end
 
-  local split_val = re_split(cached_value, ':', 'oj', nil, 2)
-  return { status = tonumber(split_val[1]), rejection_reason = split_val[2] }
+  local colon = str_find(cached_value, ':', 1, true)
+  if colon then
+    return {
+      status = tonumber(str_sub(cached_value, 1, colon - 1)),
+      rejection_reason = str_sub(cached_value, colon + 1)
+    }
+  end
+
+  return { status = tonumber(cached_value) }
 end
 
 --- Store an authorization in the cache.

--- a/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
+++ b/gateway/src/apicast/policy/3scale_batcher/keys_helper.lua
@@ -1,5 +1,6 @@
 local ipairs = ipairs
 local format = string.format
+local str_find = string.find
 local insert = table.insert
 local concat = table.concat
 local sort = table.sort
@@ -39,11 +40,24 @@ local function metrics_part_in_key(usage)
 end
 
 local regexes_report_key = {
-  [[service_id:(?<service_id>[\w-]+),user_key:(?<user_key>[\S-]+),metric:(?<metric>[\S-]+)]],
-  [[service_id:(?<service_id>[\w-]+),access_token:(?<access_token>[\S-]+),metric:(?<metric>[\S-]+)]],
-  [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\S-]+),app_key:(?<app_key>[\S-]+),metric:(?<metric>[\S-]+)]],
-  [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\S-]+),metric:(?<metric>[\S-]+)]],
+  user_key= [[service_id:(?<service_id>[\w-]+),user_key:(?<user_key>[\S-]+),metric:(?<metric>[\S-]+)]],
+  access_token = [[service_id:(?<service_id>[\w-]+),access_token:(?<access_token>[\S-]+),metric:(?<metric>[\S-]+)]],
+  app_key = [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\S-]+),app_key:(?<app_key>[\S-]+),metric:(?<metric>[\S-]+)]],
+  app_id = [[service_id:(?<service_id>[\w-]+),app_id:(?<app_id>[\S-]+),metric:(?<metric>[\S-]+)]],
 }
+
+
+local function detect_cred_type(key)
+  if str_find(key, 'user_key:', 1, true) then
+    return 'user_key'
+  elseif str_find(key, 'access_token:', 1, true) then
+    return 'access_token'
+  elseif str_find(key, 'app_key:', 1, true) then
+    return 'app_key'
+  elseif str_find(key, 'app_id:', 1, true) then
+    return 'app_id'
+  end
+end
 
 function _M.key_for_cached_auth(transaction)
   local service_part = format("service_id:%s", transaction.service_id)
@@ -61,24 +75,26 @@ function _M.key_for_batched_report(service_id, credentials, metric_name)
 end
 
 function _M.report_from_key_batched_report(key, value)
-  for _, regex in ipairs(regexes_report_key) do
-    local match = ngx_re.match(key, regex, 'oj')
-
-    if match then
-      -- some credentials will be nil.
-      return {
-        service_id = match.service_id,
-        metric = match.metric,
-        user_key = match.user_key,
-        access_token = match.access_token,
-        app_id = match.app_id,
-        app_key = match.app_key,
-        value = value
-      }
-    end
+  local cred_type = detect_cred_type(key)
+  if not cred_type then
+    return nil, 'credentials not found'
   end
 
-  return nil, 'credentials not found'
+  local match = ngx_re.match(key, regexes_report_key[cred_type], 'oj')
+  if match then
+    -- some credentials will be nil.
+    return {
+      service_id = match.service_id,
+      metric = match.metric,
+      user_key = match.user_key,
+      access_token = match.access_token,
+      app_id = match.app_id,
+      app_key = match.app_key,
+      value = value
+    }
+  end
+
+  return nil, "credentials not found"
 end
 
 return _M

--- a/spec/policy/3scale_batcher/auths_cache_spec.lua
+++ b/spec/policy/3scale_batcher/auths_cache_spec.lua
@@ -25,8 +25,8 @@ describe('Auths cache', function()
 
     cache:set(transaction, auth_status)
 
-    local cached = cache:get(transaction)
-    assert.equals(auth_status, cached.status)
+    local cached_status = cache:get(transaction)
+    assert.equals(auth_status, cached_status)
   end)
 
   it('caches auth with app id + app key', function()
@@ -35,8 +35,8 @@ describe('Auths cache', function()
 
     cache:set(transaction, auth_status)
 
-    local cached = cache:get(transaction)
-    assert.equals(auth_status, cached.status)
+    local cached_status = cache:get(transaction)
+    assert.equals(auth_status, cached_status)
   end)
 
   it('caches auth with access token', function()
@@ -45,8 +45,8 @@ describe('Auths cache', function()
 
     cache:set(transaction, auth_status)
 
-    local cached = cache:get(transaction)
-    assert.equals(auth_status, cached.status)
+    local cached_status = cache:get(transaction)
+    assert.equals(auth_status, cached_status)
   end)
 
   it('caches auths with same usages but different order in the same key', function()
@@ -65,8 +65,8 @@ describe('Auths cache', function()
 
     cache:set(transaction_with_order_1, auth_status)
 
-    local cached = cache:get(transaction_with_order_2)
-    assert.equals(auth_status, cached.status)
+    local cached_status = cache:get(transaction_with_order_2)
+    assert.equals(auth_status, cached_status)
   end)
 
   it('caches a rejection reason when given', function()
@@ -77,15 +77,54 @@ describe('Auths cache', function()
 
     cache:set(transaction, not_authorized_status, rejection_reason)
 
-    local cached = cache:get(transaction)
-    assert.equals(not_authorized_status, cached.status)
-    assert.equals(rejection_reason, cached.rejection_reason)
+    local cached_status, cached_rejection_reason = cache:get(transaction)
+    assert.equals(not_authorized_status, cached_status)
+    assert.equals(rejection_reason, cached_rejection_reason)
   end)
 
   it('returns nil when something is not cached', function()
     local user_key = { user_key = 'uk' }
     local transaction = Transaction.new(service_id, user_key, usage)
+    
 
     assert.is_nil(cache:get(transaction))
+  end)
+
+  it('returns status without rejection_reason when cached without one', function()
+    local user_key = { user_key = 'uk' }
+    local transaction = Transaction.new(service_id, user_key, usage)
+
+    cache:set(transaction, auth_status)
+
+    local cached_status, cached_rejection_reason = cache:get(transaction)
+    assert.equals(auth_status, cached_status)
+    assert.is_nil(cached_rejection_reason)
+  end)
+
+  it('parses rejection reason containing colons', function()
+    local app_id_and_key = { app_id = 'an_id', app_key = 'a_key' }
+    local transaction = Transaction.new(service_id, app_id_and_key, usage)
+    local rejection_reason = 'reason:with:colons'
+
+    cache:set(transaction, 409, rejection_reason)
+
+    local cached_status, cached_rejection_reason = cache:get(transaction)
+    assert.equals(409, cached_status)
+    assert.equals(rejection_reason, cached_rejection_reason)
+  end)
+
+  it('returns correct status for different HTTP status codes', function()
+    local user_key = { user_key = 'uk' }
+
+    for _, status_code in ipairs({ 200, 403, 404, 409, 500 }) do
+      local tx_usage = Usage.new()
+      tx_usage:add('m_' .. status_code, 1)
+      local transaction = Transaction.new(service_id, user_key, tx_usage)
+
+      cache:set(transaction, status_code)
+
+      local cached_status, cached_rejection_reason = cache:get(transaction)
+      assert.equals(status_code, cached_status)
+    end
   end)
 end)


### PR DESCRIPTION
## What

Perf improvement for batcher policy

## Perf result

### Perf script

<details>

```lua
local root = require('pl.path').currentdir()
package.path = root .. '/?.lua;' ..
               root .. '/gateway/src/?.lua;' ..
               root .. '/gateway/src/apicast/policy/3scale_batcher/?.lua;' ..
               package.path

local monotonic_msec = require("resty.core.time").monotonic_msec
local collectgarbage = collectgarbage
local update_time = ngx.update_time
local sleep = ngx.sleep
local print = print
local str_find = string.find
local str_sub = string.sub
local Usage = require('apicast.usage')
local keys_helper = require('apicast.policy.3scale_batcher.keys_helper')

local ITERATIONS = 1000000
local s, e

local function bench(name, fn)
    -- warmup
    for i = 1, math.min(ITERATIONS, 50) do fn(i) end

    collectgarbage()
    collectgarbage()
    collectgarbage()
    sleep(1)

    update_time()
    s = monotonic_msec()
    for i = 1, ITERATIONS do
      fn(i)
    end
    update_time()
    e = monotonic_msec()
    print(string.format("  %s: ", name), e - s, " ms")
end

-- Setup: build representative test data
local usage_single = Usage.new()
usage_single:add('hits', 1)

local usage_multi = Usage.new()
usage_multi:add('hits', 1)
usage_multi:add('requests', 1)
usage_multi:add('data_sent', 512)

local creds_user_key = { user_key = 'abc123def456' }
local creds_app_id_key = { app_id = 'app_001', app_key = 'secret_key_xyz' }
local creds_access_token = { access_token = 'tok_abcdefghijklmnop' }

-- Sample keys for report parsing (as produced by key_for_batched_report)
local report_key_uk = keys_helper.key_for_batched_report('svc_100', creds_user_key, 'hits')
local report_key_app = keys_helper.key_for_batched_report('svc_100', creds_app_id_key, 'hits')
local report_key_token = keys_helper.key_for_batched_report('svc_100', creds_access_token, 'hits')

-- Sample cached auth values (as produced by value_to_cache)
local cached_status_only = '200'
local cached_with_reason = '409:limits_exceeded'
local cached_with_colons = '409:reason:with:colons'

require('resty.core')
for _ = 1, 2 do

  ---------------------------------------------------------------------------
  -- Benchmark: report key parsing (detect_cred_type + single regex)
  ---------------------------------------------------------------------------
  print('\n--- Report key parsing ---')

  bench('report_from_key (user_key)', function()
    return keys_helper.report_from_key_batched_report(report_key_uk, 5)
  end)

  bench('report_from_key (app_id+key)', function()
    return keys_helper.report_from_key_batched_report(report_key_app, 10)
  end)

  bench('report_from_key (access_token)', function()
    return keys_helper.report_from_key_batched_report(report_key_token, 3)
  end)

  ---------------------------------------------------------------------------
  -- Benchmark: cached auth value parsing (string ops vs regex split)
  ---------------------------------------------------------------------------
  print('\n--- Cached auth value parsing ---')

  local re = require('ngx.re')
  local re_split = re.split

  -- Current: plain string operations
  local function parse_string_ops(cached_value)
    local colon = str_find(cached_value, ':', 1, true)
    if colon then
      return tonumber(str_sub(cached_value, 1, colon - 1)),
             str_sub(cached_value, colon + 1)
    end
    return tonumber(cached_value)
  end

  -- Previous: regex split
  local function parse_re_split(cached_value)
    local split_val = re_split(cached_value, ':', 'oj', nil, 2)
    return tonumber(split_val[1]), split_val[2]
  end

  bench('parse status-only (string ops)', function()
    return parse_string_ops(cached_status_only)
  end)

  bench('parse status-only (re.split)', function()
    return parse_re_split(cached_status_only)
  end)

  bench('parse status+reason (string ops)', function()
    return parse_string_ops(cached_with_reason)
  end)

  bench('parse status+reason (re.split)', function()
    return parse_re_split(cached_with_reason)
  end)

  bench('parse reason with colons (string ops)', function()
    return parse_string_ops(cached_with_colons)
  end)

  bench('parse reason with colons (re.split)', function()
    return parse_re_split(cached_with_colons)
  end)

end
```

</details>

### Key parsing
Before
```
--- Report key parsing ---
  report_from_key (user_key): 321 ms
  report_from_key (app_id+key): 583 ms
  report_from_key (access_token): 454 ms

--- Report key parsing ---
  report_from_key (user_key): 343 ms
  report_from_key (app_id+key): 589 ms
  report_from_key (access_token): 424 ms
```

After

```
--- Report key parsing ---
  report_from_key (user_key): 289 ms
  report_from_key (app_id+key): 399 ms
  report_from_key (access_token): 287 ms

--- Report key parsing ---
  report_from_key (user_key): 284 ms
  report_from_key (app_id+key): 390 ms
  report_from_key (access_token): 344 ms
```

### String ops vs regex

```
--- Cached auth value parsing ---
  parse status-only (string ops): 0 ms
  parse status-only (re.split): 23 ms
  parse status+reason (string ops): 0 ms
  parse status+reason (re.split): 112 ms
  parse reason with colons (string ops): 1 ms
  parse reason with colons (re.split): 103 ms
```