### PR TITLE
perf(routing): eliminate unnecessary allocations per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Performance
 - Camel Policy: avoid unnecessary closure allocation per request [PR #1584](https://github.com/3scale/APIcast/pull/1584)
 - Logging Policy: construct all templates at init time [PR #1587](https://github.com/3scale/APIcast/pull/1587)
+- Routing Policy: eliminate unnecessary TemplateString allocation per request [PR #1585](https://github.com/3scale/APIcast/pull/1585)
 
 ### Fixed
 - Correct FAPI header to `x-fapi-interaction-id` [PR #1557](https://github.com/3scale/APIcast/pull/1557) [THREESCALE-11957](https://issues.redhat.com/browse/THREESCALE-11957)

--- a/gateway/src/apicast/policy/routing/routing.lua
+++ b/gateway/src/apicast/policy/routing/routing.lua
@@ -37,6 +37,16 @@ function _M.new(config)
   return self
 end
 
+local function route_upstream_usage_cleanup(self, usage, matched_rules)
+  if not self.route_upstream then
+    return
+  end
+
+  local usage_diff = mapping_rules_matcher.clean_usage_by_owner_id(
+    matched_rules , self.route_upstream:has_owner_id())
+  usage:merge(usage_diff)
+end
+
 function _M:access(context)
   -- All route definition needs to happen in the access phase to make sure that
   -- the mapping rule with the owner_id happens before the APIcast policy and
@@ -57,16 +67,7 @@ function _M:access(context)
 
   -- this function substract the usage that does not match with the owner_id by
   -- the matched_rules
-  context.route_upstream_usage_cleanup = function(self, usage, matched_rules)
-    if not self.route_upstream then
-      return
-    end
-
-    local usage_diff = mapping_rules_matcher.clean_usage_by_owner_id(
-      matched_rules , self.route_upstream:has_owner_id())
-    usage:merge(usage_diff)
-  end
-
+  context.route_upstream_usage_cleanup = route_upstream_usage_cleanup
 end
 
 

--- a/gateway/src/apicast/policy/routing/routing_operation.lua
+++ b/gateway/src/apicast/policy/routing/routing_operation.lua
@@ -55,8 +55,9 @@ function _M.new_op_with_jwt_claim(jwt_claim_name, op, value, value_type)
 end
 
 function _M.new_op_with_liquid_templating(liquid_expression, op, value, value_type)
+  local template = TemplateString.new(liquid_expression or "", "liquid")
   local eval_left_func = function(context)
-    return TemplateString.new(liquid_expression or "" , "liquid"):render(context)
+    return template:render(context)
   end
 
   return new(eval_left_func, op, value, value_type)

--- a/gateway/src/apicast/policy/routing/routing_operation.lua
+++ b/gateway/src/apicast/policy/routing/routing_operation.lua
@@ -6,20 +6,31 @@
 -- to get the left operand instead of the operand itself.
 
 local setmetatable = setmetatable
-local Operation = require('apicast.conditions.operation')
+local match = ngx.re.match
 local TemplateString = require('apicast.template_string')
 
 local _M = {}
 
 local mt = { __index = _M }
 
+local evaluate_func = {
+  ['=='] = function(left, right) return tostring(left) == tostring(right) end,
+  ['!='] = function(left, right) return tostring(left) ~= tostring(right) end,
+
+  -- Implemented on top of ngx.re.match. Returns true when there is a match and
+  -- false otherwise.
+  ['matches'] = function(left, right)
+    return (match(tostring(left), tostring(right)) and true) or false
+  end
+}
+
 local function new(evaluate_left_side_func, op, value, value_type)
   local self = setmetatable({}, mt)
 
   self.evaluate_left_side_func = evaluate_left_side_func
-  self.op = op
-  self.value = value
-  self.value_type = value_type
+  self.evaluate_func = evaluate_func[op]
+  assert(self.evaluate_func, 'Unsupported operation: ' .. (op or 'nil'))
+  self.right_template = TemplateString.new(value, value_type or 'plain')
 
   return self
 end
@@ -64,13 +75,9 @@ function _M.new_op_with_liquid_templating(liquid_expression, op, value, value_ty
 end
 
 function _M:evaluate(context)
-  local left_operand_val = self.evaluate_left_side_func(context)
-
-  local op = Operation.new(
-    left_operand_val, 'plain', self.op, self.value, self.value_type
-  )
-
-  return op:evaluate(context)
+  local left = self.evaluate_left_side_func(context)
+  local right = self.right_template:render(context)
+  return self.evaluate_func(left, right)
 end
 
 return _M

--- a/gateway/src/apicast/policy/routing/rule.lua
+++ b/gateway/src/apicast/policy/routing/rule.lua
@@ -74,8 +74,8 @@ function _M.new_from_config_rule(config_rule)
     self.owner_id = tonumber(config_rule.owner_id)
     return self
   else
-    return nil, 'failed to initialize upstream from url: ',
-                config_rule.url, ' err: ', err
+    return nil, 'failed to initialize upstream from url: ' ..
+                config_rule.url .. ' err: ' .. (err or 'unknown')
   end
 end
 

--- a/spec/policy/routing/routing_operation_spec.lua
+++ b/spec/policy/routing/routing_operation_spec.lua
@@ -31,6 +31,46 @@ describe('RoutingOperation', function()
 
         assert.is_false(operation:evaluate(context))
       end)
+
+      it('evaluates != correctly when paths differ', function()
+        local operation = RoutingOperation.new_op_with_path('!=', '/expected')
+
+        local context = {
+          request = { get_uri = function() return '/other' end }
+        }
+
+        assert.is_true(operation:evaluate(context))
+      end)
+
+      it('evaluates != correctly when paths match', function()
+        local operation = RoutingOperation.new_op_with_path('!=', '/same')
+
+        local context = {
+          request = { get_uri = function() return '/same' end }
+        }
+
+        assert.is_false(operation:evaluate(context))
+      end)
+
+      it('evaluates matches true when regex matches', function()
+        local operation = RoutingOperation.new_op_with_path('matches', '^/api/.*')
+
+        local context = {
+          request = { get_uri = function() return '/api/users' end }
+        }
+
+        assert.is_true(operation:evaluate(context))
+      end)
+
+      it('evaluates matches false when regex does not match', function()
+        local operation = RoutingOperation.new_op_with_path('matches', '^/api/.*')
+
+        local context = {
+          request = { get_uri = function() return '/other/path' end }
+        }
+
+        assert.is_false(operation:evaluate(context))
+      end)
     end)
 
     describe('when the operation involves a header', function()
@@ -234,6 +274,12 @@ describe('RoutingOperation', function()
         assert.is_false(operation:evaluate({}))
       end)
 
+    end)
+
+    it('raises an error for unsupported operators', function()
+      assert.has_error(function()
+        RoutingOperation.new_op_with_path('unsupported_op', '/path')
+      end)
     end)
 
     it('can evaluate the right operand as liquid', function()

--- a/spec/policy/routing/routing_spec.lua
+++ b/spec/policy/routing/routing_spec.lua
@@ -2,8 +2,67 @@ local RoutingPolicy = require('apicast.policy.routing')
 local UpstreamSelector = require('apicast.policy.routing.upstream_selector')
 local Request = require('apicast.policy.routing.request')
 local Upstream = require('apicast.upstream')
+local mapping_rules_matcher = require('apicast.mapping_rules_matcher')
 
 describe('Routing policy', function()
+  describe('.access', function()
+    it('assigns route_upstream_usage_cleanup to the context', function()
+      local routing = RoutingPolicy.new()
+      local context = {}
+      routing:access(context)
+
+      assert.is_function(context.route_upstream_usage_cleanup)
+    end)
+
+    it('assigns the same function reference on every call', function()
+      local routing = RoutingPolicy.new()
+      local ctx1 = {}
+      local ctx2 = {}
+      routing:access(ctx1)
+      routing:access(ctx2)
+
+      assert.equals(ctx1.route_upstream_usage_cleanup, ctx2.route_upstream_usage_cleanup)
+    end)
+  end)
+
+  describe('route_upstream_usage_cleanup', function()
+    it('is a no-op when route_upstream is nil', function()
+      local routing = RoutingPolicy.new()
+      local context = {}
+      routing:access(context)
+
+      assert.has_no_errors(function()
+        context:route_upstream_usage_cleanup({}, {})
+      end)
+    end)
+
+    it('calls clean_usage_by_owner_id and merges usage when route_upstream exists', function()
+      local routing = RoutingPolicy.new()
+      local context = {}
+      routing:access(context)
+
+      local mock_owner_id = 42
+      context.route_upstream = {
+        has_owner_id = function() return mock_owner_id end,
+      }
+
+      local usage_diff = { some_metric = 1 }
+      stub(mapping_rules_matcher, 'clean_usage_by_owner_id').returns(usage_diff)
+
+      local usage = { merge = function() end }
+      stub(usage, 'merge')
+
+      local matched_rules = { 'rule1', 'rule2' }
+
+      context:route_upstream_usage_cleanup(usage, matched_rules)
+
+      assert.stub(mapping_rules_matcher.clean_usage_by_owner_id).was_called_with(
+        matched_rules, mock_owner_id
+      )
+      assert.stub(usage.merge).was_called_with(usage, usage_diff)
+    end)
+  end)
+
   describe('.content', function()
     describe('when there is an upstream that matches', function()
       local upstream_that_matches = Upstream.new('http://localhost')


### PR DESCRIPTION
## What

Performance refactor to avoid unnecessary allocation per request.

### Perf scripts

<details>

```lua
local root = require('pl.path').currentdir()
package.path = root .. '/?.lua;' ..
               root .. '/gateway/src/?.lua;' ..
               root .. '/gateway/src/apicast/policy/3scale_batcher/?.lua;' ..
               package.path

local ipairs = ipairs
local setmetatable = setmetatable
local match = ngx.re.match
local tostring = tostring

-- Stub ngx.var and ngx.req APIs unavailable outside request context.
-- Liquid template render() calls ngx_variable.available_context() which
-- accesses ngx.var.uri, ngx.req.get_headers(), etc. These must be stubbed
-- before any module that uses them is loaded.
ngx.var = {
  uri = '/api/v1/users',
  path = '/api/v1/users',
  host = 'localhost',
  remote_addr = '127.0.0.1',
  remote_port = '12345',
  scheme = 'http',
  server_addr = '127.0.0.1',
  server_port = '8080',
  request_id = '0',
}

local stub_headers = { ["Content-Type"] = "application/json" }
ngx.req.get_headers = function() return stub_headers end
ngx.req.get_method = function() return "GET" end

local Condition = require('apicast.conditions.condition')
local Operation = require('apicast.conditions.operation')
local TemplateString = require('apicast.template_string')

require('resty.core')
require('benchmark.ips')(function(b)
  b.time = 5
  b.warmup = 2

  -- -------------------------------------------------------
  -- 1. Operation.new per-request vs pre-resolved compare
  -- -------------------------------------------------------

  -- Current: creates Operation.new inside evaluate (per-request)
  local function evaluate_current(left_val, op_str, right_val, right_type, context)
    local op = Operation.new(left_val, 'plain', op_str, right_val, right_type)
    return op:evaluate(context)
  end

  -- Optimized: pre-resolve right template + compare func at init
  local compare_funcs = {
    ['=='] = function(l, r) return tostring(l) == tostring(r) end,
    ['!='] = function(l, r) return tostring(l) ~= tostring(r) end,
    ['matches'] = function(l, r) return (match(tostring(l), tostring(r)) and true) or false end,
  }

  local function make_pre_resolved(op_str, right_val, right_type)
    local right_tpl = TemplateString.new(right_val, right_type or 'plain')
    local cmp = compare_funcs[op_str]
    return function(left_val, context)
      return cmp(left_val, right_tpl:render(context))
    end
  end

  local ctx = {}
  local pre_resolved_eq = make_pre_resolved('==', '/api/v1', 'plain')
  local pre_resolved_match = make_pre_resolved('matches', [[^/api/v\d+]], 'plain')

  b:report('Operation.new per-request (==)', function()
    return evaluate_current('/api/v1', '==', '/api/v1', 'plain', ctx)
  end)

  b:report('pre-resolved compare (==)', function()
    return pre_resolved_eq('/api/v1', ctx)
  end)

  b:report('Operation.new per-request (matches)', function()
    return evaluate_current('/api/v1', 'matches', [[^/api/v\d+]], 'plain', ctx)
  end)

  b:report('pre-resolved compare (matches)', function()
    return pre_resolved_match('/api/v1', ctx)
  end)

  b:compare()

  -- -------------------------------------------------------
  -- 2. TemplateString.new per-request vs cached template
  -- -------------------------------------------------------

  print("\n--- liquid template: parse+render vs cached render ---")

  local liquid_expr = "{{uri}}"
  local liquid_ctx = { uri = "/api/v1/users" }

  -- Current: parse + render every request
  local function liquid_parse_and_render(expr, context)
    return TemplateString.new(expr, "liquid"):render(context)
  end

  -- Optimized: parse once, render per request
  local cached_template = TemplateString.new(liquid_expr, "liquid")
  local function liquid_cached_render(tpl, context)
    return tpl:render(context)
  end

  -- Baseline: plain template (no liquid parsing)
  local plain_template = TemplateString.new("/api/v1/users", "plain")
  local function plain_render(tpl)
    return tpl:render()
  end

  b:report('liquid: parse+render (per-request)', function()
    return liquid_parse_and_render(liquid_expr, liquid_ctx)
  end)

  b:report('liquid: cached render', function()
    return liquid_cached_render(cached_template, liquid_ctx)
  end)

  b:report('plain: render (baseline)', function()
    return plain_render(plain_template)
  end)

  b:compare()

  -- -------------------------------------------------------
  -- 2. Closure allocation: per-request vs module-level func
  -- -------------------------------------------------------

  print("\n--- closure vs module-level function ---")

  local dummy_usage = {
    merge = function() end,
  }

  local dummy_matched_rules = {}

  -- Current: closure created per request
  local function closure_alloc(context)
    context.cleanup = function(self, usage, matched_rules)
      if not self.route_upstream then return end
      local _ = matched_rules
      usage:merge()
    end
  end

  -- Optimized: module-level function assigned once
  local function module_level_cleanup(self, usage, matched_rules)
    if not self.route_upstream then return end
    local _ = matched_rules
    usage:merge()
  end

  local function module_func(context)
    context.cleanup = module_level_cleanup
  end

  local closure_ctx = { route_upstream = nil }

  b:report('per-request closure alloc', function()
    closure_alloc(closure_ctx)
    return closure_ctx.cleanup(closure_ctx, dummy_usage, dummy_matched_rules)
  end)

  b:report('module-level function ref', function()
    module_func(closure_ctx)
    return closure_ctx.cleanup(closure_ctx, dummy_usage, dummy_matched_rules)
  end)

  b:compare()
end)

```

</details>

### Perf results

```shell
Warming up --------------------------------------
Operation.new per-request (==)

    920530 i/100ms

pre-resolved compare (==)

   3716779 i/100ms

Operation.new per-request (matches)

    120903 i/100ms

pre-resolved compare (matches)

    138079 i/100ms

liquid: parse+render (per-request)

     16728 i/100ms

liquid: cached render

     69192 i/100ms

plain: render (baseline)

    216056 i/100ms

per-request closure alloc

    195534 i/100ms

module-level function ref

    219908 i/100ms

Calculating -------------------------------------
                     Operation.new per-request (==) 11268321.1 (±0.6%) i/s -   57072860 in   5.065098s
                          pre-resolved compare (==) 83650585.7 (±1.0%) i/s -  419996027 in   5.021378s
                Operation.new per-request (matches)  1174708.5 (±2.6%) i/s -    5924247 in   5.046572s
                    pre-resolved compare (matches)  1223650.6 (±13.3%) i/s -    6075476 in   5.051734s
                 liquid: parse+render (per-request)   142548.8 (±4.3%) i/s -     719304 in   5.056303s
                              liquid: cached render   588118.2 (±6.8%) i/s -    2975256 in   5.084045s
                           plain: render (baseline) 77910469.3 (±3.0%) i/s -  389332912 in   5.001722s
                          per-request closure alloc 18210146.5 (±3.6%) i/s -   91118844 in   5.010522s
                          module-level function ref 87281446.6 (±1.8%) i/s -  436297472 in   5.000413s

```

### Conclusion
* Pre-allocate template string is about 8 times faster than allocate it per request
* Matches operation is slow
* Liquid render is a lot slower than plain string render