### PR TITLE
THREESCALE-10151 fix proxy policy doesn't send headers set by APIcast to the API Backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Correct FAPI header to `x-fapi-interaction-id` [PR #1557](https://github.com/3scale/APIcast/pull/1557) [THREESCALE-11957](https://issues.redhat.com/browse/THREESCALE-11957)
 - Only validate oidc setting if authentication method is set to oidc [PR #1568](https://github.com/3scale/APIcast/pull/1568) [THREESCALE-11441](https://issues.redhat.com/browse/THREESCALE-11441)
 - Reduce memory consumption when returning large response that has been routed through a proxy server. [PR #1572](https://github.com/3scale/APIcast/pull/1572) [THREESCALE-12258](https://issues.redhat.com/browse/THREESCALE-12258)
+- Fix proxy policy doesn't send headers set by APIcast to the API Backend. [PR #1588](https://github.com/3scale/APIcast/pull/1588) [THREESCALE-10151](https://redhat.atlassian.net/browse/THREESCALE-10151)
 
 ### Added
 - Update APIcast schema manifest [PR #1550](https://github.com/3scale/APIcast/pull/1550)

--- a/gateway/src/apicast/http_proxy.lua
+++ b/gateway/src/apicast/http_proxy.lua
@@ -138,10 +138,15 @@ local function forward_https_request(proxy_uri, uri, proxy_opts)
       end
     end
 
+    local headers = ngx_req_get_headers(0, true)
+    headers["X-Real-IP"] = ngx.var.remote_addr
+    headers["X-3scale-debug"] = nil
+    headers["X-3scale-proxy-secret-token"] = ngx.var.secret_token
+
     local request = {
         uri = uri,
         method = req_method,
-        headers = ngx_req_get_headers(0, true),
+        headers = headers,
         path = (ngx.var.uri or '') .. (ngx.var.is_args or '') .. (ngx.var.query_string or ''),
         body = body,
         proxy_uri = proxy_uri,

--- a/t/apicast-policy-camel.t
+++ b/t/apicast-policy-camel.t
@@ -12,6 +12,7 @@ sub large_body {
 }
 
 $ENV{'LARGE_BODY'} = large_body();
+require("policies.pl");
 
 repeat_each(1);
 
@@ -139,7 +140,10 @@ $Test::Nginx::Util::ENDPOINT_SSL_PORT = Test::APIcast::get_random_port();
   "services": [
     {
       "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
       "proxy": {
+        "secret_token": "token",
         "api_backend": "https://localhost:$Test::Nginx::Util::ENDPOINT_SSL_PORT",
         "proxy_rules": [
           { "pattern": "/test", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
@@ -177,17 +181,19 @@ EOF
   server_name _ default_server;
 
   location /test {
+    echo_foreach_split '\r\n' \$echo_client_request_headers;
+    echo \$echo_it;
+    echo_end;
     access_by_lua_block {
       assert = require('luassert')
       assert.equal('https', ngx.var.scheme)
       assert.equal('$Test::Nginx::Util::ENDPOINT_SSL_PORT', ngx.var.server_port)
       assert.equal('localhost', ngx.var.ssl_server_name)
       assert.equal(ngx.var.request_uri, '/test?user_key=test3')
+      assert.is_nil(ngx.var.http_x_3scale_debug)
 
       local host = ngx.req.get_headers()["Host"]
       assert.equal(host, 'localhost:$Test::Nginx::Util::ENDPOINT_SSL_PORT')
-      ngx.say("yay, endpoint backend")
-
     }
   }
 }
@@ -211,6 +217,17 @@ GET /test?user_key=test3
 --- more_headers
 User-Agent: Test::APIcast::Blackbox
 ETag: foobar
+X-3scale-debug: token-value
+--- expected_response_body_like_multiple eval
+[[
+    qr{GET \/test\?user_key=test3 HTTP\/1\.1},
+    qr{ETag\: foobar},
+    qr{Connection\: close},
+    qr{User\-Agent\: Test\:\:APIcast\:\:Blackbox},
+    qr{Host\: localhost\:\d+},
+    qr{X\-Real\-IP\: 127.0.0.1},
+    qr{X\-3scale\-proxy\-secret\-token\: token}
+]]
 --- error_code: 200
 --- user_files fixture=tls.pl eval
 --- error_log eval

--- a/t/apicast-policy-http-proxy.t
+++ b/t/apicast-policy-http-proxy.t
@@ -13,6 +13,7 @@ sub large_body {
 
 
 $ENV{'LARGE_BODY'} = large_body();
+require("policies.pl");
 
 repeat_each(3);
 
@@ -137,7 +138,10 @@ using proxy: $TEST_NGINX_HTTP_PROXY
   "services": [
     {
       "backend_version":  1,
+      "backend_authentication_type": "service_token",
+      "backend_authentication_value": "token-value",
       "proxy": {
+        "secret_token": "token",
         "api_backend": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT",
         "proxy_rules": [
           { "pattern": "/test", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
@@ -180,6 +184,7 @@ location /test {
       assert.equal('https', ngx.var.scheme)
       assert.equal('$TEST_NGINX_RANDOM_PORT', ngx.var.server_port)
       assert.equal('test-upstream.lvh.me', ngx.var.ssl_server_name)
+      assert.is_nil(ngx.var.http_x_3scale_debug)
 
       local host = ngx.req.get_headers()["Host"]
       local result = string.match(host, "^test%-upstream%.lvh%.me:")
@@ -191,13 +196,16 @@ GET /test?user_key=test3
 --- more_headers
 User-Agent: Test::APIcast::Blackbox
 ETag: foobar
+X-3scale-debug: token-value
 --- expected_response_body_like_multiple eval
 [[
     qr{GET \/test\?user_key=test3 HTTP\/1\.1},
     qr{ETag\: foobar},
     qr{Connection\: close},
     qr{User\-Agent\: Test\:\:APIcast\:\:Blackbox},
-    qr{Host\: test-upstream.lvh.me\:\d+}
+    qr{Host\: test-upstream.lvh.me\:\d+},
+    qr{X\-Real\-IP\: 127.0.0.1},
+    qr{X\-3scale\-proxy\-secret\-token\: token},
 ]]
 --- error_code: 200
 --- error_log env

--- a/t/http-proxy.t
+++ b/t/http-proxy.t
@@ -451,6 +451,9 @@ proxy request: GET http://test-upstream.lvh.me:$TEST_NGINX_SERVER_PORT/test?user
     {
       "backend_version":  1,
       "proxy": {
+        "secret_token": "token",
+        "backend_authentication_type": "service_token",
+        "backend_authentication_value": "token-value",
         "api_backend": "https://test-upstream.lvh.me:$TEST_NGINX_RANDOM_PORT",
         "proxy_rules": [
           { "pattern": "/test", "http_method": "GET", "metric_system_name": "hits", "delta": 2 }
@@ -482,6 +485,7 @@ location /test {
        assert.equal('https', ngx.var.scheme)
        assert.equal('$TEST_NGINX_RANDOM_PORT', ngx.var.server_port)
        assert.equal('test-upstream.lvh.me', ngx.var.ssl_server_name)
+       assert.is_nil(ngx.var.http_x_3scale_debug)
     }
 }
 --- request
@@ -489,13 +493,16 @@ GET /test?user_key=test3
 --- more_headers
 User-Agent: Test::APIcast::Blackbox
 ETag: foobar
+X-3scale-debug: token-value
 --- expected_response_body_like_multiple eval
 [[
     qr{GET \/test\?user_key=test3 HTTP\/1\.1},
     qr{ETag\: foobar},
     qr{Connection\: close},
     qr{User\-Agent\: Test\:\:APIcast\:\:Blackbox},
-    qr{Host\: test-upstream.lvh.me\:\d+}
+    qr{Host\: test-upstream.lvh.me\:\d+},
+    qr{X\-Real\-IP\: 127.0.0.1},
+    qr{X\-3scale\-proxy\-secret\-token\: token}
 ]]
 --- error_code: 200
 --- error_log env


### PR DESCRIPTION
## What 

Fix https://redhat.atlassian.net/browse/THREESCALE-10151

## Verification steps:
* Checkout this branch
* Build new runtime-image
```
make runtime-image IMAGE_NAME=apicast-test
```
* Get inside dev-envinroment 
```
cd dev-environments/https-proxy-upstream-tlsv1.3/
```
* Update apicast-config.json as follow
```diff
diff --git a/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json b/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json
index 5227c5aa..bf662f8a 100644
--- a/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json
+++ b/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json
@@ -4,6 +4,7 @@
       "id": "1",
       "backend_version": "1",
       "proxy": {
+        "secret_token": "token",
         "hosts": ["get.example.com"],
         "api_backend": "https://example.com/get",
         "backend": {
```
* Start the gateway
```
make gateway IMAGE_NAME=apicast-test
```
* Send a request
```
curl --resolve get.example.com:8080:127.0.0.1 -v "http://get.example.com:8080/?user_key=123"
```
* You should see the secret token in the response
```shell
* Request completely sent off
< HTTP/1.1 200 OK
< Content-Type: application/json
< Transfer-Encoding: chunked
< Connection: keep-alive
< Date: Mon, 08 Jun 2026 03:19:35 GMT
< Server: WEBrick/1.6.1 (Ruby/2.7.4/2021-07-07)
<
{
  "method": "GET",
  "path": "/get",
  "query_string": "user_key=123",
  "body": "",
  "headers": {
    "X-3scale-Proxy-Secret-Token": "token",
    "User-Agent": "curl/8.15.0",
    "X-3scale-Debug": "",
    "Accept": "*/*",
    "Host": "example.com",
    "X-Real-Ip": "172.20.0.1",
    "Version": "HTTP/1.1"
  },
  "uuid": "c199b276-0856-4929-a0f4-3766d8c97b3b"
```