### PR TITLE
THREESCALE-15465 refactor: use new cpu.requests formula from Kubernetes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Reduce memory consumption when returning large response that has been routed through a proxy server. [PR #1572](https://github.com/3scale/APIcast/pull/1572) [THREESCALE-12258](https://issues.redhat.com/browse/THREESCALE-12258)
 - Fix proxy policy doesn't send headers set by APIcast to the API Backend. [PR #1588](https://github.com/3scale/APIcast/pull/1588) [THREESCALE-10151](https://redhat.atlassian.net/browse/THREESCALE-10151)
 - Ensure the synchronization key is released correctly. [PR #1591](https://github.com/3scale/APIcast/pull/1590)
+- Use new cpu.requests formula from Kubernetes. [PR #1595](https://github.com/3scale/APIcast/pull/1595) [THREESCALE-15465](https://redhat.atlassian.net/browse/THREESCALE-15465)
 
 ### Added
 - Update APIcast schema manifest [PR #1550](https://github.com/3scale/APIcast/pull/1550)

--- a/gateway/src/apicast/cli/environment.lua
+++ b/gateway/src/apicast/cli/environment.lua
@@ -60,7 +60,24 @@ local function cpu_shares()
       local weight = file:read('*n')
       file:close()
 
-      shares = (((weight - 1) * 262142) / 9999) + 2
+    -- Recent version of runc/crun change the formula to calculate CPU weight
+    -- https://github.com/kubernetes/website/blob/main/content/en/blog/_posts/2026-01-30-new-cgroup-v1-to-v2-conversion-formula/index.md#new-conversion-formula
+    -- Old formula:
+    --     cpu.weight = (1 + ((cpu.shares - 2) * 9999) / 262142)
+    --
+    -- New formula:
+    --     cpu.weight = ⌈ 10 ^ (L^2 / 612 + 125 * L / 612 − 7 / 34)
+    -- where: L=log2⁡(cpu.shares) (Please verify this with the code)
+    --
+    -- So now we need to calculate CPU shares as follow:
+    -- cpu.shares = 2^L
+    -- L = (sqrt(16129 + 2448 * log10(cpu.weight)) - 125) / 2
+    local a = math.log(weight, 10)
+    local b = 2448 * a
+    local c = 16129 + b
+    local d = math.sqrt(c)
+    local l = (d - 125)/2
+    shares = math.ceil(2^l)
     end
   else
     -- Cgroups v1


### PR DESCRIPTION
## What

https://redhat.atlassian.net/browse/THREESCALE-15465

Recently reported by support team that APIcast run with a wrong number of workers. From this blog [New Conversion from cgroup v1 CPU Shares to v2 CPU Weight](https://github.com/kubernetes/website/blob/main/content/en/blog/_posts/2026-01-30-new-cgroup-v1-to-v2-conversion-formula/index.md) the formula to calculate cpu.weight has been changed in the recent version of runc/crun
* Old formula: `cpu.weight = (1 + ((cpu.shares - 2) * 9999) / 262142)`
* New formula: `cpu.weight = 10 ^ (L^2 / 612 + 125 * L / 612 − 7 / 34)`, where: L=log2⁡(cpu.shares)
    
### Required Code Change
The implementation in [cpu_shares](https://github.com/3scale/APIcast/blob/master/gateway/src/apicast/cli/environment.lua#L47) should be updated to use the new conversion formula. This change is required to ensure that requested CPU values are computed correctly when running on cgroup v2.

### Impact
You can use this playground to play with different values.
https://go.dev/play/p/EIFB4_Ia4ae

<p>2.16</p>

CPU shares | cpu.weight (old formula) | cpu.weight (new formula) | APIcast workers count (with old container runtime) | APIcast workers count (with new container runtime)
-- | -- | -- | -- | --
100mil | 4 | 17 | 1 | 1
500mil | 19 | 58 | 1 | 2
1 | 39 | 99 | 1 | 3
2 | 77 | 170 | 2 | 5
4 | 153 | 297 | 4 | 8
8 | 306 | 522 | 8 | 14
16 | 611 | 924 | 16 | 24

<p>master</p>

CPU shares | cpu.weight (old formula) | cpu.weight (new formula) | APIcast workers count (with old container runtime) | APIcast workers count (with new container runtime)
-- | -- | -- | -- | --
100mil | 4 | 17 | 1 | 1
500mil | 19 | 58 | 1 | 1
1 | 39 | 99 | 1 | 1
2 | 77 | 170 | 1 | 2
4 | 153 | 297 | 2 | 4
8 | 306 | 522 | 5 | 8
16 | 611 | 924 | 10 | 16

With this change, the APIcast will run with less workers on older cluster with older version of container runtime. However, when I check, the container runtime does not seems to be tied to a specific version major of OCP and make it hard to adjust these value during runtime. 
For example:
* OCP 4.18.45 -> crun (1.26)
* OCP 4.20.14  -> crun (1.23.1)

In my opinion, the best is to apply this change to the master branch, then flag it in the release log to mark it as a breaking change.

## Verification steps
You will need a cluster with new version of runc/crun, I tried with Docker but it just does not handle cpu.weight the way that I wanted.  I'm using 4.20.27 in this case

* Check runc/crun version
```
 ▲ ~ oc get nodes -o wide
NAME                                         STATUS   ROLES                  AGE
ip-10-0-122-131.us-west-1.compute.internal   Ready    worker                 5
...

 △ ~ oc debug node/ip-10-0-122-131.us-west-1.compute.internal -- chroot /host crun --version
Temporary namespace openshift-debug-bwvqd is created for debugging node...
Starting pod/ip-10-0-122-131us-west-1computeinternal-debug-sb8zg ...
To use host binaries, run `chroot /host`
crun version 1.27
commit: a718a92cc9a94955a5a550b6fdec1378c247ec50
rundir: /run/crun
spec: 1.0.0
+SYSTEMD +SELINUX +APPARMOR +CAP +SECCOMP +EBPF +CRIU +YAJL
```

* Setup APIcast 
```
export NAMESPACE=apicast-test
oc new-project $NAMESPACE

cat << EOF | oc create -f -
apiVersion: v1
kind: Secret
metadata:
  name: apicast-config-secret
  namespace: $NAMESPACE
type: Opaque
stringData:
  config.json: |
    {
      "services": [
        {
          "proxy": {
            "policy_chain": [
              { "name": "apicast.policy.upstream",
                "configuration": {
                  "rules": [{
                    "regex": "/",
                    "url": "http://echo-api.3scale.net"
                  }]
                }
              }
            ]
          }
        }
      ]
    }
EOF
```
* Install APIcast operator from the catalog
* Create APIcast CR
```
cat << EOF | oc create -f -
apiVersion: apps.3scale.net/v1alpha1
kind: APIcast
metadata:
  name: example-apicast
  namespace: $NAMESPACE
spec:
  embeddedConfigurationSecretRef:
    name: apicast-config-secret
EOF
```
* One the pod is ready, jump inside and run the following
```
sh-4.4$ curl localhost:9421/metrics
...
# TYPE worker_process counter
worker_process{} 2

sh-4.4$ cat /sys/fs/cgroup/cpu.weight
59
```
By default, APIcast is setup with the following
```
- resources:
        limits:
          cpu: '1'
          memory: 128Mi
        requests:
          cpu: 500m
          memory: 64Mi
```
Cross check with the table above, we can see `2 workers` here for `500m` of cpu shares.

* Update APIcast CR with new image
```
spec:
  embeddedConfigurationSecretRef:
    name: apicast-config-secret
  image: 'quay.io/an_tran/apicast:cpus-share'
```
* Wait for the pod to ready
* Run the command again, you should see 1 worker this time
```
sh-5.1$ curl localhost:9421/metrics
...
# TYPE worker_process counter
worker_process{} 1
```