### PR TITLE
refactor(http): unify timeouts options across http client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Ensure the synchronization key is released correctly. [PR #1591](https://github.com/3scale/APIcast/pull/1590)
 - Use new cpu.requests formula from Kubernetes. [PR #1595](https://github.com/3scale/APIcast/pull/1595) [THREESCALE-15465](https://redhat.atlassian.net/browse/THREESCALE-15465)
 - Fix batcher policy fails silently when configured with string values instead of integers. [PR #1597](https://github.com/3scale/APIcast/pull/1597) [THREESCALE-15547](https://redhat.atlassian.net/browse/THREESCALE-15547)
+- Unify timeout options between http clients library [PR #1600](https://github.com/3scale/APIcast/pull/1600)
 
 ### Added
 - Update APIcast schema manifest [PR #1550](https://github.com/3scale/APIcast/pull/1550)

--- a/gateway/src/apicast/http_proxy.lua
+++ b/gateway/src/apicast/http_proxy.lua
@@ -1,4 +1,3 @@
-local format = string.format
 local tostring = tostring
 local ngx = ngx
 local ngx_get_method = ngx.req.get_method
@@ -150,6 +149,7 @@ local function forward_https_request(proxy_uri, uri, proxy_opts)
         path = (ngx.var.uri or '') .. (ngx.var.is_args or '') .. (ngx.var.query_string or ''),
         body = body,
         proxy_uri = proxy_uri,
+        timeout = opts.upstream_connection_opts,  -- Extract timeouts to top level
         proxy_options = opts
     }
 

--- a/gateway/src/resty/http/proxy.lua
+++ b/gateway/src/resty/http/proxy.lua
@@ -32,21 +32,23 @@ end
 local function connect(request)
     request = request or { }
     local httpc = http.new()
-    local proxy_options = request.proxy_options or {}
 
-    if proxy_options.upstream_connection_opts then
-      local con_opts = request.proxy_options.upstream_connection_opts
-      ngx.log(ngx.DEBUG, 'setting timeouts (secs), connect_timeout: ', con_opts.connect_timeout,
-        ' send_timeout: ', con_opts.send_timeout, ' read_timeout: ', con_opts.read_timeout)
-      -- lua-resty-http uses nginx API for lua sockets
-      -- in milliseconds
+    local timeout = request.timeout or (request.options and request.options.timeout)
+    if type(timeout) == 'number' then
+      httpc:set_timeout(timeout*1000)
+    elseif type(timeout) == 'table' then
+      ngx.log(ngx.DEBUG, 'setting timeouts (secs), connect: ', timeout.connect_timeout,
+        ' send: ', timeout.send_timeout, ' read: ', timeout.read_timeout)
+      -- lua-resty-http uses nginx API for lua sockets in milliseconds
       -- https://github.com/openresty/lua-nginx-module?tab=readme-ov-file#tcpsocksettimeouts
-      local connect_timeout = con_opts.connect_timeout and con_opts.connect_timeout * 1000
-      local send_timeout = con_opts.send_timeout and con_opts.send_timeout * 1000
-      local read_timeout = con_opts.read_timeout and con_opts.read_timeout * 1000
+      local connect_timeout = timeout.connect_timeout and timeout.connect_timeout * 1000
+      local send_timeout = timeout.send_timeout and timeout.send_timeout * 1000
+      local read_timeout = timeout.read_timeout and timeout.read_timeout * 1000
+
       httpc:set_timeouts(connect_timeout, send_timeout, read_timeout)
     end
 
+    local proxy_options = request.proxy_options or {}
     local proxy_uri = find_proxy_url(request)
     local uri = request.uri
     local scheme = uri.scheme

--- a/gateway/src/resty/http_ng/backend/async_resty.lua
+++ b/gateway/src/resty/http_ng/backend/async_resty.lua
@@ -34,9 +34,9 @@ _M.async = function(request)
   if type(timeout) == 'number' then
     httpc:set_timeout(timeout)
   elseif type(timeout) == 'table' then
-    local connect_timeout = timeout.connect
-    local send_timeout = timeout.send
-    local read_timeout = timeout.read
+    local connect_timeout = timeout.connect_timeout
+    local send_timeout = timeout.send_timeout
+    local read_timeout = timeout.read_timeout
 
     if httpc.set_timeouts then -- lua-resty-http >= 0.10
       httpc:set_timeouts(connect_timeout, send_timeout, read_timeout)

--- a/spec/http_proxy_spec.lua
+++ b/spec/http_proxy_spec.lua
@@ -9,6 +9,8 @@ describe('http_proxy', function()
       stub(ngx.req, 'get_method', function() return 'GET' end)
     end
 
+    local captured_request = nil
+
     local function stub_resty_http_proxy()
       local httpc = {
       }
@@ -19,7 +21,10 @@ describe('http_proxy', function()
       stub(httpc, 'set_keepalive')
 
       local resty_http_proxy = require 'resty.http.proxy'
-      stub(resty_http_proxy, 'new', function() return httpc end)
+      stub(resty_http_proxy, 'new', function(request)
+        captured_request = request
+        return httpc
+      end)
       local http_writer = require 'resty.http.response_writer'
       stub(http_writer, 'proxy_response')
     end
@@ -48,6 +53,70 @@ describe('http_proxy', function()
         local http_proxy = require('apicast.http_proxy')
         http_proxy.request(upstream, proxy_uri)
         assert.spy(ngx.exit).was_called_with(ngx.OK)
+      end)
+
+      it('handles nil upstream_connection_opts gracefully', function()
+        captured_request = nil  -- Reset captured request
+
+        local upstream = {
+          uri = {
+            scheme = 'https',
+            host = 'api.example.com'
+          },
+          request_unbuffered = false,
+          skip_https_connect = false,
+          upstream_connection_opts = nil,  -- No timeouts configured
+          rewrite_request = function() end
+        }
+
+        local http_proxy = require('apicast.http_proxy')
+        http_proxy.request(upstream, proxy_uri)
+
+        -- Verify resty.http.proxy.new was called with a request
+        assert.is_not_nil(captured_request, 'proxy.new should have been called')
+
+        -- timeouts should be nil when upstream_connection_opts is nil
+        assert.is_nil(captured_request.timeout, 'request.timeout should be nil when not configured')
+      end)
+
+      it('passes timeouts to proxy.new at top level', function()
+        captured_request = nil  -- Reset captured request
+
+        local upstream = {
+          uri = {
+            scheme = 'https',
+            host = 'api.example.com',
+            path = '/v1/endpoint'
+          },
+          request_unbuffered = false,
+          skip_https_connect = false,
+          upstream_connection_opts = {
+            connect_timeout = 5,
+            send_timeout = 10,
+            read_timeout = 30
+          },
+          rewrite_request = function() end
+        }
+
+        local http_proxy = require('apicast.http_proxy')
+        http_proxy.request(upstream, proxy_uri)
+
+        -- Verify resty.http.proxy.new was called
+        assert.is_not_nil(captured_request, 'proxy.new should have been called')
+
+        -- Verify that timeouts were extracted to top level
+        assert.is_not_nil(captured_request.timeout, 'request.timeout should not be nil')
+        assert.same({
+          connect_timeout = 5,
+          send_timeout = 10,
+          read_timeout = 30
+        }, captured_request.timeout, 'timeout should be extracted from upstream_connection_opts')
+
+        -- Verify proxy_options still contains the original structure
+        assert.is_not_nil(captured_request.proxy_options)
+        assert.same(upstream.upstream_connection_opts,
+                    captured_request.proxy_options.upstream_connection_opts,
+                    'proxy_options should still contain upstream_connection_opts')
       end)
     end)
   end)

--- a/spec/resty/http/proxy_spec.lua
+++ b/spec/resty/http/proxy_spec.lua
@@ -65,7 +65,7 @@ describe('resty.http.proxy', function()
           local request = {
             url = 'http://upstream:8091/request',
             method = 'GET',
-            upstream_connection_opts = {
+            timeout = {
               connect_timeout = 1,
               send_timeout = 1,
               read_timeout = 1
@@ -78,6 +78,122 @@ describe('resty.http.proxy', function()
 
           assert.same(200, res.status)
           assert.match('GET http://upstream:8091/request HTTP/1.1', res:read_body())
+      end)
+    end)
+
+    context('.timeout', function()
+      before_each(function()
+        _M:reset({ http_proxy = 'http://127.0.0.1:1984' })
+      end)
+
+      describe('timeout field names', function()
+          local http, httpc_mock, set_timeouts_spy
+
+          -- Helper function to create mock httpc with spy
+          local function create_httpc_mock()
+              return {
+                  set_timeouts = function() end,
+                  connect = function() return true end,
+                  request = function() return { status = 200, read_body = function() return 'ok' end } end,
+                  close = function() end,
+                  set_keepalive = function() end,
+                  pool = 'test',
+                  get_reused_times = function() return 0 end,
+                  host = 'example.com',
+                  port = 443
+              }
+          end
+
+          before_each(function()
+              http = require('resty.resolver.http')
+              httpc_mock = create_httpc_mock()
+              set_timeouts_spy = spy.new(function() end)
+              httpc_mock.set_timeouts = set_timeouts_spy
+              stub(http, 'new', function() return httpc_mock end)
+          end)
+
+          it('should accept timeouts with connect_timeout, send_timeout, read_timeout fields', function()
+              -- This test verifies the actual structure passed from http_proxy.lua
+              local request = {
+                  url = 'http://upstream:8091/request',
+                  method = 'GET',
+                  -- This mimics the actual structure from http_proxy.lua:152
+                  -- timeouts = opts.upstream_connection_opts
+                  timeout = {
+                      connect_timeout = 1,
+                      send_timeout = 2,
+                      read_timeout = 3
+                  }
+              }
+
+              local proxy = assert(_M.new(request))
+
+              -- Verify set_timeouts was called with milliseconds (timeout * 1000)
+              assert.spy(set_timeouts_spy).was_called()
+              assert.spy(set_timeouts_spy).was_called_with(
+                  match.is_table(),  -- self (httpc)
+                  1000,  -- connect_timeout: 1 sec -> 1000 ms
+                  2000,  -- send_timeout: 2 sec -> 2000 ms
+                  3000   -- read_timeout: 3 sec -> 3000 ms
+              )
+          end)
+
+          it('should handle nil timeout values', function()
+              local request = {
+                  url = 'http://upstream:8091/request',
+                  method = 'GET',
+                  timeout = {
+                      connect_timeout = 1,
+                      send_timeout = nil,  -- nil timeout should be handled
+                      read_timeout = 3
+                  }
+              }
+
+              assert(_M.new(request))
+
+              -- Verify set_timeouts handles nil correctly
+              assert.spy(set_timeouts_spy).was_called()
+              assert.spy(set_timeouts_spy).was_called_with(
+                  match.is_table(),
+                  1000,
+                  nil,   -- send_timeout is nil
+                  3000
+              )
+          end)
+
+          it('should skip timeout setting when timeouts is nil', function()
+              local request = {
+                  url = 'http://upstream:8091/request',
+                  method = 'GET',
+                  timeout = nil  -- No timeouts specified
+              }
+
+              assert(_M.new(request))
+
+              -- set_timeouts should NOT be called when timeouts is nil
+              assert.spy(set_timeouts_spy).was_not_called()
+          end)
+
+          it('should convert seconds to milliseconds correctly', function()
+              local request = {
+                  url = 'http://upstream:8091/request',
+                  method = 'GET',
+                  timeout = {
+                      connect_timeout = 0.5,   -- 500ms
+                      send_timeout = 1.5,      -- 1500ms
+                      read_timeout = 10        -- 10000ms
+                  }
+              }
+
+              assert(_M.new(request))
+
+              assert.spy(set_timeouts_spy).was_called_with(
+                  match.is_table(),
+                  500,    -- 0.5 * 1000
+                  1500,   -- 1.5 * 1000
+                  10000   -- 10 * 1000
+              )
+          end)
       end)
     end)
 end)

--- a/spec/resty/http_ng/backend/async_resty_spec.lua
+++ b/spec/resty/http_ng/backend/async_resty_spec.lua
@@ -31,7 +31,7 @@ describe('resty backend', function()
     end)
 
     it('returns proper error on connect timeout', function()
-      local req = { method = method, url = 'http://httpbin.org:81/', timeout = { connect = 1 } }
+      local req = { method = method, url = 'http://httpbin.org:81/', timeout = { connect_timeout = 1 } }
 
       local response = backend:send(req)
 
@@ -42,7 +42,7 @@ describe('resty backend', function()
     end)
 
     it('returns proper error on read timeout', function()
-      local req = { method = method, url = 'http://httpbin.org/delay/1', timeout = { read = 1 } }
+      local req = { method = method, url = 'http://httpbin.org/delay/1', timeout = { read_timeout = 1 } }
 
       local response = backend:send(req)
 


### PR DESCRIPTION
## What
Previously the timeout configuration is awkwardly nested inside proxy_options. This commit extract timeout to top level, the interface now become
```
options = {
    timeout = {
        connect_timeout = 5,
        read_timeout = 5,
        write_timeout = 5,
    }
}
```

This is to prepare for THREESCALE-8006

## Verification steps
* Checkout this branch
* Build new runtime-image
```
make runtime-image IMAGE_NAME=apicast-test
```
* Get into dev-environment
```
cd dev-environments/https-proxy-upstream-tlsv1.3
```
* Generate certs
```
make certs
```
* Modify the `apicast-config.json` as follow
```diff
diff --git a/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json b/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json
index 5227c5aa..f0d70dd3 100644                                                                                                                   
--- a/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json                                                                           
+++ b/dev-environments/https-proxy-upstream-tlsv1.3/apicast-config.json                                                                           
@@ -5,7 +5,7 @@                                                                                                                                   
       "backend_version": "1",                                                                                                                    
       "proxy": {                                                                                                                                 
         "hosts": ["get.example.com"],                                                                                                            
-        "api_backend": "https://example.com/get",
+        "api_backend": "https://httpbingo.org",
         "backend": {                                                                                                                             
           "endpoint": "http://127.0.0.1:8081",                                                                                                   
           "host": "backend"                                                                                                                      
@@ -17,6 +17,14 @@                                                                                                                                
               "https_proxy": "http://proxy:443/"                                                                                                 
             }                                                                                                                                    
           },                                                                                                                                     
+          {
+            "name": "apicast.policy.upstream_connection",
+            "configuration": {
+              "connect_timeout": 1,
+              "send_timeout": 1,
+              "read_timeout": 1
+            } 
+          },
           {                                                                                                                                      
             "name": "apicast.policy.apicast"                                                                                                     
           }                                                                                                
```
* Start the gateway
```
make gateway IMAGE_NAME=apicast-test
```
* Send a first request
```
curl --resolve get.example.com:8080:127.0.0.1 -v "http://get.example.com:8080/get?user_key=123"
```
* Send a second request with delay, you should see the upstream_connection policy timeout kicked in
```
curl --resolve get.example.com:8080:127.0.0.1 -v "http://get.example.com:8080/delay/3?user_key=123"

....
<html>                                     
<head><title>502 Bad Gateway</title></head>
<body>                                     
<center><h1>502 Bad Gateway</h1></center>  
</body>                                    
</html>                                           
```
